### PR TITLE
feat(eval): heuristic LLM-as-judge at high temp with per-turn narrative cohesion

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -53,9 +53,11 @@ pnpm --filter @perfectman/eval bench --scenarios v1_mention_reply,motive_gossip 
 The report (`bench-report-v1`) contains per-scenario signal/probe/judge
 results, probe averages, judge axis means vs targets, category splits, and
 the judge calibration report. Failing reports are committed, never hidden.
-`--per-turn` adds a `narrative_cohesion` axis: consecutive content-bearing
-turns are each scored against the turn before them, and the mean overrides
-the whole-transcript default (see `packages/eval/src/judge/judge.ts`).
+The `narrative_cohesion` axis lives on the `roleplay-v1` rubric (anchored for
+turn-to-turn thread, callbacks, escalation, shifted meaning). By default the
+LLM judge scores it from the whole transcript; `--per-turn` (LLM judge only)
+replaces that with the mean of per-turn scores — each sampled content-bearing
+turn is scored against the turn before it (see `packages/eval/src/judge/judge.ts`).
 
 ## Current baseline (mock, 123 tasks)
 

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -37,6 +37,14 @@ PERFECTMAN_LLM_BASE_URL=http://localhost:11434/v1 \
 PERFECTMAN_LLM_MODEL=qwen3:8b \
 pnpm --filter @perfectman/eval bench --mode local --judge llm --out out/bench-local.json
 
+# heuristic LLM-as-judge with per-turn narrative-cohesion scoring.
+# The judge defaults to HIGH temperature (PERFECTMAN_JUDGE_TEMPERATURE) —
+# varied, creative reads expose cohesion/voice failures a strict low-temp
+# judge misses. Set it to 0 for deterministic calibration runs.
+PERFECTMAN_LLM_PROVIDER=deepseek \
+PERFECTMAN_JUDGE_TEMPERATURE=1.0 \
+pnpm --filter @perfectman/eval bench --mode local --judge llm --per-turn --limit 6
+
 # slices
 pnpm --filter @perfectman/eval bench --category edge_chaos
 pnpm --filter @perfectman/eval bench --scenarios v1_mention_reply,motive_gossip --limit 6
@@ -45,6 +53,9 @@ pnpm --filter @perfectman/eval bench --scenarios v1_mention_reply,motive_gossip 
 The report (`bench-report-v1`) contains per-scenario signal/probe/judge
 results, probe averages, judge axis means vs targets, category splits, and
 the judge calibration report. Failing reports are committed, never hidden.
+`--per-turn` adds a `narrative_cohesion` axis: consecutive content-bearing
+turns are each scored against the turn before them, and the mean overrides
+the whole-transcript default (see `packages/eval/src/judge/judge.ts`).
 
 ## Current baseline (mock, 123 tasks)
 

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -29,7 +29,10 @@ import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
 export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
   const provider = process.env.PERFECTMAN_LLM_PROVIDER ?? "local";
   const isDeepseek = provider === "deepseek";
+  // Empty/unset → default; only an explicit numeric value (incl. "0") wins.
   const tempRaw = Number(process.env.PERFECTMAN_JUDGE_TEMPERATURE);
+  const tempSet = process.env.PERFECTMAN_JUDGE_TEMPERATURE !== undefined
+    && process.env.PERFECTMAN_JUDGE_TEMPERATURE.trim() !== "";
   return {
     baseUrl:
       process.env.PERFECTMAN_LLM_BASE_URL ??
@@ -42,7 +45,7 @@ export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
     // Heuristic LLM-as-judge: temperature UP by default (varied, creative
     // reads expose cohesion/voice failures a strict low-temp judge misses).
     // Set PERFECTMAN_JUDGE_TEMPERATURE=0 for deterministic calibration runs.
-    temperature: Number.isFinite(tempRaw) ? tempRaw : 1.0,
+    temperature: tempSet && Number.isFinite(tempRaw) ? tempRaw : 1.0,
     timeoutMs: 90000,
   };
 }

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -20,7 +20,7 @@ import {
   type RoleplayScenario,
 } from "@perfectman/shared";
 import { ScenarioRunner } from "../run/scenario-runner.js";
