### PR TITLE
Align Dev1 runtime with Dev2 scheduler

### DIFF
--- a/packages/server/src/agent/agent-runtime.ts
+++ b/packages/server/src/agent/agent-runtime.ts
@@ -139,8 +139,8 @@ export class AgentRuntime {
       data: {
         model: providerResult.model || llmConfig.modelName,
         requestedModel: providerResult.requestedModel || llmConfig.modelName,
-        routedModel: providerResult.routedModel,
-        fallbackAttempts: providerResult.fallbackAttempts,
+        routedModel: providerResult.routedModel ?? null,
+        fallbackAttempts: providerResult.fallbackAttempts ?? null,
         latencyMs: providerResult.latencyMs,
         inputTokens: providerResult.usage.inputTokens,
         outputTokens: providerResult.usage.outputTokens,
@@ -156,10 +156,10 @@ export class AgentRuntime {
         detail: `LLM parsing or target constraint validation failed for agent ${agentId}: ${parseResult.errorDetail}`,
         createdAt: context.now,
         data: {
-          errorDetail: parseResult.errorDetail,
+          errorDetail: parseResult.errorDetail ?? null,
           requestedModel: providerResult.requestedModel || llmConfig.modelName,
-          routedModel: providerResult.routedModel,
-          fallbackAttempts: providerResult.fallbackAttempts,
+          routedModel: providerResult.routedModel ?? null,
+          fallbackAttempts: providerResult.fallbackAttempts ?? null,
         },
       });
     }

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-resilience.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-resilience.test.ts
@@ -209,7 +209,7 @@ describe("PulseScheduler resilience", () => {
         motivationDrivers: [],
         memoryWrites: [],
       },
-      tokenUsage: {},
+      llmUsage: null,
       latencyMs: 10,
       fallbackApplied: false,
       operatorEvents: [],

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -108,7 +108,7 @@ describe("PulseScheduler", () => {
   const mockAgentRuntime: AgentRuntime = {
     generateIntent: vi.fn().mockResolvedValue({
       intent: makeNoOpIntent("agent_1"),
-      tokenUsage: {},
+      llmUsage: null,
       latencyMs: 10,
       fallbackApplied: false,
       operatorEvents: [],

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -23,6 +23,7 @@ import type { OperatorProjection } from "./projections/operator-projection.js";
 import type { EngineEventBuilder } from "./engine-event-builder.js";
 import { buildAgentRuntimeInput } from "./runtime-input-builder.js";
 import { buildWorldSignals } from "./world-signals-builder.js";
+import type { AgentRuntimeContext, AgentRuntimeOutput } from "../agent/agent-runtime.types.js";
 
 export type AgentContext = {
   id: string;
@@ -30,22 +31,12 @@ export type AgentContext = {
   persona: PersonaConfig;
 };
 
-export type RuntimeTokenUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  model?: string;
-};
-
 // Minimal dev1 interface — concrete impl injected
 export type AgentRuntime = {
-  generateIntent(input: import("@perfectman/shared").AgentRuntimeInput): Promise<{
-    intent: ActionIntent;
-    tokenUsage: RuntimeTokenUsage;
-    latencyMs: number;
-    fallbackApplied: boolean;
-    operatorEvents: import("@perfectman/shared").OperatorEvent[];
-  }>;
+  generateIntent(
+    input: import("@perfectman/shared").AgentRuntimeInput,
+    context: AgentRuntimeContext
+  ): Promise<AgentRuntimeOutput>;
 };
 
 export type LlmBudget = {
@@ -218,7 +209,10 @@ export class PulseScheduler {
         agentsCalled += 1;
         const budgetPriority = this.config.llmBudget.getPriority(sim.id, agent.id);
         const runtimeInput = buildAgentRuntimeInput(stepResult, agent.persona, budgetPriority);
-        const runtimeOutput = await this.config.agentRuntime.generateIntent(runtimeInput).catch(async (err) => {
+        const runtimeOutput = await this.config.agentRuntime.generateIntent(runtimeInput, {
+          pulseIndex: this.pulseIndex,
+          now,
+        }).catch(async (err) => {
           const failureEvent = this.llmFailureEvent(agent.id, channelAnchorId, err);
           eventsCommitted += await this.appendAndProject([failureEvent], channels, membership);
           return null;


### PR DESCRIPTION
## Summary
- Align Dev2 PulseScheduler's injected AgentRuntime contract with Dev1's generateIntent(input, context) signature.
- Pass pulseIndex and now from the scheduler into Dev1 runtime.
- Update scheduler tests/mocks from tokenUsage to llmUsage.
- Coerce optional Dev1 telemetry values to null so OperatorEvent.data satisfies Dev2's EventPayloadValue typing.

## Validation
- pnpm build
- pnpm test
- git diff --check

Note: this PR only removes integration conflicts and contract mismatches. It does not test the full model workflow yet.