### PR TITLE
fix(agent): intent validation false-rejections on create_channel/send_message

### DIFF
--- a/packages/engine/src/intent/validate-intent.ts
+++ b/packages/engine/src/intent/validate-intent.ts
@@ -65,9 +65,15 @@ export function validateIntentPure(
       detail: `intentType "${intent.intentType}" has no available action slot`,
     });
   } else {
-    // 3. Channel target validation
+    // 3. Channel target validation. An empty allow-list means this intent
+    // type doesn't constrain channelTarget (e.g. create_channel has no
+    // existing channels to target) — treat as unconstrained, matching the
+    // personTargets guard just below.
     if (intent.channelTarget) {
-      if (!availableAction.channelTargets.includes(intent.channelTarget)) {
+      if (
+        availableAction.channelTargets.length > 0 &&
+        !availableAction.channelTargets.includes(intent.channelTarget)
+      ) {
         violations.push({
           type:   "hidden_channel_target",
           detail: `channelTarget "${intent.channelTarget}" is not in available channels for ${intent.intentType}`,

--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -209,4 +209,72 @@ Hope you like it!
     expect(result.fallbackApplied).toBe(true);
     expect(result.intent.intentType).toBe("delay_response"); // used custom fallback option!
   });
+
+  describe("create_channel channelType default", () => {
+    const createChannelActions: AvailableAction[] = [
+      {
+        intentType: "create_channel",
+        channelTargets: [],
+        personTargets: [],
+        blocked: false,
+      },
+    ];
+
+    it("defaults an empty-string channelType to private_channel instead of rejecting", () => {
+      const rawText = JSON.stringify({
+        id: "intent-create-1",
+        actorId,
+        intentType: "create_channel",
+        channelType: "", // the observed real-world failure mode
+        channelName: "papo-reservado",
+        privateMotiveSummary: "want to talk privately",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, createChannelActions);
+
+      expect(result.fallbackApplied).toBe(false);
+      expect(result.intent.intentType).toBe("create_channel");
+      expect(result.intent.channelType).toBe("private_channel");
+    });
+
+    it("defaults a missing channelType to private_channel", () => {
+      const rawText = JSON.stringify({
+        id: "intent-create-2",
+        actorId,
+        intentType: "create_channel",
+        channelName: "papo-reservado",
+        privateMotiveSummary: "want to talk privately",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, createChannelActions);
+
+      expect(result.fallbackApplied).toBe(false);
+      expect(result.intent.channelType).toBe("private_channel");
+    });
+
+    it("leaves an explicit valid channelType untouched", () => {
+      const rawText = JSON.stringify({
+        id: "intent-create-3",
+        actorId,
+        intentType: "create_channel",
+        channelType: "spectator_channel",
+        channelName: "watch-party",
+        privateMotiveSummary: "want an audience",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, createChannelActions);
+
+      expect(result.fallbackApplied).toBe(false);
+      expect(result.intent.channelType).toBe("spectator_channel");
+    });
+  });
 });

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -29,16 +29,21 @@ JSON Schema:
   "id": "A unique string representing this intent (copy from the inputs or generate a new unique string)",
   "actorId": "${input.agentId}",
   "intentType": "Must match one of the available intent types",
-  "channelTarget": "Target channel ID if applicable (must match available targets)",
-  "personTargets": ["Array of target friend agentIds if applicable"],
+  "channelTarget": "ONLY for send_message/reply_to_message/leave_channel/invite_agent — the existing channel ID you're acting in. OMIT this field entirely for create_channel (use channelName/channelType instead).",
+  "personTargets": "OMIT this field for send_message and create_channel — it does not apply to them. Only used for actions that target a specific person directly.",
   "visibleContent": "Optional text message content (required for 'send_message' or 'reply_to_message')",
   "privateMotiveSummary": "A highly specific natural-language thought explaining your real, raw, hidden motive behind this action. Never leave empty.",
   "emotionDrivers": ["Emotion keywords driving this action (e.g. warmth, jealousy, irritation)"],
   "motivationDrivers": ["Motivation keywords driving this action (e.g. affinity, gossip, exclusion)"],
   "preferredDelay": 0,
   "fallbackIfBlocked": "no_op",
-  "memoryWrites": []
+  "memoryWrites": [],
+  "channelName": "ONLY for create_channel — a short name for the new channel.",
+  "channelType": "ONLY for create_channel — usually \\"private_channel\\".",
+  "invitedAgentIds": ["ONLY for create_channel — array of agentIds to invite into the new channel."]
 }
+
+Field notes by intentType — send_message/reply_to_message use "channelTarget" (an existing channel); create_channel uses "channelName" + "channelType" (usually "private_channel") + "invitedAgentIds" instead, and has no "channelTarget" or "personTargets".
 
 Ensure:
 - "privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -61,8 +61,32 @@ export class IntentParser {
         }
       }
 
+      // 4c. create_channel with a missing/empty channelType is by far the
+      // most common way this intent type gets rejected — the prompt already
+      // tells the model channelType is "usually private_channel" for this
+      // action, but a small model frequently omits the field or emits ""
+      // instead of following through. Default rather than reject: this is a
+      // clear, single, prompt-consistent inference, not a guess.
+      if (
+        parsedObject.intentType === "create_channel" &&
+        (parsedObject.channelType === "" || parsedObject.channelType === undefined)
+      ) {
+        parsedObject.channelType = "private_channel";
+      }
+
       // 5. Validate against ActionIntentSchema
       const validatedIntent = ActionIntentSchema.parse(parsedObject) as ActionIntent;
+
+      // 5b. Normalize a stray leading '#' on channelTarget. The transcript
+      // rendered into the prompt displays channels as "#channelId"
+      // (action-intent-prompt-builder.ts formatEvent) — small models copy
+      // that display convention into the channelTarget value itself, which
+      // then fails the availableActions allow-list check since the actual
+      // channel IDs never carry the '#'. This is display formatting bleeding
+      // into model output, not a real different channel.
+      if (validatedIntent.channelTarget?.startsWith("#")) {
+        validatedIntent.channelTarget = validatedIntent.channelTarget.slice(1);
+      }
 
       // 6. Reject empty privateMotiveSummary
       if (!validatedIntent.privateMotiveSummary || validatedIntent.privateMotiveSummary.trim() === "") {
@@ -84,18 +108,29 @@ export class IntentParser {
           );
         }
 
-        // Validate channelTarget if specified
+        // Validate channelTarget if specified. An empty allow-list means the
+        // intent type doesn't constrain this field (e.g. create_channel has
+        // no existing channelTargets to pick from) — treat that as "no
+        // constraint", not "reject everything". Mirrors validate-intent.ts's
+        // personTargets guard below.
         if (validatedIntent.channelTarget) {
-          if (!matchedAction.channelTargets.includes(validatedIntent.channelTarget)) {
+          if (
+            matchedAction.channelTargets.length > 0 &&
+            !matchedAction.channelTargets.includes(validatedIntent.channelTarget)
+          ) {
             throw new Error(
               `Channel target '${validatedIntent.channelTarget}' is not permitted for intent type '${validatedIntent.intentType}'`
             );
           }
         }
 
-        // Validate personTargets
+        // Validate personTargets — same empty-allow-list-means-unconstrained
+        // rule (e.g. send_message has no personTargets allow-list at all).
         for (const targetPerson of validatedIntent.personTargets) {
-          if (!matchedAction.personTargets.includes(targetPerson)) {
+          if (
+            matchedAction.personTargets.length > 0 &&
+            !matchedAction.personTargets.includes(targetPerson)
+          ) {
             throw new Error(
               `Person target '${targetPerson}' is not permitted for intent type '${validatedIntent.intentType}'`
             );


### PR DESCRIPTION
## What
Two guard bugs in the intent-type-vs-available-action-allowlist check, plus two related normalizations, all found via live benchmark transcripts:

- **`personTargets` guard missing** in `intent-parser.ts` (present in `validate-intent.ts`, inconsistently): `send_message`'s available `personTargets` is always `[]` by design — any `personTargets` value on a `send_message` intent was rejected outright.
- **`channelTarget` guard missing in both enforcement sites** (`intent-parser.ts` **and** the engine's authoritative `validate-intent.ts`): `create_channel`'s available `channelTargets` is always `[]` — any `channelTarget` value on `create_channel` was rejected even at the authoritative layer.
- **`channelType: ""` default**: empirically the single most common `create_channel` failure — the model routinely emits an empty string instead of a valid enum value. Defaults to `"private_channel"` (matches the prompt's own guidance) instead of hard-rejecting. This fired on nearly every `create_channel` attempt across a 16-scenario benchmark run, invisible in fallback-count metrics since it's a validation rejection, not a provider failure.
- **Stray leading `#`** on `channelTarget`: the prompt's transcript rendering displays channels as `#channelId`; the model sometimes copies that display convention into the field value. Stripped before validation.
- **`action-intent-prompt-builder.ts`**: the JSON schema shown to the model listed one flat field set for every `intentType` and never mentioned `channelName`/`channelType`/`invitedAgentIds` (the fields `create_channel` actually needs) — very likely the root cause of the model guessing the wrong shape. Added per-`intentType` field notes.

## Verification
- New unit tests for the `channelType` default (empty string, missing, explicit-valid-value-untouched) — 3 new tests, 767/767 total passing.
- Re-ran the benchmark scenarios after this fix — the create_channel/send_message rejection errors present in nearly every prior transcript were gone.

Stacked on #19 (this branch's base) — that PR must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)