### PR TITLE
fix(llm): Ollama repeat_penalty/top_p sampling params silently dropped

### DIFF
--- a/packages/server/src/llm/ollama-provider.ts
+++ b/packages/server/src/llm/ollama-provider.ts
@@ -39,15 +39,33 @@ export class OllamaProvider implements LlmProvider {
     ];
 
     const { extraBody = {} } = this.config;
-    const { think, options: extraOptions, ...restExtra } = extraBody as {
+    const {
+      think,
+      options: extraOptions,
+      // top_p/repetition_penalty are populated at the top level of extraBody
+      // by persona-loader.ts and scenario-runner.ts (matching the
+      // OpenAI-compatible provider's flat-body convention). Ollama's native
+      // /api/chat only reads sampling params from a nested `options` object,
+      // and its repetition-penalty key is `repeat_penalty`, not
+      // `repetition_penalty` — pull both out here and translate them instead
+      // of letting them fall into restExtra and get silently dropped on the
+      // request body root.
+      top_p,
+      repetition_penalty,
+      ...restExtra
+    } = extraBody as {
       think?: boolean;
       options?: Record<string, unknown>;
+      top_p?: number;
+      repetition_penalty?: number;
       [key: string]: unknown;
     };
 
     const ollamaOptions: Record<string, unknown> = {
       num_predict: this.config.maxOutputTokens,
       temperature: this.config.temperature,
+      ...(top_p !== undefined ? { top_p } : {}),
+      ...(repetition_penalty !== undefined ? { repeat_penalty: repetition_penalty } : {}),
       ...extraOptions,
     };
 


### PR DESCRIPTION
## What
`persona-loader.ts` (and the eval harness's equivalent local-mode config) puts per-persona sampling tuning at the top level of `LlmConfig.extraBody`: `{ top_p, repetition_penalty }`, matching the OpenAI-compatible provider's flat-body convention — works correctly there.

`ollama-provider.ts`'s native `/api/chat` path only reads sampling params from a nested `extraBody.options` object, so these landed in an unused top-level spread and were silently ignored by the Ollama server. Even nested correctly, the key name would still be wrong — Ollama's parameter is `repeat_penalty`, not `repetition_penalty`.

**Net effect: per-persona repetition control has been a complete no-op on the local/Ollama path — the exact path used for free, zero-cost local demos** — while working correctly against any OpenAI-compatible endpoint.

## Fix
Pull `top_p`/`repetition_penalty` out of the top-level `extraBody` and translate them into Ollama's `options` object with the correct key names, instead of letting them fall through unused.

## Verification
`pnpm test:all` passes — no existing unit coverage over the Ollama request-body construction to extend; this is an infra wiring fix, verified via the same live benchmark runs used across this stack.

Stacked on #20 (this branch's base) — that PR must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)