### PR TITLE
docs: OSS launch readiness (README, LICENSE, CONTRIBUTING, .env.example)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy to .env and fill in. .env is gitignored — never commit real values.
+
+# Required for `pnpm freellm:dev` (FreeLLMAPI container).
+# Used to encrypt provider API keys FreeLLMAPI stores on disk. Any long random string works.
+FREELLMAPI_ENCRYPTION_KEY=
+
+# Set after creating a unified key in the FreeLLMAPI dashboard (http://localhost:5173),
+# once you've added at least one free-tier provider key there.
+FREELLMAPI_KEY=
+
+# Optional: pin the FreeLLMAPI build to a specific git ref instead of `main`.
+# FREELLMAPI_REF=main
+
+# Optional overrides for `pnpm qwen:dev` (local Ollama/Qwen3 container).
+# OLLAMA_MODEL=qwen3:1.7b
+# OLLAMA_KEEP_ALIVE=30m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Perfectman
+
+Thanks for taking a look. This is an early-stage experiment, so expect design churn — the fastest way in is usually a small PR against an open question, not a big architectural proposal.
+
+## Setup
+
+```bash
+pnpm install
+pnpm build
+```
+
+Run the test suite before opening a PR:
+
+```bash
+pnpm test:all     # unit/integration tests + the test-hygiene gate (scripts/audit-tests.mjs)
+pnpm lint         # typecheck across all packages
+```
+
+`pnpm test:all` is what CI-equivalent checks run — a PR that doesn't pass it locally won't merge. See [`docs/testing-strategy.md`](docs/testing-strategy.md) for the test taxonomy and what makes an assertion meaningful here; it's a living guideline, not boilerplate.
+
+## Where things live
+
+```text
+packages/
+  shared/  — shared types, schemas, constants (pure)
+  engine/  — pure social presence engine: attention, motivation, emotion, pressure, inhibition (no I/O)
+  server/  — event-oriented runtime: event log, command handlers, intent resolver, projections,
+             agent runtime/LLM providers, persistence, delivery gateways, CLI entrypoint
+  eval/    — evaluation harness
+```
+
+Read [`docs/README.md`](docs/README.md) first for the canonical architecture and design decisions, and [`docs/plans/master-contract.md`](docs/plans/master-contract.md) for the cross-package ownership map and type contracts (e.g. the `PersonaConfig` vs `PersonaPromptProfile` split) if your change crosses a package boundary.
+
+## Picking something to work on
+
+- Issues tagged `good first issue` are scoped and don't require reading the full architecture doc first.
+- [`docs/README.md`](docs/README.md#current-open-questions) lists genuinely undecided design questions (private-channel spectator visibility, scoring machinery, which symbolic actions earn their keep). If one interests you, open an issue or discussion before a big PR so the direction gets agreed on first.
+- Use GitHub Discussions for design debate; issues for concrete, scoped work.
+
+## Personas and private data
+
+Real, person-specific persona files are gitignored by design (`config/index.json`, `config/personas/`, `docs/personas/` subfolders except templates). Never commit real names, transcripts, or persona interview material outside the example/template paths in `examples/personas/`. See [`docs/personas/README.md`](docs/personas/README.md) for the intended workflow.
+
+## PR expectations
+
+- Keep PRs scoped to one concern; cross-package changes should respect the ownership map in `docs/plans/master-contract.md`.
+- Add or update tests per `docs/testing-strategy.md` — a test that can't fail for a real bug isn't worth adding.
+- Explain *why*, not just *what*, in the PR description if the change touches behavior (emotion model, motivation thresholds, intent resolution) rather than pure plumbing.
+
+First-time contributors: expect a response within a few days. If you don't hear back, it's fine to ping the PR/issue.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 caiotheodoro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# Perfectman
+
+AI personas that hang out in a socket chat server like people do: noticing unevenly, replying late, lurking, masking, forming private alliances, misreading silence — and creating real, emergent social drama nobody scripted.
+
+> <!-- TODO before sharing publicly: replace this with a spectator-view transcript or short GIF of an actual emergent moment (exclusion, grudge, private alliance) captured from a real run. See docs/README.md "V1 Target Behaviors" for what to look for. -->
+> **Status:** early, pre-1.0 experiment. The core event-oriented runtime and social presence engine work end-to-end; the interesting behaviors (exclusion, masking, grudges, biased memory) are what we're actively tuning for. Expect rough edges.
+
+## What this is
+
+Most "AI agent chat" demos are agents replying because it's their turn. Perfectman agents act because something caught their attention, produced motivation and emotion, and built up enough pressure to overcome inhibition:
+
+```text
+event -> visibility -> attention -> interpretation -> motivation -> emotion -> pressure -> inhibition -> intent -> resolver -> committed event
+```
+
+Concretely, that pipeline is what lets an agent:
+
+- Notice a mention and reply, or notice a message and deliberately not reply.
+- Create or enter a private channel out of curiosity, gossip, jealousy, secrecy, or repair.
+- Infer exclusion from public silence — nobody told it, it just wasn't invited.
+- Reply late in a way that changes what the reply means.
+- Store a biased, emotionally-colored memory instead of a perfect log.
+
+A rule-based spectator layer turns the committed event log into a narrative recap of the hidden social shifts, without leaking backend metrics into the story.
+
+## Quickstart
+
+Requires Node.js and [pnpm](https://pnpm.io/).
+
+```bash
+pnpm install
+pnpm build
+```
+
+Set up a local simulation config (kept out of git so personas stay private):
+
+```bash
+mkdir -p config/personas config/persona-notes
+cp examples/simulations/mock.inline-personas.example.json config/index.json
+```
+
+Run it:
+
+```bash
+pnpm --filter @perfectman/server simulation
+```
+
+This uses `providerType: "mock"` by default — no API key or model needed to see the runtime work.
+
+### Running with a real model, for free
+
+You don't need a paid API key. Two free local options:
+
+**Local Qwen3 via Ollama** (recommended if you have a GPU, works on CPU too):
+
+```bash
+pnpm qwen:dev          # pulls qwen3:1.7b, exposes an OpenAI-compatible API on :11434
+# or: pnpm qwen:dev:8b for the 8B model
+```
+
+Then point `config/index.json` at `examples/simulations/qwen3-local.example.json`.
+
+**FreeLLMAPI** (unified proxy for aggregating free-tier provider keys):
+
+```bash
+cp .env.example .env   # set FREELLMAPI_ENCRYPTION_KEY
+pnpm freellm:dev        # API on :3001, dashboard on :5173
+```
+
+Add provider keys and create a unified key via the dashboard, then set `FREELLMAPI_KEY` in `.env`.
+
+### Bring your own personas
+
+See [`docs/personas/README.md`](docs/personas/README.md) for the plug-and-play persona interview/compile workflow. Real, person-specific persona files live under `config/` and `docs/personas/`, both gitignored — nothing personal gets committed.
+
+## Architecture
+
+The full design lives in [`docs/README.md`](docs/README.md) — start there for the canonical architecture, the emotion model, social presence engine, and open design questions. Short version:
+
+- **Event-oriented runtime** (`packages/server`): canonical append-only event log, command handlers, intent resolver, per-audience projections (delivery, spectator, operator, engine snapshot), pluggable transports (Socket.IO, Discord, stdout, mock).
+- **Social presence engine** (`packages/engine`): pure, I/O-free attention/motivation/emotion/pressure/inhibition model — the behavioral core.
+- **Agent mind** (`packages/server/src/agent`): persona identity, writing style, relationship beliefs, and the LLM-backed runtime that turns perception into an action intent.
+- **Continuity system**: episodic + relationship memory, emotional drift, rumination — memory is biased and emotional on purpose, not a perfect log.
+
+## Status / open questions
+
+This is an active experiment, not a finished product. See [`docs/README.md`](docs/README.md#current-open-questions) for what's genuinely undecided — private-channel spectator visibility, how much scoring machinery should exist, which symbolic actions are worth keeping. If one of those interests you, that's a good place to start.
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Issues tagged `good first issue` are scoped entry points that don't require reading the full architecture doc first.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## What
Adds the baseline a stranger needs to evaluate/run the project:
- `README.md` — public pitch, architecture summary, free-tier quickstart (mock provider or local Qwen3/FreeLLMAPI, no paid API key required)
- `LICENSE` — MIT
- `CONTRIBUTING.md` — setup, test commands, package boundaries, gitignored-persona-data convention
- `.env.example` — documents the env vars `docker/freellmapi` and `docker/qwen3` actually read

## Why
Repo had no top-level README/LICENSE/CONTRIBUTING — nothing to orient a first-time visitor or contributor.

## Verification
- `pnpm test:all` passes clean
- The quickstart's mock-provider flow was run end-to-end (simulation starts, event log flows, clean shutdown)

Independent of the narrative-sharpening stack in the other open PRs — not stacked, can merge any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)