### PR TITLE
feat: Discord delivery gateway (write-only MVP)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@perfectman/shared": "workspace:*",
     "@perfectman/engine": "workspace:*",
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "^11.0.0",
+    "discord.js": "^14.18.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -86,7 +86,15 @@ export type DebugConfig = {
 
 export type DeliveryGatewayConfig =
   | { id: string; type: "mock" }
-  | { id: string; type: "stdout"; debug?: boolean };
+  | { id: string; type: "stdout"; debug?: boolean }
+  | {
+      id: string;
+      type: "discord";
+      guildId: string;
+      personaBots: Array<{ agentId: string; tokenEnv: string }>;
+      managerBotTokenEnv?: string;
+      setupMode?: "readonly_existing" | "manage_channels";
+    };
 
 export type InitialChannelConfig = {
   id: string;
@@ -254,7 +262,7 @@ export async function buildConfiguredSimulation(
 ): Promise<ConfiguredSimulationHandle> {
   const simulationId = config.simulation.id ?? createId();
   const persistence = createRepositories(config.persistence);
-  const gateways = createGateways(config);
+  const gateways = await createGateways(config);
   const delivery = new CompositeDeliveryGateway(Object.values(gateways));
   const configuredAgents = config.agents.map<ConfiguredAgent>((agent) => ({
     id: agent.id,
@@ -336,7 +344,7 @@ function createRepositories(config: PersistenceConfig): {
 type GatewayFactory = (
   cfg: DeliveryGatewayConfig,
   debug: DebugConfig | undefined,
-) => IDeliveryGateway;
+) => IDeliveryGateway | Promise<IDeliveryGateway>;
 
 const GATEWAY_FACTORIES: Record<DeliveryGatewayConfig["type"], GatewayFactory> =
   {
@@ -347,14 +355,76 @@ const GATEWAY_FACTORIES: Record<DeliveryGatewayConfig["type"], GatewayFactory> =
           debug?.operatorEvents ??
           false,
       ),
+    discord: async (cfg) => {
+      const discordCfg = cfg as Extract<DeliveryGatewayConfig, { type: "discord" }>;
+      const { parseDiscordGatewayConfig, validateDiscordGatewayConfig } = await import(
+        "../discord/discord-config.js"
+      );
+      const parsed = parseDiscordGatewayConfig({
+        guildId: discordCfg.guildId,
+        managerBotTokenEnv: discordCfg.managerBotTokenEnv,
+        personaBots: discordCfg.personaBots,
+      });
+      validateDiscordGatewayConfig(parsed);
+
+      const { BotRegistry } = await import("../discord/bot-registry.js");
+      const { DiscordJsGuildAdapter } = await import("../discord/discord-guild-adapter.js");
+      const { ChannelMap } = await import("../discord/channel-map.js");
+      const { DiscordRoleManager } = await import("../discord/role-manager.js");
+      const { DiscordRateLimiter } = await import("../discord/discord-rate-limiter.js");
+      const { DiscordDeliveryGateway } = await import("../discord/discord-gateway.js");
+
+      const registry = new BotRegistry(parsed.guildId);
+      for (const bot of parsed.personaBots) {
+        await registry.startPersonaBot(bot.agentId, bot.token);
+      }
+      if (parsed.managerBotToken) {
+        await registry.startManagerBot(parsed.managerBotToken);
+      }
+
+      const managerOrFirst = (() => {
+        try { return registry.getManagerBot(); }
+        catch { return registry.get(parsed.personaBots[0]!.agentId); }
+      })();
+
+      const managerGuildPort = new DiscordJsGuildAdapter(managerOrFirst.guild);
+      const guildPortByAgent = new Map(
+        registry.allAgentIds().map((id) => [
+          id,
+          new DiscordJsGuildAdapter(registry.get(id).guild),
+        ]),
+      );
+
+      const channelMap = new ChannelMap();
+      const botUserIdByAgentId = new Map(
+        registry.allAgentIds().map((id) => [id, registry.getUserId(id)]),
+      );
+      const roleManager = new DiscordRoleManager({
+        guild: managerGuildPort,
+        channelMap,
+        botUserIdByAgentId,
+        discordGuildId: parsed.guildId,
+      });
+
+      return new DiscordDeliveryGateway({
+        simulationId: discordCfg.id,
+        config: parsed,
+        botRegistry: registry,
+        managerGuildPort,
+        guildPortByAgent,
+        channelMap,
+        roleManager,
+        rateLimiter: new DiscordRateLimiter(),
+      });
+    },
   };
 
-function createGateways(
+async function createGateways(
   config: SimulationAppConfig,
-): Record<string, IDeliveryGateway> {
+): Promise<Record<string, IDeliveryGateway>> {
   const result: Record<string, IDeliveryGateway> = {};
   for (const gateway of config.deliveryGateways) {
-    result[gateway.id] = GATEWAY_FACTORIES[gateway.type](gateway, config.debug);
+    result[gateway.id] = await GATEWAY_FACTORIES[gateway.type](gateway, config.debug);
   }
   if (
     config.debug?.stdoutDelivery &&
@@ -447,6 +517,32 @@ function parseGateways(input: unknown): DeliveryGatewayConfig[] {
         debug: optionalBoolean(
           gateway["debug"],
           `deliveryGateways[${index}].debug`,
+        ),
+      };
+    }
+    if (type === "discord") {
+      const guildId = requiredString(
+        gateway["guildId"],
+        `deliveryGateways[${index}].guildId`,
+      );
+      const personaBots = asArray(
+        gateway["personaBots"],
+        `deliveryGateways[${index}].personaBots`,
+      ).map((bot, bi) => {
+        const b = asRecord(bot, `deliveryGateways[${index}].personaBots[${bi}]`);
+        return {
+          agentId: requiredString(b["agentId"], `deliveryGateways[${index}].personaBots[${bi}].agentId`),
+          tokenEnv: requiredString(b["tokenEnv"], `deliveryGateways[${index}].personaBots[${bi}].tokenEnv`),
+        };
+      });
+      return {
+        id,
+        type,
+        guildId,
+        personaBots,
+        managerBotTokenEnv: optionalString(
+          gateway["managerBotTokenEnv"],
+          `deliveryGateways[${index}].managerBotTokenEnv`,
         ),
       };
     }

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -364,6 +364,7 @@ const GATEWAY_FACTORIES: Record<DeliveryGatewayConfig["type"], GatewayFactory> =
         guildId: discordCfg.guildId,
         managerBotTokenEnv: discordCfg.managerBotTokenEnv,
         personaBots: discordCfg.personaBots,
+        setupMode: discordCfg.setupMode,
       });
       validateDiscordGatewayConfig(parsed);
 
@@ -535,6 +536,19 @@ function parseGateways(input: unknown): DeliveryGatewayConfig[] {
           tokenEnv: requiredString(b["tokenEnv"], `deliveryGateways[${index}].personaBots[${bi}].tokenEnv`),
         };
       });
+      const setupModeRaw = optionalString(
+        gateway["setupMode"],
+        `deliveryGateways[${index}].setupMode`,
+      );
+      const setupMode =
+        setupModeRaw === "readonly_existing" || setupModeRaw === "manage_channels"
+          ? setupModeRaw
+          : undefined;
+      if (setupModeRaw !== undefined && setupMode === undefined) {
+        throw new Error(
+          `deliveryGateways[${index}].setupMode must be "readonly_existing" or "manage_channels"`,
+        );
+      }
       return {
         id,
         type,
@@ -544,6 +558,7 @@ function parseGateways(input: unknown): DeliveryGatewayConfig[] {
           gateway["managerBotTokenEnv"],
           `deliveryGateways[${index}].managerBotTokenEnv`,
         ),
+        setupMode,
       };
     }
     throw new Error(`Unsupported deliveryGateways[${index}].type: ${type}`);

--- a/packages/server/src/delivery/index.ts
+++ b/packages/server/src/delivery/index.ts
@@ -1,3 +1,4 @@
 export { MockDeliveryGateway } from "./mock-delivery-gateway.js";
 export { StdoutDeliveryGateway } from "./stdout-delivery-gateway.js";
 export { CompositeDeliveryGateway } from "./composite-delivery-gateway.js";
+export { DiscordDeliveryGateway } from "../discord/index.js";

--- a/packages/server/src/discord/__tests__/bot-registry.test.ts
+++ b/packages/server/src/discord/__tests__/bot-registry.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { BotRegistry } from "../bot-registry.js";
+
+function createFakeClient(userId: string, guildId: string, guildAvailable = true) {
+  const guild = { id: guildId, available: guildAvailable };
+  const guilds = { cache: new Map([[guildId, guild]]) };
+  const user = { id: userId };
+
+  let readyHandler: ((client: unknown) => void) | null = null;
+  let errorHandler: ((err: Error) => void) | null = null;
+
+  const client = {
+    user: null as typeof user | null,
+    guilds: { cache: new Map() },
+    once(event: string, handler: (...args: unknown[]) => void) {
+      if (event === "ready") readyHandler = handler;
+      if (event === "error") errorHandler = handler;
+      return client;
+    },
+    async login(_token: string) {
+      client.user = user;
+      (client as Record<string, unknown>).guilds = guilds;
+      if (readyHandler) readyHandler(client);
+    },
+    async destroy() {},
+    _triggerError(err: Error) {
+      if (errorHandler) errorHandler(err);
+    },
+  };
+
+  return client;
+}
+
+function makeRegistry(guildId: string, fakeClients: Array<ReturnType<typeof createFakeClient>>) {
+  let idx = 0;
+  return new BotRegistry(guildId, {
+    createClient: () => {
+      const c = fakeClients[idx++];
+      if (!c) throw new Error("no more fake clients");
+      return c as never;
+    },
+  });
+}
+
+describe("BotRegistry", () => {
+  const GUILD_ID = "guild-1";
+
+  it("starts and retrieves persona bot", async () => {
+    const reg = makeRegistry(GUILD_ID, [createFakeClient("user-alice", GUILD_ID)]);
+    const handle = await reg.startPersonaBot("alice", "tok");
+    expect(handle.agentId).toBe("alice");
+    expect(handle.userId).toBe("user-alice");
+    expect(reg.has("alice")).toBe(true);
+    expect(reg.getUserId("alice")).toBe("user-alice");
+  });
+
+  it("starts and retrieves manager bot", async () => {
+    const reg = makeRegistry(GUILD_ID, [createFakeClient("user-mgr", GUILD_ID)]);
+    await reg.startManagerBot("tok");
+    const mgr = reg.getManagerBot();
+    expect(mgr.userId).toBe("user-mgr");
+  });
+
+  it("throws on unknown agentId", () => {
+    const reg = makeRegistry(GUILD_ID, []);
+    expect(() => reg.get("nonexistent")).toThrow('no bot registered for agent "nonexistent"');
+  });
+
+  it("throws on duplicate agentId", async () => {
+    const reg = makeRegistry(GUILD_ID, [
+      createFakeClient("u1", GUILD_ID),
+      createFakeClient("u2", GUILD_ID),
+    ]);
+    await reg.startPersonaBot("alice", "tok1");
+    await expect(reg.startPersonaBot("alice", "tok2")).rejects.toThrow(
+      'bot already registered for agent "alice"',
+    );
+  });
+
+  it("throws on duplicate manager", async () => {
+    const reg = makeRegistry(GUILD_ID, [
+      createFakeClient("m1", GUILD_ID),
+      createFakeClient("m2", GUILD_ID),
+    ]);
+    await reg.startManagerBot("tok1");
+    await expect(reg.startManagerBot("tok2")).rejects.toThrow("manager bot already registered");
+  });
+
+  it("throws when guild unavailable", async () => {
+    const reg = makeRegistry(GUILD_ID, [
+      createFakeClient("u1", GUILD_ID, false),
+    ]);
+    await expect(reg.startPersonaBot("alice", "tok")).rejects.toThrow("unavailable");
+  });
+
+  it("throws when guild not found", async () => {
+    const reg = makeRegistry(GUILD_ID, [
+      createFakeClient("u1", "other-guild"),
+    ]);
+    await expect(reg.startPersonaBot("alice", "tok")).rejects.toThrow("not found");
+  });
+
+  it("shutdown destroys all clients", async () => {
+    const fakes = [createFakeClient("u1", GUILD_ID), createFakeClient("u2", GUILD_ID)];
+    const spies = fakes.map((f) => vi.spyOn(f, "destroy"));
+    const reg = makeRegistry(GUILD_ID, fakes);
+    await reg.startPersonaBot("alice", "tok");
+    await reg.startManagerBot("tok2");
+    await reg.shutdown();
+    for (const spy of spies) expect(spy).toHaveBeenCalled();
+    expect(reg.has("alice")).toBe(false);
+    expect(() => reg.getManagerBot()).toThrow();
+  });
+
+  it("allAgentIds returns registered persona ids", async () => {
+    const reg = makeRegistry(GUILD_ID, [
+      createFakeClient("u1", GUILD_ID),
+      createFakeClient("u2", GUILD_ID),
+    ]);
+    await reg.startPersonaBot("alice", "t1");
+    await reg.startPersonaBot("bob", "t2");
+    expect(reg.allAgentIds().sort()).toEqual(["alice", "bob"]);
+  });
+});

--- a/packages/server/src/discord/__tests__/channel-map.test.ts
+++ b/packages/server/src/discord/__tests__/channel-map.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { ChannelMap } from "../channel-map.js";
+
+describe("ChannelMap", () => {
+  function entry(overrides: Partial<Parameters<ChannelMap["upsert"]>[0]> = {}) {
+    return {
+      simulationId: "sim-1",
+      channelId: "ch-1",
+      channelType: "public_channel" as const,
+      discordGuildId: "guild-1",
+      discordChannelId: "dc-1",
+      lastSyncedAt: 1000,
+      ...overrides,
+    };
+  }
+
+  it("set and get roundtrip", () => {
+    const map = new ChannelMap();
+    const e = entry();
+    map.upsert(e);
+    expect(map.get("sim-1", "ch-1")).toEqual(e);
+  });
+
+  it("returns null for missing entry", () => {
+    const map = new ChannelMap();
+    expect(map.get("sim-1", "nope")).toBeNull();
+  });
+
+  it("upsert overwrites (idempotent)", () => {
+    const map = new ChannelMap();
+    map.upsert(entry({ discordChannelId: "dc-old" }));
+    map.upsert(entry({ discordChannelId: "dc-new" }));
+    expect(map.get("sim-1", "ch-1")!.discordChannelId).toBe("dc-new");
+  });
+
+  it("allForSimulation filters by simulationId", () => {
+    const map = new ChannelMap();
+    map.upsert(entry({ simulationId: "sim-1", channelId: "ch-1" }));
+    map.upsert(entry({ simulationId: "sim-1", channelId: "ch-2", discordChannelId: "dc-2" }));
+    map.upsert(entry({ simulationId: "sim-2", channelId: "ch-3", discordChannelId: "dc-3" }));
+    expect(map.allForSimulation("sim-1")).toHaveLength(2);
+    expect(map.allForSimulation("sim-2")).toHaveLength(1);
+  });
+
+  it("reverse lookup by discord channel id", () => {
+    const map = new ChannelMap();
+    map.upsert(entry({ discordChannelId: "dc-42" }));
+    expect(map.getByDiscordChannelId("dc-42")?.channelId).toBe("ch-1");
+    expect(map.getByDiscordChannelId("dc-99")).toBeNull();
+  });
+
+  it("remove deletes entry", () => {
+    const map = new ChannelMap();
+    map.upsert(entry());
+    expect(map.remove("sim-1", "ch-1")).toBe(true);
+    expect(map.get("sim-1", "ch-1")).toBeNull();
+    expect(map.remove("sim-1", "ch-1")).toBe(false);
+  });
+});

--- a/packages/server/src/discord/__tests__/discord-config.test.ts
+++ b/packages/server/src/discord/__tests__/discord-config.test.ts
@@ -98,6 +98,37 @@ describe("parseDiscordGatewayConfig", () => {
       }),
     ).toThrow('duplicate agentId "alice"');
   });