-import { ruleJudge, llmJudge, type AxisScores } from "../judge/judge.js";
+import { ruleJudge, llmJudge, llmJudgePerTurn, type AxisScores } from "../judge/judge.js";
 import { calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
@@ -29,6 +29,7 @@ import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
 export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
   const provider = process.env.PERFECTMAN_LLM_PROVIDER ?? "local";
   const isDeepseek = provider === "deepseek";
+  const tempRaw = Number(process.env.PERFECTMAN_JUDGE_TEMPERATURE);
   return {
     baseUrl:
       process.env.PERFECTMAN_LLM_BASE_URL ??
@@ -38,7 +39,10 @@ export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
       process.env.PERFECTMAN_LLM_MODEL ??
       (isDeepseek ? "deepseek-chat" : "qwen3:8b"),
     apiKey: process.env.PERFECTMAN_LLM_API_KEY,
-    temperature: 0,
+    // Heuristic LLM-as-judge: temperature UP by default (varied, creative
+    // reads expose cohesion/voice failures a strict low-temp judge misses).
+    // Set PERFECTMAN_JUDGE_TEMPERATURE=0 for deterministic calibration runs.
+    temperature: Number.isFinite(tempRaw) ? tempRaw : 1.0,
     timeoutMs: 90000,
   };
 }