+
+  it("respects explicit setupMode readonly_existing even with manager token", () => {
+    const result = parseDiscordGatewayConfig({
+      guildId: "123",
+      managerBotTokenEnv: "MANAGER_TOKEN",
+      personaBots: [{ agentId: "alice", tokenEnv: "ALICE_TOKEN" }],
+      setupMode: "readonly_existing",
+    });
+    expect(result.setupMode).toBe("readonly_existing");
+    expect(result.managerBotToken).toBe("tok-manager-secret");
+  });
+
+  it("throws on invalid setupMode value", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({
+        guildId: "123",
+        personaBots: [{ agentId: "alice", tokenEnv: "ALICE_TOKEN" }],
+        setupMode: "invalid_mode",
+      }),
+    ).toThrow('setupMode must be');
+  });
+
+  it("throws when manage_channels requested without manager token", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({
+        guildId: "123",
+        personaBots: [{ agentId: "alice", tokenEnv: "ALICE_TOKEN" }],
+        setupMode: "manage_channels",
+      }),
+    ).toThrow("managerBotToken required");
+  });
 });
 
 describe("validateDiscordGatewayConfig", () => {

--- a/packages/server/src/discord/__tests__/discord-config.test.ts
+++ b/packages/server/src/discord/__tests__/discord-config.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  parseDiscordGatewayConfig,
+  validateDiscordGatewayConfig,
+  type DiscordGatewayConfig,
+} from "../discord-config.js";
+
+describe("parseDiscordGatewayConfig", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv.ALICE_TOKEN = process.env.ALICE_TOKEN;
+    savedEnv.BOB_TOKEN = process.env.BOB_TOKEN;
+    savedEnv.MANAGER_TOKEN = process.env.MANAGER_TOKEN;
+    process.env.ALICE_TOKEN = "tok-alice-secret";
+    process.env.BOB_TOKEN = "tok-bob-secret";
+    process.env.MANAGER_TOKEN = "tok-manager-secret";
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("parses valid config", () => {
+    const result = parseDiscordGatewayConfig({
+      guildId: "123456",
+      personaBots: [
+        { agentId: "alice", tokenEnv: "ALICE_TOKEN" },
+        { agentId: "bob", tokenEnv: "BOB_TOKEN" },
+      ],
+    });
+
+    expect(result.guildId).toBe("123456");
+    expect(result.personaBots).toHaveLength(2);
+    expect(result.personaBots[0].token).toBe("tok-alice-secret");
+    expect(result.setupMode).toBe("readonly_existing");
+  });
+
+  it("derives manage_channels when manager token present", () => {
+    const result = parseDiscordGatewayConfig({
+      guildId: "123456",
+      managerBotTokenEnv: "MANAGER_TOKEN",
+      personaBots: [{ agentId: "alice", tokenEnv: "ALICE_TOKEN" }],
+    });
+
+    expect(result.setupMode).toBe("manage_channels");
+    expect(result.managerBotToken).toBe("tok-manager-secret");
+  });
+
+  it("throws on missing guildId", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({
+        personaBots: [{ agentId: "alice", tokenEnv: "ALICE_TOKEN" }],
+      }),
+    ).toThrow("guildId is required");
+  });
+
+  it("throws on empty personaBots", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({ guildId: "123", personaBots: [] }),
+    ).toThrow("at least one personaBot");
+  });
+
+  it("throws on missing tokenEnv value", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({
+        guildId: "123",
+        personaBots: [{ agentId: "alice", tokenEnv: "NONEXISTENT_VAR" }],
+      }),
+    ).toThrow('"NONEXISTENT_VAR" is not set');
+  });
+
+  it("error message names env var, not token value", () => {
+    try {
+      parseDiscordGatewayConfig({
+        guildId: "123",
+        personaBots: [{ agentId: "alice", tokenEnv: "NONEXISTENT_VAR" }],
+      });
+    } catch (e: unknown) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("NONEXISTENT_VAR");
+      expect(msg).not.toContain("tok-alice-secret");
+      expect(msg).not.toContain("tok-bob-secret");
+    }
+  });
+
+  it("throws on duplicate agentIds", () => {
+    expect(() =>
+      parseDiscordGatewayConfig({
+        guildId: "123",
+        personaBots: [
+          { agentId: "alice", tokenEnv: "ALICE_TOKEN" },
+          { agentId: "alice", tokenEnv: "BOB_TOKEN" },
+        ],
+      }),
+    ).toThrow('duplicate agentId "alice"');
+  });
+});
+
+describe("validateDiscordGatewayConfig", () => {
+  const validConfig: DiscordGatewayConfig = {
+    guildId: "123",
+    personaBots: [{ agentId: "alice", token: "secret" }],
+    setupMode: "readonly_existing",
+  };
+
+  it("accepts valid config", () => {
+    expect(() => validateDiscordGatewayConfig(validConfig)).not.toThrow();
+  });
+
+  it("rejects manage_channels without manager token", () => {
+    expect(() =>
+      validateDiscordGatewayConfig({ ...validConfig, setupMode: "manage_channels" }),
+    ).toThrow("managerBotToken required");
+  });
+
+  it("rejects duplicate agentIds", () => {
+    expect(() =>
+      validateDiscordGatewayConfig({
+        ...validConfig,
+        personaBots: [
+          { agentId: "alice", token: "a" },
+          { agentId: "alice", token: "b" },
+        ],
+      }),
+    ).toThrow('duplicate agentId "alice"');
+  });
+});

--- a/packages/server/src/discord/__tests__/discord-errors.test.ts
+++ b/packages/server/src/discord/__tests__/discord-errors.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { classifyDiscordError, isRetryable } from "../discord-errors.js";
+
+describe("classifyDiscordError", () => {
+  const now = 1_000_000;
+
+  it("classifies 429 as rate_limited with retryAt", () => {
+    const err = Object.assign(new Error("rate limited"), { status: 429, retry_after: 3 });
+    const result = classifyDiscordError(err, now);
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAt).toBe(now + 3000);
+  });
+
+  it("defaults retryAfter to 5s when missing", () => {
+    const err = Object.assign(new Error("rate limited"), { status: 429 });
+    const result = classifyDiscordError(err, now);
+    expect(result.retryAt).toBe(now + 5000);
+  });
+
+  it("classifies 401 as invalid_auth", () => {
+    const err = Object.assign(new Error("bad token"), { status: 401 });
+    expect(classifyDiscordError(err, now).kind).toBe("invalid_auth");
+  });
+
+  it("classifies 403 as missing_permission", () => {
+    const err = Object.assign(new Error("forbidden"), { status: 403 });
+    expect(classifyDiscordError(err, now).kind).toBe("missing_permission");
+  });
+
+  it("classifies 404 as not_found", () => {
+    const err = Object.assign(new Error("not found"), { status: 404 });
+    expect(classifyDiscordError(err, now).kind).toBe("not_found");
+  });
+
+  it("classifies 5xx as transient", () => {
+    const err = Object.assign(new Error("server err"), { status: 502 });
+    expect(classifyDiscordError(err, now).kind).toBe("transient");
+  });
+
+  it("classifies ECONNRESET as transient", () => {
+    const err = new Error("read ECONNRESET");
+    expect(classifyDiscordError(err, now).kind).toBe("transient");
+  });
+
+  it("classifies ETIMEDOUT as transient", () => {
+    const err = new Error("connect ETIMEDOUT");
+    expect(classifyDiscordError(err, now).kind).toBe("transient");
+  });
+
+  it("classifies unknown errors", () => {
+    expect(classifyDiscordError(new Error("wat"), now).kind).toBe("unknown");
+    expect(classifyDiscordError("string err", now).kind).toBe("unknown");
+  });
+});
+
+describe("isRetryable", () => {
+  it("rate_limited is retryable", () => {
+    expect(isRetryable({ kind: "rate_limited", message: "" })).toBe(true);
+  });
+
+  it("transient is retryable", () => {
+    expect(isRetryable({ kind: "transient", message: "" })).toBe(true);
+  });
+
+  it("invalid_auth is not retryable", () => {
+    expect(isRetryable({ kind: "invalid_auth", message: "" })).toBe(false);
+  });
+
+  it("missing_permission is not retryable", () => {
+    expect(isRetryable({ kind: "missing_permission", message: "" })).toBe(false);
+  });
+});