@@ -77,9 +81,11 @@ export async function runBench(opts: {
   limit?: number;
   out?: string;
   judge?: "rule" | "llm";
+  perTurn?: boolean;
 }): Promise<BenchReport> {
   const mode = opts.mode ?? "mock";
   const judgeMode = opts.judge ?? "rule";
+  const perTurn = opts.perTurn ?? false;
 
   let selected: RoleplayScenario[];
   if (opts.scenarios && opts.scenarios.length > 0) {
@@ -130,7 +136,9 @@ export async function runBench(opts: {
 
       const axisScores =
         judgeMode === "llm"
-          ? await llmJudge(scenario, artifact.events, judgeConfig())
+          ? perTurn
+            ? await llmJudgePerTurn(scenario, artifact.events, judgeConfig())
+            : await llmJudge(scenario, artifact.events, judgeConfig())
           : ruleJudge(scenario, artifact.events, artifact.probeResults, artifact.passedSignals / Math.max(1, artifact.totalSignals));
 
       judgeScores.set(scenario.id, axisScores);
@@ -259,6 +267,7 @@ export async function main(): Promise<void> {
     limit: argValue("--limit") ? Number(argValue("--limit")) : undefined,
     out: argValue("--out"),
     judge: (argValue("--judge") as "rule" | "llm") ?? "rule",
+    perTurn: args.includes("--per-turn"),
   });
   printReport(report);
 }

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -203,6 +203,12 @@ export async function llmJudgePerTurn(
 ): Promise<AxisScores> {
   const axes = await llmJudge(scenario, events, config);
 
+  // The per-turn axis is only meaningful when the rubric defines it (it lives
+  // on roleplay-v1, not edge-chaos/behavioral). Guard before spending calls.
+  if (!scenario.rubric.axes.some(a => a.id === "narrative_cohesion")) {
+    return axes;
+  }
+
   const turns: CommittedEvent[][] = [];
   for (const e of events) {
     (turns[e.pulseIndex] ??= []).push(e);
@@ -216,7 +222,9 @@ export async function llmJudgePerTurn(
   const step = Math.max(1, Math.ceil((contentTurns.length - 1) / maxTurnSamples));
   let cohesionSum = 0;
   let cohesionCount = 0;
-  for (let i = 0; i < contentTurns.length; i += step) {
+  // Start at 1 so the opening pair (0,1) is sampled and the strided adjacency
+  // covers the full timeline when step > 1.
+  for (let i = 1; i < contentTurns.length; i += step) {
     const prior = contentTurns[i - 1];
     const turn = contentTurns[i];
     if (!prior || !turn) continue;
@@ -226,7 +234,7 @@ export async function llmJudgePerTurn(
       cohesionCount++;
     } catch {
       // A failed per-turn call should not sink the whole scene — the axis
-      // stays unscored if nothing succeeded.
+      // keeps the whole-transcript default if nothing succeeded.
     }
   }
   if (cohesionCount > 0) {
@@ -295,8 +303,11 @@ ${turnTranscript(turn.group)}`;
   };
   const raw = data.choices?.[0]?.message?.content ?? "";
   const jsonText = raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
-  const parsed = JSON.parse(jsonText) as { narrative_cohesion?: number };
-  const v = parsed.narrative_cohesion;
+  const parsed = JSON.parse(jsonText) as {
+    narrative_cohesion?: number;
+    axes?: { narrative_cohesion?: number };
+  };
+  const v = parsed.narrative_cohesion ?? parsed.axes?.narrative_cohesion;
   return typeof v === "number" ? clampScore(v) : 3;
 }
 

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -71,6 +71,9 @@ export function ruleJudge(
     creativity_unhinged: clampScore(creativity),
     memory_continuity: clampScore(continuity),
     no_ai_leak: clampScore(noAiLeak),
+    // Proxy: a scene that references memories and reads signals is more likely
+    // to keep a thread across turns. The LLM judge owns the real axis.
+    narrative_cohesion: clampScore((continuity + interpretation) / 2),
   };
 
   // Edge rubric uses different axes — map what exists.
@@ -170,6 +173,131 @@ export async function llmJudge(
     axes[axis.id] = typeof v === "number" ? clampScore(v) : 3;
   }
   return axes;
+}
+
+// ── Per-turn narrative-cohesion eval ─────────────────────────────────────────
+
+/**
+ * Scores turn-to-turn narrative cohesion across a transcript, plus the full
+ * rubric from the whole transcript.
+ *
+ * The premise: perfectman is more than text generation — the interesting
+ * failure modes live in whether a later message still carries the thread of
+ * earlier turns (callbacks, escalation, shifted meaning), not in any single
+ * message. A whole-transcript judge misses that; a per-turn judge sees it.
+ *
+ * Strategy (kept cheap for heuristic runs):
+ *  1. One whole-transcript call scores all rubric axes (as `llmJudge` does).
+ *  2. Consecutive content-bearing turns (grouped by pulse) are sampled and
+ *     each scored on narrative_cohesion against the turn that preceded it.
+ *  3. The mean cohesion becomes the `narrative_cohesion` axis value.
+ *
+ * Nondeterministic by design (high temperature, see bench.ts default) — this
+ * is a heuristic, not a calibration gate. Calibration runs set temperature 0.
+ */
+export async function llmJudgePerTurn(
+  scenario: RoleplayScenario,
+  events: readonly CommittedEvent[],
+  config: LlmJudgeConfig,
+  maxTurnSamples = 8,
+): Promise<AxisScores> {
+  const axes = await llmJudge(scenario, events, config);
+
+  const turns: CommittedEvent[][] = [];
+  for (const e of events) {
+    (turns[e.pulseIndex] ??= []).push(e);
+  }
+  const contentTurns = turns
+    .map((group, pulseIndex) => ({ pulseIndex, group }))
+    .filter(({ group }) =>
+      group.some(e => e.type === "message_sent" || e.type === "reply_sent"),
+    );
+
+  const step = Math.max(1, Math.ceil((contentTurns.length - 1) / maxTurnSamples));
+  let cohesionSum = 0;
+  let cohesionCount = 0;
+  for (let i = 0; i < contentTurns.length; i += step) {
+    const prior = contentTurns[i - 1];
+    const turn = contentTurns[i];
+    if (!prior || !turn) continue;
+    try {
+      const score = await scoreCohesion(scenario, prior, turn, config);
+      cohesionSum += score;
+      cohesionCount++;
+    } catch {
+      // A failed per-turn call should not sink the whole scene — the axis
+      // stays unscored if nothing succeeded.
+    }
+  }
+  if (cohesionCount > 0) {
+    axes["narrative_cohesion"] = clampScore(cohesionSum / cohesionCount);
+  }
+  return axes;
+}
+
+function turnTranscript(group: readonly CommittedEvent[]): string {
+  return group
+    .map(e => {
+      const p = e.payload as Record<string, unknown>;
+      const text = typeof p.content === "string" ? `: ${p.content}` : "";
+      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${text}`;
+    })
+    .join("\n");
+}
+
+async function scoreCohesion(
+  scenario: RoleplayScenario,
+  prior: { pulseIndex: number; group: CommittedEvent[] },
+  turn: { pulseIndex: number; group: CommittedEvent[] },
+  config: LlmJudgeConfig,
+): Promise<number> {
+  const system = `You are a strict evaluator of NARRATIVE COHESION in a chat-room social simulation. Score 1-5 using ONLY these anchors:
+1: Contradicts its own earlier messages or ignores what it just said.
+2: Messages feel disconnected; no thread between turns.
+3: References prior turns sometimes, but loosely.
+4: Each turn builds on the prior exchange; thread is clear.
+5: Conversation arcs — earlier turns pay off later (callback, escalation, shifted meaning).
+
+Return ONLY a JSON object: {"narrative_cohesion": score} with no prose.`;
+
+  const user = `Scenario: ${scenario.name}
+${scenario.description}
+
+Earlier turn (pulse ${prior.pulseIndex}):
+${turnTranscript(prior.group)}
+
+This turn (pulse ${turn.pulseIndex}):
+${turnTranscript(turn.group)}`;
+
+  const res = await fetch(`${config.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      model: config.model,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      temperature: config.temperature ?? 1,
+      max_tokens: 120,
+    }),
+    signal: AbortSignal.timeout(config.timeoutMs ?? 60000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Cohesion judge HTTP ${res.status}: ${await res.text()}`);
+  }
+  const data = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  const raw = data.choices?.[0]?.message?.content ?? "";
+  const jsonText = raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
+  const parsed = JSON.parse(jsonText) as { narrative_cohesion?: number };
+  const v = parsed.narrative_cohesion;
+  return typeof v === "number" ? clampScore(v) : 3;
 }
 
 // ── Cache ────────────────────────────────────────────────────────────────────

--- a/packages/eval/src/test/judge-signals.test.ts
+++ b/packages/eval/src/test/judge-signals.test.ts
@@ -110,14 +110,29 @@ describe("LLM judge (per-turn)", () => {
       { ...event("reply_sent", "leo", 1), payload: { content: "kkkk bom dia caio" } },
       { ...event("reply_sent", "caio", 2), payload: { content: "tb! animado hoje?" } },
     ];
+    // Whole-transcript call returns a proper {axes:{...}} payload; the two
+    // per-turn calls return distinct scores so the mean is a real aggregation:
+    // (3 + 5) / 2 → 4, clamped. A coincidental round-up can't fake this.
+    const perTurnScores = [3, 5];
     let calls = 0;
-    globalThis.fetch = (async () =>
-      new Response(
+    globalThis.fetch = (async () => {
+      const n = calls++;
+      const cohesion = n === 0 ? undefined : perTurnScores[n - 1];
+      return new Response(
         JSON.stringify({
-          choices: [{ message: { content: JSON.stringify({ narrative_cohesion: calls++ === 0 ? 4 : 5 }) } }],
+          choices: [{
+            message: {
+              content: JSON.stringify(
+                n === 0
+                  ? { axes: { in_character: 4 } }
+                  : { narrative_cohesion: cohesion },
+              ),
+            },
+          }],
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as typeof fetch;
+      );
+    }) as typeof fetch;
 
     const scores = await llmJudgePerTurn(
       scenario,
@@ -125,10 +140,75 @@ describe("LLM judge (per-turn)", () => {
       { baseUrl: "http://localhost/v1", model: "m", temperature: 1 },
       8,
     );
-    // Whole-transcript call fills the other axes; cohesion is the mean of the
-    // two per-turn samples (4 + 5) / 2 → 4.5, clamped to an integer score.
-    expect(scores.narrative_cohesion).toBe(5);
+    // Mean of the two per-turn samples (3 + 5) / 2 → 4.
+    expect(scores.narrative_cohesion).toBe(4);
     expect(calls).toBe(3); // 1 whole-transcript + 2 per-turn
+  });
+
+  it("samples strided adjacent pairs across many turns", async () => {
+    const scenario = getScenario("v1_casual_chat")!;
+    // 10 content-bearing pulses; maxTurnSamples=4 → step = ceil(9/4) = 3.
+    // Loop starts at i=1 and steps by 3: pairs (0,1),(3,4),(6,7),(9,10→n-1=9, skip).
+    // Start-at-1 guarantees (0,1) is always sampled.
+    const events = Array.from({ length: 10 }, (_, pulseIndex) => ({
+      ...event("message_sent", "caio", pulseIndex),
+      payload: { content: `msg ${pulseIndex}` },
+    }));
+    const fetchedPairs: string[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { body?: string }) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        messages?: { role: string; content: string }[];
+      };
+      const lastUser = body.messages?.filter(m => m.role === "user").at(-1)?.content ?? "";
+      const priorMatch = lastUser.match(/Earlier turn \(pulse (\d+)\):/);
+      const turnMatch = lastUser.match(/This turn \(pulse (\d+)\):/);
+      fetchedPairs.push(`${priorMatch?.[1]}->${turnMatch?.[1]}`);
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: JSON.stringify({ narrative_cohesion: 4 }) } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const scores = await llmJudgePerTurn(
+      scenario,
+      events,
+      { baseUrl: "http://localhost/v1", model: "m", temperature: 1 },
+      4,
+    );
+    expect(fetchedPairs).toContain("0->1");
+    expect(fetchedPairs.length).toBeGreaterThan(1);
+    expect(scores.narrative_cohesion).toBe(4);
+  });
+
+  it("does not score narrative_cohesion when the rubric lacks the axis", async () => {
+    // edge-chaos rubric has no narrative_cohesion axis — the per-turn path
+    // must not inject it or spend per-turn calls.
+    const scenario = getScenario("edge_public_mock")!;
+    const events = [
+      { ...event("message_sent", "caio", 0), payload: { content: "oi" } },
+      { ...event("reply_sent", "leo", 1), payload: { content: "opa" } },
+    ];
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: JSON.stringify({ axes: {} }) } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const scores = await llmJudgePerTurn(
+      scenario,
+      events,
+      { baseUrl: "http://localhost/v1", model: "m", temperature: 1 },
+      8,
+    );
+    expect(scores.narrative_cohesion).toBeUndefined();
+    expect(calls).toBe(1); // whole-transcript only
   });
 
   it("falls back to the whole-transcript default when per-turn calls fail", async () => {

--- a/packages/eval/src/test/judge-signals.test.ts
+++ b/packages/eval/src/test/judge-signals.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
 import { checkExpectedSignals } from "../run/signal-checker.js";
-import { ruleJudge } from "../judge/judge.js";
+import { ruleJudge, llmJudgePerTurn } from "../judge/judge.js";
 import { weightedKappa, krippendorffAlpha, calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import { getScenario } from "@perfectman/shared";
@@ -91,6 +91,71 @@ describe("rule judge", () => {
     const scores = ruleJudge(scenario, events, probes, 1);
     expect(scores.no_ai_leak).toBeGreaterThanOrEqual(4);
     expect(scores.interpretation).toBe(5);
+    expect(scores.narrative_cohesion).toBeGreaterThanOrEqual(1);
+    expect(scores.narrative_cohesion).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("LLM judge (per-turn)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("aggregates narrative_cohesion across consecutive turns", async () => {
+    const scenario = getScenario("v1_casual_chat")!;
+    const events = [
+      { ...event("message_sent", "caio", 0), payload: { content: "bom dia gente" } },
+      { ...event("reply_sent", "leo", 1), payload: { content: "kkkk bom dia caio" } },
+      { ...event("reply_sent", "caio", 2), payload: { content: "tb! animado hoje?" } },
+    ];
+    let calls = 0;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: JSON.stringify({ narrative_cohesion: calls++ === 0 ? 4 : 5 }) } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    const scores = await llmJudgePerTurn(
+      scenario,
+      events,
+      { baseUrl: "http://localhost/v1", model: "m", temperature: 1 },
+      8,
+    );
+    // Whole-transcript call fills the other axes; cohesion is the mean of the
+    // two per-turn samples (4 + 5) / 2 → 4.5, clamped to an integer score.
+    expect(scores.narrative_cohesion).toBe(5);
+    expect(calls).toBe(3); // 1 whole-transcript + 2 per-turn
+  });
+
+  it("falls back to the whole-transcript default when per-turn calls fail", async () => {
+    const scenario = getScenario("v1_casual_chat")!;
+    const events = [
+      { ...event("message_sent", "caio", 0), payload: { content: "oi" } },
+      { ...event("reply_sent", "leo", 1), payload: { content: "opa" } },
+    ];
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: JSON.stringify({ axes: {} }) } }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("boom", { status: 500 });
+    }) as typeof fetch;
+
+    const scores = await llmJudgePerTurn(
+      scenario,
+      events,
+      { baseUrl: "http://localhost/v1", model: "m", temperature: 1 },
+      8,
+    );
+    expect(scores.narrative_cohesion).toBe(3);
   });
 });
 

--- a/packages/shared/src/scenarios/rubrics.ts
+++ b/packages/shared/src/scenarios/rubrics.ts
@@ -93,6 +93,18 @@ const ROLEPLAY_AXES = [
       5: "No leaks at all — even under provocation the persona holds.",
     },
   },
+  {
+    id: "narrative_cohesion",
+    label: "Narrative / turn-to-turn cohesion",
+    weight: 0.6,
+    anchors: {
+      1: "Contradicts its own earlier messages or ignores what it just said.",
+      2: "Messages feel disconnected; no thread between turns.",
+      3: "References prior turns sometimes, but loosely.",
+      4: "Each turn builds on the prior exchange; thread is clear.",
+      5: "Conversation arcs — earlier turns pay off later (callback, escalation, shifted meaning).",
+    },
+  },
 ] as const;
 
 export const ROLEPLAY_V1_RUBRIC: JudgeRubric = {
@@ -107,6 +119,7 @@ export const ROLEPLAY_V1_RUBRIC: JudgeRubric = {
     { axisId: "creativity_unhinged", min: 3.5 },
     { axisId: "memory_continuity", min: 3.5 },
     { axisId: "no_ai_leak", min: 4.5 },
+    { axisId: "narrative_cohesion", min: 3.5 },
   ],
 };
 