--- a/packages/server/src/discord/__tests__/discord-formatter.test.ts
+++ b/packages/server/src/discord/__tests__/discord-formatter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatDeliveryMessage,
+  formatSpectatorEvent,
+  formatOperatorEvent,
+} from "../discord-formatter.js";
+import type { DeliveryMessage } from "../../simulation/scheduler-contracts.js";
+import type { SpectatorEvent, OperatorEvent } from "@perfectman/shared";
+
+describe("formatDeliveryMessage", () => {
+  it("formats message kind", () => {
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "hello world",
+      salience: "medium",
+    };
+    const result = formatDeliveryMessage(msg);
+    expect(result.content).toBe("hello world");
+    expect(result.allowedMentions).toEqual({ parse: [] });
+  });
+
+  it("formats reply kind", () => {
+    const msg: DeliveryMessage = {
+      kind: "reply",
+      agentId: "bob",
+      content: "replying",
+      replyToEventId: "evt-1",
+      salience: "high",
+    };
+    expect(formatDeliveryMessage(msg).content).toBe("replying");
+  });
+
+  it("formats reaction kind with emoji", () => {
+    const msg: DeliveryMessage = {
+      kind: "reaction",
+      agentId: "alice",
+      emoji: "👍",
+      targetEventId: "evt-1",
+      salience: "low",
+    };
+    expect(formatDeliveryMessage(msg).content).toBe("👍");
+  });
+
+  it("truncates at 1900 chars", () => {
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "x".repeat(2000),
+      salience: "medium",
+    };
+    const result = formatDeliveryMessage(msg);
+    expect(result.content.length).toBe(1900);
+    expect(result.content.endsWith("...")).toBe(true);
+  });
+
+  it("handles empty content", () => {
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "",
+      salience: "low",
+    };
+    expect(formatDeliveryMessage(msg).content).toBe("(empty)");
+  });
+
+  it("always suppresses mentions", () => {
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "@everyone hello",
+      salience: "critical",
+    };
+    expect(formatDeliveryMessage(msg).allowedMentions).toEqual({ parse: [] });
+  });
+});
+
+describe("formatSpectatorEvent", () => {
+  it("uses [recap] prefix for recap type", () => {
+    const event: SpectatorEvent = {
+      type: "recap",
+      simulationId: "sim-1",
+      summary: "things happened",
+      createdAt: 1000,
+      pulseIndex: 1,
+    };
+    const result = formatSpectatorEvent(event);
+    expect(result.content).toMatch(/^\[recap\]/);
+    expect(result.allowedMentions).toEqual({ parse: [] });
+  });
+
+  it("uses [spectator] prefix for other types", () => {
+    const event: SpectatorEvent = {
+      type: "motive_reveal",
+      simulationId: "sim-1",
+      visibleContent: "revealed motive",
+      createdAt: 1000,
+      pulseIndex: 1,
+    };
+    expect(formatSpectatorEvent(event).content).toMatch(/^\[spectator\]/);
+  });
+});
+
+describe("formatOperatorEvent", () => {
+  it("formats with type prefix", () => {
+    const event: OperatorEvent = {
+      type: "llm_failure",
+      simulationId: "sim-1",
+      pulseIndex: 1,
+      detail: "timeout after 30s",
+      createdAt: 1000,
+    };
+    const result = formatOperatorEvent(event);
+    expect(result.content).toBe("[operator:llm_failure] timeout after 30s");
+    expect(result.allowedMentions).toEqual({ parse: [] });
+  });
+});

--- a/packages/server/src/discord/__tests__/discord-gateway.test.ts
+++ b/packages/server/src/discord/__tests__/discord-gateway.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DiscordDeliveryGateway } from "../discord-gateway.js";
+import { ChannelMap } from "../channel-map.js";
+import { DiscordRoleManager } from "../role-manager.js";
+import { DiscordRateLimiter } from "../discord-rate-limiter.js";
+import { FakeGuildPort } from "./fake-guild-port.js";
+import type { BotRegistry } from "../bot-registry.js";
+import type { DiscordGatewayConfig } from "../discord-config.js";
+import type { DeliveryMessage } from "../../simulation/scheduler-contracts.js";
+import type { SpectatorEvent, OperatorEvent } from "@perfectman/shared";
+
+function createFakeBotRegistry(): BotRegistry {
+  const hasManager = true;
+  return {
+    get(agentId: string) {
+      return { agentId, userId: `user-${agentId}`, client: {} as never, guild: {} as never };
+    },
+    getManagerBot() {
+      if (!hasManager) throw new Error("no manager");
+      return { agentId: "__manager__", userId: "user-manager", client: {} as never, guild: {} as never };
+    },
+    has(agentId: string) { return agentId === "alice" || agentId === "bob"; },
+    getUserId(agentId: string) { return `user-${agentId}`; },
+    allAgentIds() { return ["alice", "bob"]; },
+    async shutdown() {},
+    async startPersonaBot() { return {} as never; },
+    async startManagerBot() { return {} as never; },
+  } as BotRegistry;
+}
+
+describe("DiscordDeliveryGateway", () => {
+  let guildPort: FakeGuildPort;
+  let channelMap: ChannelMap;
+  let roleManager: DiscordRoleManager;
+  let rateLimiter: DiscordRateLimiter;
+  let gateway: DiscordDeliveryGateway;
+
+  const config: DiscordGatewayConfig = {
+    guildId: "guild-1",
+    personaBots: [
+      { agentId: "alice", token: "tok" },
+      { agentId: "bob", token: "tok" },
+    ],
+    setupMode: "manage_channels",
+    managerBotToken: "mgr-tok",
+  };
+
+  beforeEach(() => {
+    guildPort = new FakeGuildPort("everyone-role");
+    guildPort.addMemberRecord("user-alice");
+    guildPort.addMemberRecord("user-bob");
+    guildPort.addMemberRecord("user-manager");
+    channelMap = new ChannelMap();
+    const botUserIdByAgentId = new Map([
+      ["alice", "user-alice"],
+      ["bob", "user-bob"],
+    ]);
+    roleManager = new DiscordRoleManager({
+      guild: guildPort,
+      channelMap,
+      botUserIdByAgentId,
+      discordGuildId: "guild-1",
+    });
+    rateLimiter = new DiscordRateLimiter();
+
+    const guildPortByAgent = new Map([
+      ["alice", guildPort as import("../discord-guild-port.js").DiscordGuildPort],
+      ["bob", guildPort as import("../discord-guild-port.js").DiscordGuildPort],
+    ]);
+
+    gateway = new DiscordDeliveryGateway({
+      simulationId: "sim-1",
+      config,
+      botRegistry: createFakeBotRegistry(),
+      managerGuildPort: guildPort,
+      guildPortByAgent,
+      channelMap,
+      roleManager,
+      rateLimiter,
+    });
+  });
+
+  it("sendAgentMessage on public channel delivers with allowedMentions", async () => {
+    await gateway.createChannel("general", "public_channel", []);
+    const entry = channelMap.get("sim-1", "general")!;
+
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "hello @everyone",
+      salience: "medium",
+    };
+    await gateway.sendAgentMessage("general", msg);
+
+    const sent = guildPort.getSentMessages(entry.discordChannelId);
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    expect(sent[0].allowedMentions).toEqual({ parse: [] });
+  });
+
+  it("createChannel private creates role + channel with deny @everyone", async () => {
+    await gateway.createChannel("secret", "private_channel", ["alice", "bob"]);
+    const entry = channelMap.get("sim-1", "secret")!;
+    expect(entry.discordRoleId).toBeDefined();
+
+    const overwrites = guildPort.getChannelOverwrites(entry.discordChannelId);
+    const everyoneDeny = overwrites.find((o) => o.id === "everyone-role");
+    expect(everyoneDeny?.deny).toContain("ViewChannel");
+  });
+
+  it("createChannel public creates channel without role", async () => {
+    await gateway.createChannel("lobby", "public_channel", []);
+    const entry = channelMap.get("sim-1", "lobby")!;
+    expect(entry.discordRoleId).toBeUndefined();
+    expect(entry.discordChannelId).toBeDefined();
+  });
+
+  it("createChannel spectator creates named channel", async () => {
+    await gateway.createChannel("__spectator", "spectator_channel", []);
+    const entry = channelMap.get("sim-1", "__spectator")!;
+    const rec = guildPort.channels.get(entry.discordChannelId)!;
+    expect(rec.name).toContain("spectator");
+  });
+
+  it("addMember assigns role", async () => {
+    await gateway.createChannel("secret", "private_channel", ["alice"]);
+    await gateway.addMember("secret", "bob");
+    const entry = channelMap.get("sim-1", "secret")!;
+    expect(guildPort.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(true);
+  });
+
+  it("removeMember removes role", async () => {
+    await gateway.createChannel("secret", "private_channel", ["alice", "bob"]);
+    await gateway.removeMember("secret", "bob");
+    const entry = channelMap.get("sim-1", "secret")!;
+    expect(guildPort.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(false);
+  });
+
+  it("sendSpectatorEvent delivers formatted message", async () => {
+    await gateway.createChannel("__spectator", "spectator_channel", []);
+    const event: SpectatorEvent = {
+      type: "recap",
+      simulationId: "sim-1",
+      summary: "things happened",
+      createdAt: 1000,
+      pulseIndex: 1,
+    };
+    await gateway.sendSpectatorEvent(event);
+
+    const entry = channelMap.get("sim-1", "__spectator")!;
+    const sent = guildPort.getSentMessages(entry.discordChannelId);
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    expect(sent.at(-1)!.content).toMatch(/\[recap\]/);
+  });
+
+  it("sendOperatorEvent delivers formatted message", async () => {
+    await gateway.createChannel("__operator", "operator_channel", []);
+    const event: OperatorEvent = {
+      type: "llm_failure",
+      simulationId: "sim-1",
+      pulseIndex: 1,
+      detail: "timeout",
+      createdAt: 1000,
+    };
+    await gateway.sendOperatorEvent(event);
+
+    const entry = channelMap.get("sim-1", "__operator")!;
+    const sent = guildPort.getSentMessages(entry.discordChannelId);
+    expect(sent.at(-1)!.content).toContain("[operator:llm_failure]");
+  });
+
+  it("onSimulationStopped locks channels and sends final message", async () => {
+    await gateway.createChannel("secret", "private_channel", ["alice"]);
+    await gateway.createChannel("__operator", "operator_channel", []);
+
+    await gateway.onSimulationStopped("sim-1");
+
+    const privEntry = channelMap.get("sim-1", "secret")!;
+    const overwrites = guildPort.getChannelOverwrites(privEntry.discordChannelId);
+    const roleOw = overwrites.find((o) => o.id === privEntry.discordRoleId);
+    expect(roleOw?.deny).toContain("SendMessages");
+
+    const opEntry = channelMap.get("sim-1", "__operator")!;
+    const opSent = guildPort.getSentMessages(opEntry.discordChannelId);
+    expect(opSent.at(-1)!.content).toContain("simulation_stopped");
+  });
+
+  it("missing channel map throws descriptive error", async () => {
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "alice",
+      content: "hello",
+      salience: "medium",
+    };
+    await expect(gateway.sendAgentMessage("nonexistent", msg)).rejects.toThrow(
+      "no channel mapping",
+    );
+  });
+});

--- a/packages/server/src/discord/__tests__/discord-gateway.test.ts
+++ b/packages/server/src/discord/__tests__/discord-gateway.test.ts
@@ -195,4 +195,34 @@ describe("DiscordDeliveryGateway", () => {
       "no channel mapping",
     );
   });
+
+  it("sendAgentMessage throws when agent has no persona bot", async () => {
+    await gateway.createChannel("general", "public_channel", []);
+    const msg: DeliveryMessage = {
+      kind: "message",
+      agentId: "charlie",
+      content: "hello",
+      salience: "medium",
+    };
+    await expect(gateway.sendAgentMessage("general", msg)).rejects.toThrow(
+      'no persona bot configured for agent "charlie"',
+    );
+  });
+
+  it("operator channel denies @everyone ViewChannel", async () => {
+    await gateway.createChannel("__operator", "operator_channel", []);
+    const entry = channelMap.get("sim-1", "__operator")!;
+    const overwrites = guildPort.getChannelOverwrites(entry.discordChannelId);
+    const everyoneDeny = overwrites.find((o) => o.id === "everyone-role");
+    expect(everyoneDeny?.deny).toContain("ViewChannel");
+  });
+
+  it("operator channel grants manager bot access", async () => {
+    await gateway.createChannel("__operator", "operator_channel", []);
+    const entry = channelMap.get("sim-1", "__operator")!;
+    const overwrites = guildPort.getChannelOverwrites(entry.discordChannelId);
+    const mgrOw = overwrites.find((o) => o.id === "user-manager");
+    expect(mgrOw?.allow).toContain("ViewChannel");
+    expect(mgrOw?.allow).toContain("SendMessages");
+  });
 });

--- a/packages/server/src/discord/__tests__/discord-rate-limiter.test.ts
+++ b/packages/server/src/discord/__tests__/discord-rate-limiter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import { DiscordRateLimiter, type OutboundDiscordMessage } from "../discord-rate-limiter.js";
+
+function makeMsg(
+  overrides: Partial<OutboundDiscordMessage> = {},
+): OutboundDiscordMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 6)}`,
+    agentId: "alice",
+    discordChannelId: "dc-1",
+    payload: { content: "hello", allowedMentions: { parse: [] } },
+    salience: "medium",
+    attempts: 0,
+    notBefore: 0,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("DiscordRateLimiter", () => {
+  it("delivers in FIFO order", async () => {
+    const limiter = new DiscordRateLimiter();
+    const order: string[] = [];
+    limiter.enqueue(makeMsg({ id: "a", payload: { content: "first", allowedMentions: { parse: [] } } }));
+    limiter.enqueue(makeMsg({ id: "b", payload: { content: "second", allowedMentions: { parse: [] } } }));
+
+    const sendFn = vi.fn(async (_ch: string, payload: { content: string }) => {
+      order.push(payload.content);
+      return { id: "sent" };
+    });
+
+    await limiter.flush("alice:dc-1", sendFn);
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("drops low salience when queue full", () => {
+    const limiter = new DiscordRateLimiter({ maxQueueDepth: 2 });
+    limiter.enqueue(makeMsg({ id: "a", salience: "medium" }));
+    limiter.enqueue(makeMsg({ id: "b", salience: "medium" }));
+    const accepted = limiter.enqueue(makeMsg({ id: "c", salience: "low" }));
+    expect(accepted).toBe(false);
+    expect(limiter.queueDepth("alice:dc-1")).toBe(2);
+  });
+
+  it("never drops high/critical salience", () => {
+    const limiter = new DiscordRateLimiter({ maxQueueDepth: 2 });
+    limiter.enqueue(makeMsg({ id: "a", salience: "low" }));
+    limiter.enqueue(makeMsg({ id: "b", salience: "medium" }));
+
+    const accepted = limiter.enqueue(makeMsg({ id: "c", salience: "high" }));
+    expect(accepted).toBe(true);
+    expect(limiter.queueDepth("alice:dc-1")).toBe(2);
+  });
+
+  it("rate_limited sets notBefore", async () => {
+    let time = 1000;
+    const limiter = new DiscordRateLimiter({}, () => time);
+    limiter.enqueue(makeMsg({ id: "a" }));
+
+    const sendFn = vi.fn(async () => {
+      throw Object.assign(new Error("rate limited"), {
+        status: 429,
+        retry_after: 5,
+      });
+    });
+
+    await limiter.flush("alice:dc-1", sendFn);
+    expect(limiter.queueDepth("alice:dc-1")).toBe(1);
+
+    time = 6001;
+    const okSend = vi.fn(async () => ({ id: "ok" }));
+    await limiter.flush("alice:dc-1", okSend);
+    expect(okSend).toHaveBeenCalled();
+    expect(limiter.queueDepth("alice:dc-1")).toBe(0);
+  });
+
+  it("missing_permission calls onError and removes", async () => {
+    const limiter = new DiscordRateLimiter();
+    limiter.enqueue(makeMsg({ id: "a" }));
+
+    const sendFn = vi.fn(async () => {
+      throw Object.assign(new Error("forbidden"), { status: 403 });
+    });
+    const onError = vi.fn();
+
+    await limiter.flush("alice:dc-1", sendFn, onError);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][1].kind).toBe("missing_permission");
+    expect(limiter.queueDepth("alice:dc-1")).toBe(0);
+  });
+
+  it("transient retries with backoff, then drops after maxAttempts", async () => {
+    let time = 1000;
+    const limiter = new DiscordRateLimiter(
+      { maxAttempts: 2, baseBackoffMs: 100, maxBackoffMs: 10000 },
+      () => time,
+    );
+    limiter.enqueue(makeMsg({ id: "a" }));
+
+    const sendFn = vi.fn(async () => {
+      throw Object.assign(new Error("server error"), { status: 500 });
+    });
+    const onError = vi.fn();
+
+    await limiter.flush("alice:dc-1", sendFn, onError);
+    expect(onError).not.toHaveBeenCalled();
+    expect(limiter.queueDepth("alice:dc-1")).toBe(1);
+
+    time = 2000;
+    await limiter.flush("alice:dc-1", sendFn, onError);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(limiter.queueDepth("alice:dc-1")).toBe(0);
+  });
+
+  it("skips messages with notBefore > now", async () => {
+    let time = 1000;
+    const limiter = new DiscordRateLimiter({}, () => time);
+    limiter.enqueue(makeMsg({ id: "a", notBefore: 5000 }));
+
+    const sendFn = vi.fn(async () => ({ id: "ok" }));
+    await limiter.flush("alice:dc-1", sendFn);
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+
+  it("flushAll processes all keys", async () => {
+    const limiter = new DiscordRateLimiter();
+    limiter.enqueue(makeMsg({ agentId: "alice", discordChannelId: "dc-1" }));
+    limiter.enqueue(makeMsg({ agentId: "bob", discordChannelId: "dc-2" }));
+
+    const sendFn = vi.fn(async () => ({ id: "ok" }));
+    await limiter.flushAll(() => sendFn);
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(limiter.allKeys()).toHaveLength(0);
+  });
+});

--- a/packages/server/src/discord/__tests__/fake-guild-port.ts
+++ b/packages/server/src/discord/__tests__/fake-guild-port.ts
@@ -1,0 +1,136 @@
+import type {
+  CreateTextChannelInput,
+  DiscordGuildPort,
+  DiscordMemberPort,
+  DiscordRolePort,
+  DiscordTextChannelPort,
+  PermissionName,
+  PermissionOverwriteInput,
+} from "../discord-guild-port.js";
+
+let nextId = 1;
+function snowflake(): string {
+  return `fake-${nextId++}`;
+}
+
+export type FakeChannelRecord = {
+  port: DiscordTextChannelPort;
+  name: string;
+  overwrites: PermissionOverwriteInput[];
+  sentMessages: Array<{ content: string; allowedMentions: { parse: [] } }>;
+};
+
+export type FakeRoleRecord = { id: string; name: string };
+
+export type FakeMemberRecord = {
+  userId: string;
+  roles: Set<string>;
+};
+
+export class FakeGuildPort implements DiscordGuildPort {
+  readonly channels = new Map<string, FakeChannelRecord>();
+  readonly roles = new Map<string, FakeRoleRecord>();
+  readonly members = new Map<string, FakeMemberRecord>();
+  private readonly guildEveryoneRoleId: string;
+
+  constructor(everyoneId = "everyone-role") {
+    this.guildEveryoneRoleId = everyoneId;
+  }
+
+  everyoneRoleId(): string {
+    return this.guildEveryoneRoleId;
+  }
+
+  addMemberRecord(userId: string): FakeMemberRecord {
+    const rec: FakeMemberRecord = { userId, roles: new Set() };
+    this.members.set(userId, rec);
+    return rec;
+  }
+
+  async fetchTextChannel(id: string): Promise<DiscordTextChannelPort | null> {
+    return this.channels.get(id)?.port ?? null;
+  }
+
+  async createTextChannel(input: CreateTextChannelInput): Promise<DiscordTextChannelPort> {
+    const id = snowflake();
+    const overwrites = input.permissionOverwrites ?? [];
+    const sentMessages: FakeChannelRecord["sentMessages"] = [];
+
+    const port: DiscordTextChannelPort = {
+      id,
+      async send(msg) {
+        sentMessages.push(msg);
+        return { id: snowflake() };
+      },
+      async sendTyping() {},
+      async setPermissionOverwrites(ow, _reason) {
+        rec.overwrites = ow;
+      },
+      async editPermissionOverwrite(targetId, permissions, _reason) {
+        let existing = rec.overwrites.find((o) => o.id === targetId);
+        if (!existing) {
+          existing = { id: targetId };
+          rec.overwrites.push(existing);
+        }
+        for (const [name, value] of Object.entries(permissions)) {
+          const perm = name as PermissionName;
+          if (value) {
+            existing.allow = [...(existing.allow ?? []), perm];
+            existing.deny = (existing.deny ?? []).filter((d) => d !== perm);
+          } else {
+            existing.deny = [...(existing.deny ?? []), perm];
+            existing.allow = (existing.allow ?? []).filter((a) => a !== perm);
+          }
+        }
+      },
+      async permissionsForMember(_userId) {
+        return new Set<PermissionName>();
+      },
+    };
+
+    const rec: FakeChannelRecord = { port, name: input.name, overwrites, sentMessages };
+    this.channels.set(id, rec);
+    return port;
+  }
+
+  async fetchRole(id: string): Promise<DiscordRolePort | null> {
+    return this.roles.get(id) ?? null;
+  }
+
+  async createRole(input: {
+    name: string;
+    reason: string;
+    mentionable: boolean;
+  }): Promise<DiscordRolePort> {
+    const id = snowflake();
+    const role: FakeRoleRecord = { id, name: input.name };
+    this.roles.set(id, role);
+    return role;
+  }
+
+  async fetchMember(userId: string): Promise<DiscordMemberPort | null> {
+    const rec = this.members.get(userId);
+    if (!rec) return null;
+    return {
+      userId,
+      async addRole(roleId, _reason) {
+        rec.roles.add(roleId);
+      },
+      async removeRole(roleId, _reason) {
+        rec.roles.delete(roleId);
+      },
+    };
+  }
+
+  getChannelOverwrites(channelId: string): PermissionOverwriteInput[] {
+    return this.channels.get(channelId)?.overwrites ?? [];
+  }
+
+  getMemberRoles(userId: string): Set<string> {
+    return this.members.get(userId)?.roles ?? new Set();
+  }
+
+  getSentMessages(channelId: string): FakeChannelRecord["sentMessages"] {
+    return this.channels.get(channelId)?.sentMessages ?? [];
+  }
+}

--- a/packages/server/src/discord/__tests__/role-manager.test.ts
+++ b/packages/server/src/discord/__tests__/role-manager.test.ts
@@ -126,6 +126,41 @@ describe("DiscordRoleManager", () => {
     });
   });
 
+  describe("ensureOperatorChannel", () => {
+    it("creates channel with @everyone denied", async () => {
+      const dcId = await mgr.ensureOperatorChannel("sim-1", "user-manager");
+      const rec = guild.channels.get(dcId)!;
+      expect(rec.name).toBe("pm-sim-1-operator");
+
+      const everyoneDeny = rec.overwrites.find((o) => o.id === "everyone-role");
+      expect(everyoneDeny?.deny).toContain("ViewChannel");
+    });
+
+    it("grants manager bot ViewChannel + SendMessages + ReadMessageHistory", async () => {
+      const dcId = await mgr.ensureOperatorChannel("sim-1", "user-manager");
+      const rec = guild.channels.get(dcId)!;
+
+      const mgrOw = rec.overwrites.find((o) => o.id === "user-manager");
+      expect(mgrOw?.allow).toContain("ViewChannel");
+      expect(mgrOw?.allow).toContain("SendMessages");
+      expect(mgrOw?.allow).toContain("ReadMessageHistory");
+    });
+
+    it("is idempotent", async () => {
+      const id1 = await mgr.ensureOperatorChannel("sim-1", "user-manager");
+      const id2 = await mgr.ensureOperatorChannel("sim-1", "user-manager");
+      expect(id1).toBe(id2);
+      expect(guild.channels.size).toBe(1);
+    });
+
+    it("works without manager bot (no manager overwrites)", async () => {
+      const dcId = await mgr.ensureOperatorChannel("sim-1");
+      const rec = guild.channels.get(dcId)!;
+      expect(rec.overwrites).toHaveLength(1);
+      expect(rec.overwrites[0].id).toBe("everyone-role");
+    });
+  });
+
   describe("lockAllChannels", () => {
     it("denies SendMessages for private channel roles", async () => {
       await mgr.createPrivateChannel({

--- a/packages/server/src/discord/__tests__/role-manager.test.ts
+++ b/packages/server/src/discord/__tests__/role-manager.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DiscordRoleManager } from "../role-manager.js";
+import { ChannelMap } from "../channel-map.js";
+import { FakeGuildPort } from "./fake-guild-port.js";
+
+describe("DiscordRoleManager", () => {
+  let guild: FakeGuildPort;
+  let channelMap: ChannelMap;
+  let botUserIdByAgentId: Map<string, string>;
+  let mgr: DiscordRoleManager;
+
+  beforeEach(() => {
+    guild = new FakeGuildPort("everyone-role");
+    channelMap = new ChannelMap();
+    botUserIdByAgentId = new Map([
+      ["alice", "user-alice"],
+      ["bob", "user-bob"],
+    ]);
+    guild.addMemberRecord("user-alice");
+    guild.addMemberRecord("user-bob");
+    guild.addMemberRecord("user-manager");
+    mgr = new DiscordRoleManager({
+      guild,
+      channelMap,
+      botUserIdByAgentId,
+      discordGuildId: "guild-1",
+    });
+  });
+
+  describe("createPrivateChannel", () => {
+    it("creates role + channel with correct overwrites", async () => {
+      const dcId = await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice"],
+        managerBotUserId: "user-manager",
+      });
+
+      const rec = guild.channels.get(dcId)!;
+      expect(rec).toBeDefined();
+      expect(rec.name).toBe("pm-sim-1-priv-secret");
+
+      const overwrites = rec.overwrites;
+      const everyoneDeny = overwrites.find((o) => o.id === "everyone-role");
+      expect(everyoneDeny?.deny).toContain("ViewChannel");
+
+      const roleOw = overwrites.find(
+        (o) => o.id !== "everyone-role" && o.id !== "user-manager",
+      );
+      expect(roleOw?.allow).toContain("ViewChannel");
+      expect(roleOw?.allow).toContain("SendMessages");
+      expect(roleOw?.allow).toContain("ReadMessageHistory");
+
+      const mgrOw = overwrites.find((o) => o.id === "user-manager");
+      expect(mgrOw?.allow).toContain("ViewChannel");
+      expect(mgrOw?.allow).toContain("SendMessages");
+      expect(mgrOw?.allow).toContain("ManageChannels");
+    });
+
+    it("assigns role to member bots", async () => {
+      await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice", "bob"],
+      });
+
+      const entry = channelMap.get("sim-1", "ch-priv")!;
+      expect(guild.getMemberRoles("user-alice").has(entry.discordRoleId!)).toBe(true);
+      expect(guild.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(true);
+    });
+
+    it("is idempotent — reuses existing channel", async () => {
+      const id1 = await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice"],
+      });
+      const id2 = await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice"],
+      });
+      expect(id1).toBe(id2);
+      expect(guild.roles.size).toBe(1);
+    });
+  });
+
+  describe("addMember / removeMember", () => {
+    it("adds and removes role", async () => {
+      await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice"],
+      });
+
+      const entry = channelMap.get("sim-1", "ch-priv")!;
+      expect(guild.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(false);
+
+      await mgr.addMember("sim-1", "ch-priv", "bob");
+      expect(guild.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(true);
+
+      await mgr.removeMember("sim-1", "ch-priv", "bob");
+      expect(guild.getMemberRoles("user-bob").has(entry.discordRoleId!)).toBe(false);
+    });
+  });
+
+  describe("ensurePublicChannel", () => {
+    it("creates channel and is idempotent", async () => {
+      const id1 = await mgr.ensurePublicChannel({
+        simulationId: "sim-1",
+        channelId: "general",
+        channelName: "general",
+      });
+      const id2 = await mgr.ensurePublicChannel({
+        simulationId: "sim-1",
+        channelId: "general",
+        channelName: "general",
+      });
+      expect(id1).toBe(id2);
+      expect(guild.channels.size).toBe(1);
+    });
+  });
+
+  describe("lockAllChannels", () => {
+    it("denies SendMessages for private channel roles", async () => {
+      await mgr.createPrivateChannel({
+        simulationId: "sim-1",
+        channelId: "ch-priv",
+        channelName: "secret",
+        memberAgentIds: ["alice"],
+      });
+
+      const entry = channelMap.get("sim-1", "ch-priv")!;
+      await mgr.lockAllChannels("sim-1");
+
+      const overwrites = guild.getChannelOverwrites(entry.discordChannelId);
+      const roleOw = overwrites.find((o) => o.id === entry.discordRoleId);
+      expect(roleOw?.deny).toContain("SendMessages");
+    });
+  });
+});

--- a/packages/server/src/discord/bot-registry.ts
+++ b/packages/server/src/discord/bot-registry.ts
@@ -1,0 +1,118 @@
+import { Client, GatewayIntentBits } from "discord.js";
+import type { Guild } from "discord.js";
+
+export type PersonaBotHandle = {
+  agentId: string;
+  userId: string;
+  client: Client<true>;
+  guild: Guild;
+};
+
+export type BotRegistryDeps = {
+  createClient?: () => Client;
+};
+
+const READY_TIMEOUT_MS = 30_000;
+
+export class BotRegistry {
+  private readonly guildId: string;
+  private readonly personas = new Map<string, PersonaBotHandle>();
+  private managerHandle: PersonaBotHandle | null = null;
+  private readonly createClient: () => Client;
+
+  constructor(guildId: string, deps?: BotRegistryDeps) {
+    this.guildId = guildId;
+    this.createClient =
+      deps?.createClient ??
+      (() => new Client({ intents: [GatewayIntentBits.Guilds] }));
+  }
+
+  async startPersonaBot(agentId: string, token: string): Promise<PersonaBotHandle> {
+    if (this.personas.has(agentId)) {
+      throw new Error(`bot already registered for agent "${agentId}"`);
+    }
+
+    const handle = await this.loginBot(agentId, token);
+    this.personas.set(agentId, handle);
+    return handle;
+  }
+
+  async startManagerBot(token: string): Promise<PersonaBotHandle> {
+    if (this.managerHandle) {
+      throw new Error("manager bot already registered");
+    }
+    const handle = await this.loginBot("__manager__", token);
+    this.managerHandle = handle;
+    return handle;
+  }
+
+  get(agentId: string): PersonaBotHandle {
+    const handle = this.personas.get(agentId);
+    if (!handle) throw new Error(`no bot registered for agent "${agentId}"`);
+    return handle;
+  }
+
+  getManagerBot(): PersonaBotHandle {
+    if (!this.managerHandle) throw new Error("no manager bot registered");
+    return this.managerHandle;
+  }
+
+  has(agentId: string): boolean {
+    return this.personas.has(agentId);
+  }
+
+  getUserId(agentId: string): string {
+    return this.get(agentId).userId;
+  }
+
+  allAgentIds(): string[] {
+    return [...this.personas.keys()];
+  }
+
+  async shutdown(): Promise<void> {
+    const clients: Client[] = [...this.personas.values()].map((h) => h.client);
+    if (this.managerHandle) clients.push(this.managerHandle.client);
+    this.personas.clear();
+    this.managerHandle = null;
+    await Promise.all(clients.map((c) => c.destroy()));
+  }
+
+  private async loginBot(agentId: string, token: string): Promise<PersonaBotHandle> {
+    const client = this.createClient();
+
+    const readyPromise = new Promise<Client<true>>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`bot "${agentId}": ready timeout after ${READY_TIMEOUT_MS}ms`)),
+        READY_TIMEOUT_MS,
+      );
+      client.once("ready", (readyClient) => {
+        clearTimeout(timer);
+        resolve(readyClient);
+      });
+      client.once("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    await client.login(token);
+    const readyClient = await readyPromise;
+
+    const guild = readyClient.guilds.cache.get(this.guildId);
+    if (!guild) {
+      await client.destroy();
+      throw new Error(`bot "${agentId}": guild ${this.guildId} not found`);
+    }
+    if (!guild.available) {
+      await client.destroy();
+      throw new Error(`bot "${agentId}": guild ${this.guildId} unavailable`);
+    }
+
+    return {
+      agentId,
+      userId: readyClient.user.id,
+      client: readyClient,
+      guild,
+    };
+  }
+}

--- a/packages/server/src/discord/channel-map.ts
+++ b/packages/server/src/discord/channel-map.ts
@@ -1,0 +1,46 @@
+import type { ChannelType } from "@perfectman/shared";
+
+export type DiscordChannelMapEntry = {
+  simulationId: string;
+  channelId: string;
+  channelType: ChannelType;
+  discordGuildId: string;
+  discordChannelId: string;
+  discordRoleId?: string;
+  lastSyncedAt: number;
+};
+
+export class ChannelMap {
+  private readonly entries = new Map<string, DiscordChannelMapEntry>();
+
+  private key(simulationId: string, channelId: string): string {
+    return `${simulationId}:${channelId}`;
+  }
+
+  get(simulationId: string, channelId: string): DiscordChannelMapEntry | null {
+    return this.entries.get(this.key(simulationId, channelId)) ?? null;
+  }
+
+  upsert(entry: DiscordChannelMapEntry): void {
+    this.entries.set(this.key(entry.simulationId, entry.channelId), entry);
+  }
+
+  getByDiscordChannelId(discordChannelId: string): DiscordChannelMapEntry | null {
+    for (const entry of this.entries.values()) {
+      if (entry.discordChannelId === discordChannelId) return entry;
+    }
+    return null;
+  }
+
+  allForSimulation(simulationId: string): DiscordChannelMapEntry[] {
+    const result: DiscordChannelMapEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (entry.simulationId === simulationId) result.push(entry);
+    }
+    return result;
+  }
+
+  remove(simulationId: string, channelId: string): boolean {
+    return this.entries.delete(this.key(simulationId, channelId));
+  }
+}

--- a/packages/server/src/discord/discord-config.ts
+++ b/packages/server/src/discord/discord-config.ts
@@ -68,9 +68,25 @@ export function parseDiscordGatewayConfig(
     }
   }
 
-  const setupMode: DiscordSetupMode = managerBotToken
-    ? "manage_channels"
-    : "readonly_existing";
+  let setupMode: DiscordSetupMode;
+  if (
+    raw.setupMode === "readonly_existing" ||
+    raw.setupMode === "manage_channels"
+  ) {
+    setupMode = raw.setupMode;
+  } else if (raw.setupMode !== undefined) {
+    throw new Error(
+      `discord config: setupMode must be "readonly_existing" or "manage_channels"`,
+    );
+  } else {
+    setupMode = managerBotToken ? "manage_channels" : "readonly_existing";
+  }
+
+  if (setupMode === "manage_channels" && !managerBotToken) {
+    throw new Error(
+      "discord config: managerBotToken required for manage_channels mode",
+    );
+  }
 
   return { guildId: raw.guildId, managerBotToken, personaBots, setupMode };
 }

--- a/packages/server/src/discord/discord-config.ts
+++ b/packages/server/src/discord/discord-config.ts
@@ -1,0 +1,99 @@
+export type DiscordPersonaBotConfig = {
+  agentId: string;
+  token: string;
+};
+
+export type DiscordSetupMode = "readonly_existing" | "manage_channels";
+
+export type DiscordGatewayConfig = {
+  guildId: string;
+  managerBotToken?: string;
+  personaBots: DiscordPersonaBotConfig[];
+  setupMode: DiscordSetupMode;
+};
+
+export type RawDiscordGatewayConfig = {
+  guildId?: string;
+  managerBotTokenEnv?: string;
+  personaBots?: Array<{ agentId?: string; tokenEnv?: string }>;
+  setupMode?: string;
+};
+
+export function parseDiscordGatewayConfig(
+  raw: RawDiscordGatewayConfig,
+): DiscordGatewayConfig {
+  if (!raw.guildId || typeof raw.guildId !== "string") {
+    throw new Error("discord config: guildId is required");
+  }
+
+  if (!Array.isArray(raw.personaBots) || raw.personaBots.length === 0) {
+    throw new Error("discord config: at least one personaBot is required");
+  }
+
+  const seenAgentIds = new Set<string>();
+  const personaBots: DiscordPersonaBotConfig[] = raw.personaBots.map(
+    (bot, i) => {
+      if (!bot.agentId || typeof bot.agentId !== "string") {
+        throw new Error(`discord config: personaBots[${i}].agentId is required`);
+      }
+      if (!bot.tokenEnv || typeof bot.tokenEnv !== "string") {
+        throw new Error(
+          `discord config: personaBots[${i}].tokenEnv is required`,
+        );
+      }
+      if (seenAgentIds.has(bot.agentId)) {
+        throw new Error(
+          `discord config: duplicate agentId "${bot.agentId}"`,
+        );
+      }
+      seenAgentIds.add(bot.agentId);
+
+      const token = process.env[bot.tokenEnv];
+      if (!token) {
+        throw new Error(
+          `discord config: env var "${bot.tokenEnv}" is not set`,
+        );
+      }
+      return { agentId: bot.agentId, token };
+    },
+  );
+
+  let managerBotToken: string | undefined;
+  if (raw.managerBotTokenEnv) {
+    managerBotToken = process.env[raw.managerBotTokenEnv];
+    if (!managerBotToken) {
+      throw new Error(
+        `discord config: env var "${raw.managerBotTokenEnv}" is not set`,
+      );
+    }
+  }
+
+  const setupMode: DiscordSetupMode = managerBotToken
+    ? "manage_channels"
+    : "readonly_existing";
+
+  return { guildId: raw.guildId, managerBotToken, personaBots, setupMode };
+}
+
+export function validateDiscordGatewayConfig(
+  config: DiscordGatewayConfig,
+): void {
+  if (!config.guildId) {
+    throw new Error("discord config: guildId is required");
+  }
+  if (config.personaBots.length === 0) {
+    throw new Error("discord config: at least one personaBot is required");
+  }
+  const agentIds = new Set<string>();
+  for (const bot of config.personaBots) {
+    if (agentIds.has(bot.agentId)) {
+      throw new Error(`discord config: duplicate agentId "${bot.agentId}"`);
+    }
+    agentIds.add(bot.agentId);
+  }
+  if (config.setupMode === "manage_channels" && !config.managerBotToken) {
+    throw new Error(
+      "discord config: managerBotToken required for manage_channels mode",
+    );
+  }
+}

--- a/packages/server/src/discord/discord-errors.ts
+++ b/packages/server/src/discord/discord-errors.ts
@@ -1,0 +1,73 @@
+export type DiscordErrorKind =
+  | "rate_limited"
+  | "missing_permission"
+  | "invalid_auth"
+  | "not_found"
+  | "transient"
+  | "validation"
+  | "unknown";
+
+export type ClassifiedDiscordError = {
+  kind: DiscordErrorKind;
+  retryAt?: number;
+  status?: number;
+  message: string;
+};
+
+export function classifyDiscordError(
+  error: unknown,
+  now: number = Date.now(),
+): ClassifiedDiscordError {
+  if (error instanceof Error) {
+    const anyErr = error as unknown as Record<string, unknown>;
+    const status =
+      typeof anyErr.status === "number"
+        ? anyErr.status
+        : typeof anyErr.httpStatus === "number"
+          ? anyErr.httpStatus
+          : undefined;
+
+    if (status === 429) {
+      const retryAfterSec =
+        typeof anyErr.retry_after === "number"
+          ? anyErr.retry_after
+          : typeof anyErr.retryAfter === "number"
+            ? anyErr.retryAfter
+            : 5;
+      return {
+        kind: "rate_limited",
+        retryAt: now + retryAfterSec * 1000,
+        status,
+        message: error.message,
+      };
+    }
+
+    if (status === 401) {
+      return { kind: "invalid_auth", status, message: error.message };
+    }
+
+    if (status === 403) {
+      return { kind: "missing_permission", status, message: error.message };
+    }
+
+    if (status === 404) {
+      return { kind: "not_found", status, message: error.message };
+    }
+
+    if (status !== undefined && status >= 500) {
+      return { kind: "transient", status, message: error.message };
+    }
+
+    if (error.message.includes("ECONNRESET") || error.message.includes("ETIMEDOUT")) {
+      return { kind: "transient", message: error.message };
+    }
+
+    return { kind: "unknown", status, message: error.message };
+  }
+
+  return { kind: "unknown", message: String(error) };
+}
+
+export function isRetryable(classified: ClassifiedDiscordError): boolean {
+  return classified.kind === "rate_limited" || classified.kind === "transient";
+}

--- a/packages/server/src/discord/discord-formatter.ts
+++ b/packages/server/src/discord/discord-formatter.ts
@@ -1,0 +1,49 @@
+import type { DeliveryMessage } from "../simulation/scheduler-contracts.js";
+import type { SpectatorEvent, OperatorEvent } from "@perfectman/shared";
+
+export type DiscordFormattedMessage = {
+  content: string;
+  allowedMentions: { parse: [] };
+};
+
+const DISCORD_MAX_CONTENT_LENGTH = 1900;
+
+function truncate(text: string): string {
+  if (text.length <= DISCORD_MAX_CONTENT_LENGTH) return text;
+  return text.slice(0, DISCORD_MAX_CONTENT_LENGTH - 3) + "...";
+}
+
+export function formatDeliveryMessage(msg: DeliveryMessage): DiscordFormattedMessage {
+  let content: string;
+  switch (msg.kind) {
+    case "message":
+      content = msg.content;
+      break;
+    case "reply":
+      content = msg.content;
+      break;
+    case "reaction":
+      content = msg.emoji;
+      break;
+  }
+  return {
+    content: truncate(content || "(empty)"),
+    allowedMentions: { parse: [] },
+  };
+}
+
+export function formatSpectatorEvent(event: SpectatorEvent): DiscordFormattedMessage {
+  const prefix = event.type === "recap" ? "[recap]" : "[spectator]";
+  const body = event.visibleContent ?? event.narrativeHint ?? event.summary ?? "";
+  return {
+    content: truncate(`${prefix} ${body}` || "(empty)"),
+    allowedMentions: { parse: [] },
+  };
+}
+
+export function formatOperatorEvent(event: OperatorEvent): DiscordFormattedMessage {
+  return {
+    content: truncate(`[operator:${event.type}] ${event.detail}`),
+    allowedMentions: { parse: [] },
+  };
+}

--- a/packages/server/src/discord/discord-gateway.ts
+++ b/packages/server/src/discord/discord-gateway.ts
@@ -46,6 +46,14 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
     this.rateLimiter = deps.rateLimiter;
   }
 
+  private getManagerBotUserId(): string | undefined {
+    try {
+      return this.botRegistry.getManagerBot().userId;
+    } catch {
+      return undefined;
+    }
+  }
+
   async sendAgentMessage(
     channelId: string,
     message: DeliveryMessage,
@@ -54,6 +62,13 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
     if (!entry) {
       throw new Error(
         `discord gateway: no channel mapping for ${this.simulationId}:${channelId}`,
+      );
+    }
+
+    const guildPort = this.guildPortByAgent.get(message.agentId);
+    if (!guildPort) {
+      throw new Error(
+        `discord gateway: no persona bot configured for agent "${message.agentId}"`,
       );
     }
 
@@ -72,8 +87,6 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
     });
 
     const key = `${message.agentId}:${entry.discordChannelId}`;
-    const guildPort = this.guildPortByAgent.get(message.agentId);
-    if (!guildPort) return;
 
     await this.rateLimiter.flush(
       key,
@@ -92,12 +105,7 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
   ): Promise<void> {
     switch (type) {
       case "private_channel": {
-        let managerBotUserId: string | undefined;
-        try {
-          managerBotUserId = this.botRegistry.getManagerBot().userId;
-        } catch {
-          // no manager bot
-        }
+        const managerBotUserId = this.getManagerBotUserId();
         await this.roleManager.createPrivateChannel({
           simulationId: this.simulationId,
           channelId,
@@ -118,7 +126,7 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
         await this.roleManager.ensureSpectatorChannel(this.simulationId);
         break;
       case "operator_channel":
-        await this.roleManager.ensureOperatorChannel(this.simulationId);
+        await this.roleManager.ensureOperatorChannel(this.simulationId, this.getManagerBotUserId());
         break;
     }
   }
@@ -155,6 +163,7 @@ export class DiscordDeliveryGateway implements IDeliveryGateway {
 
     const operatorChannelId = await this.roleManager.ensureOperatorChannel(
       simulationId,
+      this.getManagerBotUserId(),
     );
     const ch = await this.managerGuildPort.fetchTextChannel(operatorChannelId);
     if (ch) {

--- a/packages/server/src/discord/discord-gateway.ts
+++ b/packages/server/src/discord/discord-gateway.ts
@@ -1,0 +1,167 @@
+import type {
+  ChannelType,
+  SpectatorEvent,
+  OperatorEvent,
+} from "@perfectman/shared";
+import type { DeliveryMessage, IDeliveryGateway } from "../simulation/scheduler-contracts.js";
+import type { BotRegistry } from "./bot-registry.js";
+import type { ChannelMap } from "./channel-map.js";
+import type { DiscordRoleManager } from "./role-manager.js";
+import type { DiscordRateLimiter } from "./discord-rate-limiter.js";
+import type { DiscordGuildPort } from "./discord-guild-port.js";
+import type { DiscordGatewayConfig } from "./discord-config.js";
+import {
+  formatDeliveryMessage,
+  formatSpectatorEvent,
+  formatOperatorEvent,
+} from "./discord-formatter.js";
+
+export type DiscordGatewayDeps = {
+  simulationId: string;
+  config: DiscordGatewayConfig;
+  botRegistry: BotRegistry;
+  managerGuildPort: DiscordGuildPort;
+  guildPortByAgent: Map<string, DiscordGuildPort>;
+  channelMap: ChannelMap;
+  roleManager: DiscordRoleManager;
+  rateLimiter: DiscordRateLimiter;
+};
+
+export class DiscordDeliveryGateway implements IDeliveryGateway {
+  private readonly simulationId: string;
+  private readonly botRegistry: BotRegistry;
+  private readonly managerGuildPort: DiscordGuildPort;
+  private readonly guildPortByAgent: Map<string, DiscordGuildPort>;
+  private readonly channelMap: ChannelMap;
+  private readonly roleManager: DiscordRoleManager;
+  private readonly rateLimiter: DiscordRateLimiter;
+
+  constructor(deps: DiscordGatewayDeps) {
+    this.simulationId = deps.simulationId;
+    this.botRegistry = deps.botRegistry;
+    this.managerGuildPort = deps.managerGuildPort;
+    this.guildPortByAgent = deps.guildPortByAgent;
+    this.channelMap = deps.channelMap;
+    this.roleManager = deps.roleManager;
+    this.rateLimiter = deps.rateLimiter;
+  }
+
+  async sendAgentMessage(
+    channelId: string,
+    message: DeliveryMessage,
+  ): Promise<void> {
+    const entry = this.channelMap.get(this.simulationId, channelId);
+    if (!entry) {
+      throw new Error(
+        `discord gateway: no channel mapping for ${this.simulationId}:${channelId}`,
+      );
+    }
+
+    const formatted = formatDeliveryMessage(message);
+    const msgId = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+    this.rateLimiter.enqueue({
+      id: msgId,
+      agentId: message.agentId,
+      discordChannelId: entry.discordChannelId,
+      payload: formatted,
+      salience: message.salience,
+      attempts: 0,
+      notBefore: 0,
+      createdAt: Date.now(),
+    });
+
+    const key = `${message.agentId}:${entry.discordChannelId}`;
+    const guildPort = this.guildPortByAgent.get(message.agentId);
+    if (!guildPort) return;
+
+    await this.rateLimiter.flush(
+      key,
+      async (discordChannelId, payload) => {
+        const ch = await guildPort.fetchTextChannel(discordChannelId);
+        if (!ch) throw new Error(`channel ${discordChannelId} not found`);
+        return ch.send(payload);
+      },
+    );
+  }
+
+  async createChannel(
+    channelId: string,
+    type: ChannelType,
+    memberAgentIds: string[],
+  ): Promise<void> {
+    switch (type) {
+      case "private_channel": {
+        let managerBotUserId: string | undefined;
+        try {
+          managerBotUserId = this.botRegistry.getManagerBot().userId;
+        } catch {
+          // no manager bot
+        }
+        await this.roleManager.createPrivateChannel({
+          simulationId: this.simulationId,
+          channelId,
+          channelName: channelId,
+          memberAgentIds,
+          managerBotUserId,
+        });
+        break;
+      }
+      case "public_channel":
+        await this.roleManager.ensurePublicChannel({
+          simulationId: this.simulationId,
+          channelId,
+          channelName: channelId,
+        });
+        break;
+      case "spectator_channel":
+        await this.roleManager.ensureSpectatorChannel(this.simulationId);
+        break;
+      case "operator_channel":
+        await this.roleManager.ensureOperatorChannel(this.simulationId);
+        break;
+    }
+  }
+
+  async addMember(channelId: string, agentId: string): Promise<void> {
+    await this.roleManager.addMember(this.simulationId, channelId, agentId);
+  }
+
+  async removeMember(channelId: string, agentId: string): Promise<void> {
+    await this.roleManager.removeMember(this.simulationId, channelId, agentId);
+  }
+
+  async sendSpectatorEvent(event: SpectatorEvent): Promise<void> {
+    const discordChannelId = await this.roleManager.ensureSpectatorChannel(
+      this.simulationId,
+    );
+    const formatted = formatSpectatorEvent(event);
+    const ch = await this.managerGuildPort.fetchTextChannel(discordChannelId);
+    if (ch) await ch.send(formatted);
+  }
+
+  async sendOperatorEvent(event: OperatorEvent): Promise<void> {
+    const discordChannelId = await this.roleManager.ensureOperatorChannel(
+      this.simulationId,
+    );
+    const formatted = formatOperatorEvent(event);
+    const ch = await this.managerGuildPort.fetchTextChannel(discordChannelId);
+    if (ch) await ch.send(formatted);
+  }
+
+  async onSimulationStopped(simulationId: string): Promise<void> {
+    await this.roleManager.lockAllChannels(simulationId);
+    this.rateLimiter.clear();
+
+    const operatorChannelId = await this.roleManager.ensureOperatorChannel(
+      simulationId,
+    );
+    const ch = await this.managerGuildPort.fetchTextChannel(operatorChannelId);
+    if (ch) {
+      await ch.send({
+        content: `[operator:simulation_stopped] Simulation ${simulationId} has been stopped.`,
+        allowedMentions: { parse: [] },
+      });
+    }
+  }
+}

--- a/packages/server/src/discord/discord-guild-adapter.ts
+++ b/packages/server/src/discord/discord-guild-adapter.ts
@@ -1,7 +1,6 @@
 import {
   ChannelType,
   PermissionFlagsBits,
-  PermissionsBitField,
   type Guild,
   type GuildMember,
   type TextChannel,
@@ -51,14 +50,7 @@ function wrapTextChannel(channel: TextChannel): DiscordTextChannelPort {
       );
     },
     async editPermissionOverwrite(id, permissions, reason) {
-      const resolved: Partial<Record<string, boolean>> = {};
-      for (const [name, value] of Object.entries(permissions)) {
-        const bit = PERM_MAP[name as PermissionName];
-        if (bit !== undefined) {
-          resolved[bit.toString()] = value;
-        }
-      }
-      await channel.permissionOverwrites.edit(id, resolved, { reason });
+      await channel.permissionOverwrites.edit(id, permissions, { reason });
     },
     async permissionsForMember(userId) {
       const member = await channel.guild.members.fetch(userId);

--- a/packages/server/src/discord/discord-guild-adapter.ts
+++ b/packages/server/src/discord/discord-guild-adapter.ts
@@ -1,0 +1,134 @@
+import {
+  ChannelType,
+  PermissionFlagsBits,
+  PermissionsBitField,
+  type Guild,
+  type GuildMember,
+  type TextChannel,
+  type OverwriteResolvable,
+} from "discord.js";
+import type {
+  CreateTextChannelInput,
+  DiscordGuildPort,
+  DiscordMemberPort,
+  DiscordRolePort,
+  DiscordTextChannelPort,
+  PermissionName,
+  PermissionOverwriteInput,
+} from "./discord-guild-port.js";
+
+const PERM_MAP: Record<PermissionName, bigint> = {
+  ViewChannel: PermissionFlagsBits.ViewChannel,
+  SendMessages: PermissionFlagsBits.SendMessages,
+  ReadMessageHistory: PermissionFlagsBits.ReadMessageHistory,
+  ManageChannels: PermissionFlagsBits.ManageChannels,
+  ManageRoles: PermissionFlagsBits.ManageRoles,
+  AddReactions: PermissionFlagsBits.AddReactions,
+};
+
+function toOverwriteResolvable(input: PermissionOverwriteInput): OverwriteResolvable {
+  let allow = BigInt(0);
+  let deny = BigInt(0);
+  for (const p of input.allow ?? []) allow |= PERM_MAP[p];
+  for (const p of input.deny ?? []) deny |= PERM_MAP[p];
+  return { id: input.id, allow, deny };
+}
+
+function wrapTextChannel(channel: TextChannel): DiscordTextChannelPort {
+  return {
+    id: channel.id,
+    async send(input) {
+      const msg = await channel.send(input);
+      return { id: msg.id };
+    },
+    async sendTyping() {
+      await channel.sendTyping();
+    },
+    async setPermissionOverwrites(overwrites, reason) {
+      await channel.permissionOverwrites.set(
+        overwrites.map(toOverwriteResolvable),
+        reason,
+      );
+    },
+    async editPermissionOverwrite(id, permissions, reason) {
+      const resolved: Partial<Record<string, boolean>> = {};
+      for (const [name, value] of Object.entries(permissions)) {
+        const bit = PERM_MAP[name as PermissionName];
+        if (bit !== undefined) {
+          resolved[bit.toString()] = value;
+        }
+      }
+      await channel.permissionOverwrites.edit(id, resolved, { reason });
+    },
+    async permissionsForMember(userId) {
+      const member = await channel.guild.members.fetch(userId);
+      const perms = channel.permissionsFor(member);
+      const result = new Set<PermissionName>();
+      for (const [name, bit] of Object.entries(PERM_MAP)) {
+        if (perms?.has(bit)) result.add(name as PermissionName);
+      }
+      return result;
+    },
+  };
+}
+
+function wrapMember(member: GuildMember): DiscordMemberPort {
+  return {
+    userId: member.id,
+    async addRole(roleId, reason) {
+      await member.roles.add(roleId, reason);
+    },
+    async removeRole(roleId, reason) {
+      await member.roles.remove(roleId, reason);
+    },
+  };
+}
+
+export class DiscordJsGuildAdapter implements DiscordGuildPort {
+  constructor(private readonly guild: Guild) {}
+
+  everyoneRoleId(): string {
+    return this.guild.id;
+  }
+
+  async fetchTextChannel(id: string): Promise<DiscordTextChannelPort | null> {
+    const channel = await this.guild.channels.fetch(id).catch(() => null);
+    if (!channel || channel.type !== ChannelType.GuildText) return null;
+    return wrapTextChannel(channel as TextChannel);
+  }
+
+  async createTextChannel(input: CreateTextChannelInput): Promise<DiscordTextChannelPort> {
+    const channel = await this.guild.channels.create({
+      name: input.name,
+      type: ChannelType.GuildText,
+      reason: input.reason,
+      permissionOverwrites: input.permissionOverwrites?.map(toOverwriteResolvable),
+    });
+    return wrapTextChannel(channel);
+  }
+
+  async fetchRole(id: string): Promise<DiscordRolePort | null> {
+    const role = await this.guild.roles.fetch(id).catch(() => null);
+    if (!role) return null;
+    return { id: role.id, name: role.name };
+  }
+
+  async createRole(input: {
+    name: string;
+    reason: string;
+    mentionable: boolean;
+  }): Promise<DiscordRolePort> {
+    const role = await this.guild.roles.create({
+      name: input.name,
+      reason: input.reason,
+      mentionable: input.mentionable,
+    });
+    return { id: role.id, name: role.name };
+  }
+
+  async fetchMember(userId: string): Promise<DiscordMemberPort | null> {
+    const member = await this.guild.members.fetch(userId).catch(() => null);
+    if (!member) return null;
+    return wrapMember(member);
+  }
+}

--- a/packages/server/src/discord/discord-guild-port.ts
+++ b/packages/server/src/discord/discord-guild-port.ts
@@ -1,0 +1,62 @@
+export type PermissionName =
+  | "ViewChannel"
+  | "SendMessages"
+  | "ReadMessageHistory"
+  | "ManageChannels"
+  | "ManageRoles"
+  | "AddReactions";
+
+export type PermissionOverwriteInput = {
+  id: string;
+  allow?: PermissionName[];
+  deny?: PermissionName[];
+};
+
+export type CreateTextChannelInput = {
+  name: string;
+  reason: string;
+  permissionOverwrites?: PermissionOverwriteInput[];
+};
+
+export type DiscordTextChannelPort = {
+  id: string;
+  send(input: {
+    content: string;
+    allowedMentions: { parse: [] };
+  }): Promise<{ id: string }>;
+  sendTyping(): Promise<void>;
+  setPermissionOverwrites(
+    overwrites: PermissionOverwriteInput[],
+    reason: string,
+  ): Promise<void>;
+  editPermissionOverwrite(
+    id: string,
+    permissions: Partial<Record<PermissionName, boolean>>,
+    reason: string,
+  ): Promise<void>;
+  permissionsForMember(userId: string): Promise<Set<PermissionName>>;
+};
+
+export type DiscordRolePort = {
+  id: string;
+  name: string;
+};
+
+export type DiscordMemberPort = {
+  userId: string;
+  addRole(roleId: string, reason: string): Promise<void>;
+  removeRole(roleId: string, reason: string): Promise<void>;
+};
+
+export type DiscordGuildPort = {
+  everyoneRoleId(): string;
+  fetchTextChannel(id: string): Promise<DiscordTextChannelPort | null>;
+  createTextChannel(input: CreateTextChannelInput): Promise<DiscordTextChannelPort>;
+  fetchRole(id: string): Promise<DiscordRolePort | null>;
+  createRole(input: {
+    name: string;
+    reason: string;
+    mentionable: boolean;
+  }): Promise<DiscordRolePort>;
+  fetchMember(userId: string): Promise<DiscordMemberPort | null>;
+};

--- a/packages/server/src/discord/discord-rate-limiter.ts
+++ b/packages/server/src/discord/discord-rate-limiter.ts
@@ -1,0 +1,135 @@
+import type { EmotionalSalience } from "@perfectman/shared";
+import type { DiscordFormattedMessage } from "./discord-formatter.js";
+import { classifyDiscordError, isRetryable } from "./discord-errors.js";
+import type { ClassifiedDiscordError } from "./discord-errors.js";
+
+export type OutboundDiscordMessage = {
+  id: string;
+  agentId: string;
+  discordChannelId: string;
+  payload: DiscordFormattedMessage;
+  salience: EmotionalSalience;
+  attempts: number;
+  notBefore: number;
+  createdAt: number;
+};
+
+export type DiscordSendFn = (
+  channelId: string,
+  payload: DiscordFormattedMessage,
+) => Promise<{ id: string }>;
+
+export type RateLimiterConfig = {
+  maxQueueDepth: number;
+  maxAttempts: number;
+  baseBackoffMs: number;
+  maxBackoffMs: number;
+};
+
+const DEFAULT_CONFIG: RateLimiterConfig = {
+  maxQueueDepth: 20,
+  maxAttempts: 3,
+  baseBackoffMs: 1000,
+  maxBackoffMs: 30_000,
+};
+
+export class DiscordRateLimiter {
+  private readonly queues = new Map<string, OutboundDiscordMessage[]>();
+  private readonly config: RateLimiterConfig;
+  private readonly now: () => number;
+
+  constructor(config?: Partial<RateLimiterConfig>, now?: () => number) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.now = now ?? (() => Date.now());
+  }
+
+  enqueue(msg: OutboundDiscordMessage): boolean {
+    const key = `${msg.agentId}:${msg.discordChannelId}`;
+    let queue = this.queues.get(key);
+    if (!queue) {
+      queue = [];
+      this.queues.set(key, queue);
+    }
+
+    if (queue.length >= this.config.maxQueueDepth) {
+      if (msg.salience === "low") return false;
+      const lowIdx = queue.findIndex((m) => m.salience === "low");
+      if (lowIdx >= 0) queue.splice(lowIdx, 1);
+    }
+
+    queue.push(msg);
+    return true;
+  }
+
+  async flush(
+    key: string,
+    sendFn: DiscordSendFn,
+    onError?: (msg: OutboundDiscordMessage, err: ClassifiedDiscordError) => void,
+  ): Promise<void> {
+    const queue = this.queues.get(key);
+    if (!queue) return;
+
+    while (queue.length > 0) {
+      const msg = queue[0]!;
+      const currentTime = this.now();
+
+      if (msg.notBefore > currentTime) break;
+
+      try {
+        await sendFn(msg.discordChannelId, msg.payload);
+        queue.shift();
+      } catch (err) {
+        const classified = classifyDiscordError(err, currentTime);
+
+        if (classified.kind === "rate_limited" && classified.retryAt) {
+          msg.notBefore = classified.retryAt;
+          break;
+        }
+
+        if (!isRetryable(classified)) {
+          const removed = queue.shift()!;
+          onError?.(removed, classified);
+          continue;
+        }
+
+        msg.attempts++;
+        if (msg.attempts >= this.config.maxAttempts) {
+          const removed = queue.shift()!;
+          onError?.(removed, classified);
+          continue;
+        }
+
+        const backoff = Math.min(
+          this.config.baseBackoffMs * 2 ** (msg.attempts - 1),
+          this.config.maxBackoffMs,
+        );
+        msg.notBefore = currentTime + backoff;
+        break;
+      }
+    }
+
+    if (queue.length === 0) this.queues.delete(key);
+  }
+
+  async flushAll(
+    sendFnByAgent: (agentId: string) => DiscordSendFn,
+    onError?: (msg: OutboundDiscordMessage, err: ClassifiedDiscordError) => void,
+  ): Promise<void> {
+    for (const key of [...this.queues.keys()]) {
+      const agentId = key.split(":")[0]!;
+      await this.flush(key, sendFnByAgent(agentId), onError);
+    }
+  }
+
+  queueDepth(key: string): number {
+    return this.queues.get(key)?.length ?? 0;
+  }
+
+  allKeys(): string[] {
+    return [...this.queues.keys()];
+  }
+
+  clear(): void {
+    this.queues.clear();
+  }
+}

--- a/packages/server/src/discord/index.ts
+++ b/packages/server/src/discord/index.ts
@@ -1,0 +1,42 @@
+export { DiscordDeliveryGateway } from "./discord-gateway.js";
+export type { DiscordGatewayDeps } from "./discord-gateway.js";
+export {
+  parseDiscordGatewayConfig,
+  validateDiscordGatewayConfig,
+} from "./discord-config.js";
+export type {
+  DiscordGatewayConfig,
+  DiscordPersonaBotConfig,
+  DiscordSetupMode,
+  RawDiscordGatewayConfig,
+} from "./discord-config.js";
+export { classifyDiscordError, isRetryable } from "./discord-errors.js";
+export type { DiscordErrorKind, ClassifiedDiscordError } from "./discord-errors.js";
+export { BotRegistry } from "./bot-registry.js";
+export type { PersonaBotHandle, BotRegistryDeps } from "./bot-registry.js";
+export { ChannelMap } from "./channel-map.js";
+export type { DiscordChannelMapEntry } from "./channel-map.js";
+export { DiscordRoleManager } from "./role-manager.js";
+export type { RoleManagerDeps } from "./role-manager.js";
+export {
+  formatDeliveryMessage,
+  formatSpectatorEvent,
+  formatOperatorEvent,
+} from "./discord-formatter.js";
+export type { DiscordFormattedMessage } from "./discord-formatter.js";
+export { DiscordRateLimiter } from "./discord-rate-limiter.js";
+export type {
+  OutboundDiscordMessage,
+  DiscordSendFn,
+  RateLimiterConfig,
+} from "./discord-rate-limiter.js";
+export type {
+  DiscordGuildPort,
+  DiscordTextChannelPort,
+  DiscordRolePort,
+  DiscordMemberPort,
+  PermissionName,
+  PermissionOverwriteInput,
+  CreateTextChannelInput,
+} from "./discord-guild-port.js";
+export { DiscordJsGuildAdapter } from "./discord-guild-adapter.js";

--- a/packages/server/src/discord/role-manager.ts
+++ b/packages/server/src/discord/role-manager.ts
@@ -54,12 +54,40 @@ export class DiscordRoleManager {
     });
   }
 
-  async ensureOperatorChannel(simulationId: string): Promise<string> {
-    return this.ensurePublicChannel({
+  async ensureOperatorChannel(
+    simulationId: string,
+    managerBotUserId?: string,
+  ): Promise<string> {
+    const existing = this.channelMap.get(simulationId, "__operator");
+    if (existing) return existing.discordChannelId;
+
+    const overwrites: import("./discord-guild-port.js").PermissionOverwriteInput[] = [
+      { id: this.guild.everyoneRoleId(), deny: ["ViewChannel"] },
+    ];
+
+    if (managerBotUserId) {
+      overwrites.push({
+        id: managerBotUserId,
+        allow: ["ViewChannel", "SendMessages", "ReadMessageHistory"],
+      });
+    }
+
+    const ch = await this.guild.createTextChannel({
+      name: `pm-${simulationId}-operator`,
+      reason: "perfectman operator channel",
+      permissionOverwrites: overwrites,
+    });
+
+    this.channelMap.upsert({
       simulationId,
       channelId: "__operator",
-      channelName: "operator",
+      channelType: "operator_channel",
+      discordGuildId: this.discordGuildId,
+      discordChannelId: ch.id,
+      lastSyncedAt: Date.now(),
     });
+
+    return ch.id;
   }
 
   async createPrivateChannel(opts: {

--- a/packages/server/src/discord/role-manager.ts
+++ b/packages/server/src/discord/role-manager.ts
@@ -1,0 +1,165 @@
+import type { DiscordGuildPort } from "./discord-guild-port.js";
+import type { ChannelMap } from "./channel-map.js";
+
+export type RoleManagerDeps = {
+  guild: DiscordGuildPort;
+  channelMap: ChannelMap;
+  botUserIdByAgentId: Map<string, string>;
+  discordGuildId: string;
+};
+
+export class DiscordRoleManager {
+  private readonly guild: DiscordGuildPort;
+  private readonly channelMap: ChannelMap;
+  private readonly botUserIdByAgentId: Map<string, string>;
+  private readonly discordGuildId: string;
+
+  constructor(deps: RoleManagerDeps) {
+    this.guild = deps.guild;
+    this.channelMap = deps.channelMap;
+    this.botUserIdByAgentId = deps.botUserIdByAgentId;
+    this.discordGuildId = deps.discordGuildId;
+  }
+
+  async ensurePublicChannel(opts: {
+    simulationId: string;
+    channelId: string;
+    channelName: string;
+  }): Promise<string> {
+    const existing = this.channelMap.get(opts.simulationId, opts.channelId);
+    if (existing) return existing.discordChannelId;
+
+    const ch = await this.guild.createTextChannel({
+      name: `pm-${opts.simulationId}-${opts.channelName}`,
+      reason: `perfectman public channel: ${opts.channelId}`,
+    });
+
+    this.channelMap.upsert({
+      simulationId: opts.simulationId,
+      channelId: opts.channelId,
+      channelType: "public_channel",
+      discordGuildId: this.discordGuildId,
+      discordChannelId: ch.id,
+      lastSyncedAt: Date.now(),
+    });
+
+    return ch.id;
+  }
+
+  async ensureSpectatorChannel(simulationId: string): Promise<string> {
+    return this.ensurePublicChannel({
+      simulationId,
+      channelId: "__spectator",
+      channelName: "spectator",
+    });
+  }
+
+  async ensureOperatorChannel(simulationId: string): Promise<string> {
+    return this.ensurePublicChannel({
+      simulationId,
+      channelId: "__operator",
+      channelName: "operator",
+    });
+  }
+
+  async createPrivateChannel(opts: {
+    simulationId: string;
+    channelId: string;
+    channelName: string;
+    memberAgentIds: string[];
+    managerBotUserId?: string;
+  }): Promise<string> {
+    const existing = this.channelMap.get(opts.simulationId, opts.channelId);
+    if (existing) return existing.discordChannelId;
+
+    const role = await this.guild.createRole({
+      name: `pm-${opts.simulationId}-role-${opts.channelId}`,
+      reason: `perfectman private channel role: ${opts.channelId}`,
+      mentionable: false,
+    });
+
+    const overwrites: import("./discord-guild-port.js").PermissionOverwriteInput[] = [
+      { id: this.guild.everyoneRoleId(), deny: ["ViewChannel"] },
+      {
+        id: role.id,
+        allow: ["ViewChannel", "SendMessages", "ReadMessageHistory"],
+      },
+    ];
+
+    if (opts.managerBotUserId) {
+      overwrites.push({
+        id: opts.managerBotUserId,
+        allow: ["ViewChannel", "SendMessages", "ManageChannels"],
+      });
+    }
+
+    const ch = await this.guild.createTextChannel({
+      name: `pm-${opts.simulationId}-priv-${opts.channelName}`,
+      reason: `perfectman private channel: ${opts.channelId}`,
+      permissionOverwrites: overwrites,
+    });
+
+    for (const agentId of opts.memberAgentIds) {
+      const userId = this.botUserIdByAgentId.get(agentId);
+      if (!userId) continue;
+      const member = await this.guild.fetchMember(userId);
+      if (member) await member.addRole(role.id, "perfectman: initial member");
+    }
+
+    this.channelMap.upsert({
+      simulationId: opts.simulationId,
+      channelId: opts.channelId,
+      channelType: "private_channel",
+      discordGuildId: this.discordGuildId,
+      discordChannelId: ch.id,
+      discordRoleId: role.id,
+      lastSyncedAt: Date.now(),
+    });
+
+    return ch.id;
+  }
+
+  async addMember(
+    simulationId: string,
+    channelId: string,
+    agentId: string,
+  ): Promise<void> {
+    const entry = this.channelMap.get(simulationId, channelId);
+    if (!entry?.discordRoleId) return;
+
+    const userId = this.botUserIdByAgentId.get(agentId);
+    if (!userId) return;
+
+    const member = await this.guild.fetchMember(userId);
+    if (member) await member.addRole(entry.discordRoleId, "perfectman: add member");
+  }
+
+  async removeMember(
+    simulationId: string,
+    channelId: string,
+    agentId: string,
+  ): Promise<void> {
+    const entry = this.channelMap.get(simulationId, channelId);
+    if (!entry?.discordRoleId) return;
+
+    const userId = this.botUserIdByAgentId.get(agentId);
+    if (!userId) return;
+
+    const member = await this.guild.fetchMember(userId);
+    if (member) await member.removeRole(entry.discordRoleId, "perfectman: remove member");
+  }
+
+  async lockAllChannels(simulationId: string): Promise<void> {
+    const entries = this.channelMap.allForSimulation(simulationId);
+    for (const entry of entries) {
+      if (!entry.discordRoleId) continue;
+      const ch = await this.guild.fetchTextChannel(entry.discordChannelId);
+      if (!ch) continue;
+      await ch.editPermissionOverwrite(
+        entry.discordRoleId,
+        { SendMessages: false },
+        "perfectman: simulation stopped",
+      );
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
+      discord.js:
+        specifier: ^14.18.0
+        version: 14.26.4
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -94,6 +97,34 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.1':
+    resolution: {integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -396,6 +427,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.3':
+    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -407,6 +454,9 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -445,6 +495,10 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -546,6 +600,13 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  discord-api-types@0.38.47:
+    resolution: {integrity: sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==}
+
+  discord.js@14.26.4:
+    resolution: {integrity: sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==}
+    engines: {node: '>=18'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -576,6 +637,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -642,11 +706,20 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -845,6 +918,12 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -855,6 +934,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -941,6 +1024,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -965,6 +1060,55 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/rest@2.6.1':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      tslib: 2.8.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1138,6 +1282,17 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.18.1
+
+  '@sapphire/snowflake@3.5.3': {}
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.9.1
@@ -1149,6 +1304,10 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.1))':
     dependencies:
@@ -1207,6 +1366,8 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vladfrangu/async_event_emitter@2.4.7': {}
 
   ansi-regex@5.0.1: {}
 
@@ -1294,6 +1455,27 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  discord-api-types@0.38.47: {}
+
+  discord.js@14.26.4:
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.3
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
@@ -1339,6 +1521,8 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
 
   file-uri-to-path@1.0.0: {}
 
@@ -1404,9 +1588,15 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  lodash.snakecase@4.1.1: {}
+
+  lodash@4.18.1: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1628,6 +1818,10 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  ts-mixer@6.0.4: {}
+
+  tslib@2.8.1: {}
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -1635,6 +1829,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.24.6: {}
+
+  undici@6.24.1: {}
 
   util-deprecate@1.0.2: {}
 
@@ -1722,5 +1918,7 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

- **Full `IDeliveryGateway` implementation** for Discord — one bot per persona, write-only projection of simulation events to guild text channels
- **10 source files + barrel index** under `packages/server/src/discord/`: config parser, error classifier, bot registry, guild port interface + adapter, channel map, role manager, formatter, rate limiter, gateway orchestrator
- **48 new tests across 8 test files** — all use `FakeGuildPort`, zero real Discord API calls
- **Wired into `simulation-config.ts`** — `DeliveryGatewayConfig` union extended, `GatewayFactory` made async, parser handles discord type with env-var token resolution

### Key design decisions

- `DiscordGuildPort` interface isolates discord.js behind a testability boundary
- Private channels use role + permission overwrites (deny `@everyone` ViewChannel at creation — no visibility race)
- Formatter enforces `allowedMentions: { parse: [] }` on all outbound messages and truncates at 1900 chars
- Rate limiter never drops high/critical salience messages; low salience dropped under queue pressure
- Error messages never contain token values (only env var names)
- Discord factory uses dynamic `import()` so discord.js is only loaded when the gateway type is configured

### Verification

- `pnpm -r build` — all 3 packages compile clean
- `pnpm -r test` — 663 tests pass (53 shared + 216 engine + 394 server)
- 48 new discord tests: config (10), errors (13), bot-registry (9), channel-map (6), role-manager (6), formatter (9), rate-limiter (8), gateway integration (10)

## Test plan

- [ ] All existing 615 tests still pass (no regressions)
- [ ] 48 new discord tests pass with `FakeGuildPort` (no network calls)
- [ ] `pnpm -r build` compiles clean with strict TypeScript
- [ ] Config parser rejects missing guildId, empty personaBots, duplicate agentIds
- [ ] Error classifier correctly maps HTTP status codes (429→rate_limited, 401→invalid_auth, etc.)
- [ ] Rate limiter: FIFO delivery, low-salience drop under pressure, high/critical never dropped
- [ ] Role manager: private channel overwrites deny @everyone, lock channels on simulation stop
- [ ] Gateway integration: sendAgentMessage, createChannel, addMember, removeMember, spectator/operator events all route correctly
- [ ] Manual smoke test with real Discord guild (DG-M6 — separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)