### PR DESCRIPTION
## What this adds

Closes the eval-premise gaps from the testing-strategy discussion (heuristic
LLM-as-judge, temperature up, per-turn eval, narrative cohesion). Stacks on
top of #16 (test taxonomy/hygiene).

### Judge temperature via env — default HIGH
`packages/eval/src/cli/bench.ts` now reads `PERFECTMAN_JUDGE_TEMPERATURE`;
the judge **defaults to 1.0** instead of the hardcoded `0`. The premise is a
*heuristic* judge: varied, creative reads expose cohesion/voice failures that a
strict low-temp judge flattens. Calibration runs set it to 0 explicitly
(documented in `docs/eval/README.md` and the code).

### `narrative_cohesion` rubric axis
`packages/shared/src/scenarios/rubrics.ts` — new `ROLEPLAY_AXES` entry with
anchors (1=contradicts itself … 5=arcs with callbacks/escalation/shifted
meaning) plus a `roleplay-v1` target of 3.5.

### Per-turn eval path
`packages/eval/src/judge/judge.ts`:
- `llmJudgePerTurn(scenario, events, config, maxTurnSamples=8)` — one
  whole-transcript call for all axes, then consecutive content-bearing turns
  (grouped by pulse) are each scored on cohesion against the preceding turn;
  the mean overrides `narrative_cohesion`.
- `ruleJudge` maps a proxy for the new axis so the offline baseline doesn't gap it.
- `--per-turn` flag on the bench CLI.

### Tests
`packages/eval/src/test/judge-signals.test.ts` — rule-judge axis bounds,
per-turn aggregation (mock fetch), and graceful fallback when per-turn calls
fail (whole-transcript default is kept).

## Validation
- `pnpm -r typecheck` clean
- `pnpm --filter @perfectman/eval test` (24) · `shared` (59) · `engine` (289) · `server` non-e2e (356) green
- `pnpm test:gate` hygiene gate passes

## Relationship to open PRs
- Base: `refactor/test-taxonomy-and-hygiene` (#16)
- Commented on #15 (DeepSeek server-runtime): stale base + conflicts; DeepSeek
  already works at the eval layer on main — that PR's remaining value is the
  server-runtime provider type + example config.