### PR TITLE
feat(agent): structural repetition guard with regenerate-on-repeat retry

### DIFF
--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -69,6 +69,22 @@ export function buildPerceptionPacket(
     if (replyTarget && replyTarget !== agent.agentId) involvedPeople.add(replyTarget);
   }
 
+  // Own recent utterances — sourced from cleanEvents (full visible history,
+  // pre-CONTEXT_WINDOW-truncation), not contextEvents, so it survives the
+  // shared window filling up with other agents' turns. Deduped consecutively
+  // in case the same content was committed more than once in a row.
+  const OWN_UTTERANCE_WINDOW = 5;
+  const ownRecentUtterances: string[] = [];
+  for (const e of cleanEvents) {
+    if (e.actorId !== agent.agentId) continue;
+    if (e.type !== "message_sent" && e.type !== "reply_sent") continue;
+    const content = (e.payload as Record<string, unknown>)["content"];
+    if (typeof content !== "string" || content.length === 0) continue;
+    if (ownRecentUtterances[ownRecentUtterances.length - 1] === content) continue;
+    ownRecentUtterances.push(content);
+  }
+  const recentOwnUtterances = ownRecentUtterances.slice(-OWN_UTTERANCE_WINDOW);
+
   // Relevant memories: most recent N, preference for memories involving involved people
   const MAX_MEMORIES = 8;
   const involvedSet = involvedPeople;
@@ -85,6 +101,7 @@ export function buildPerceptionPacket(
     agentId:               agent.agentId,
     triggeringEvent:       triggeringEvent,
     visibleContextEvents:  contextEvents,
+    ownRecentUtterances:   recentOwnUtterances,
     involvedPeople:        [...involvedPeople],
     relevantChannels,
     relevantMemories,

--- a/packages/server/src/agent/__tests__/agent-runtime.test.ts
+++ b/packages/server/src/agent/__tests__/agent-runtime.test.ts
@@ -52,7 +52,7 @@ describe("AgentRuntime Orchestration", () => {
     perceptionPacket: {
       agentId: "example-friend",
       triggeringEvent: null,
-      visibleContextEvents: [],
+      visibleContextEvents: [], ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],
@@ -194,5 +194,82 @@ describe("AgentRuntime Orchestration", () => {
     expect(output.operatorEvents[1]!.type).toBe("llm_failure");
     expect(output.operatorEvents[1]!.detail).toContain("LLM parsing or target constraint validation failed");
     expect(output.operatorEvents[1]!.data!.errorDetail).toContain("No JSON object found in response");
+  });
+
+  describe("repetition guard retry", () => {
+    const repeatingInput: AgentRuntimeInput = {
+      ...baseInput,
+      perceptionPacket: {
+        ...baseInput.perceptionPacket,
+        ownRecentUtterances: ["kkkkk não acredito nesse take"],
+      },
+    };
+
+    function jsonResponse(content: string, promptTokens = 50, completionTokens = 10) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [{ message: { content: JSON.stringify({
+            id: "intent-1",
+            actorId: "example-friend",
+            intentType: "send_message",
+            channelTarget: "general",
+            personTargets: [],
+            visibleContent: content,
+            privateMotiveSummary: "reacting",
+            emotionDrivers: [],
+            motivationDrivers: [],
+            memoryWrites: [],
+          }) } }],
+          usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens },
+          model: "test-model",
+        }),
+        headers: new Map(),
+      };
+    }
+
+    it("retries once and commits fresh content when the retry is genuinely different", async () => {
+      const runtime = new AgentRuntime({
+        "example-friend": { providerType: "qwen3", baseUrl: "http://localhost:11434/v1", modelName: "test-model" },
+      });
+
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse("kkkkk não acredito nesse take", 50, 10)) // repeat of ownRecentUtterances
+        .mockResolvedValueOnce(jsonResponse("acho que devíamos falar de outra coisa agora", 60, 15)); // genuinely new
+      vi.stubGlobal("fetch", fetchMock);
+
+      const output = await runtime.generateIntent(repeatingInput, context);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(output.fallbackApplied).toBe(false);
+      expect(output.intent.intentType).toBe("send_message");
+      expect(output.intent.visibleContent).toBe("acho que devíamos falar de outra coisa agora");
+      // Usage should sum both calls, not just the first.
+      expect(output.llmUsage!.inputTokens).toBe(110);
+      expect(output.llmUsage!.outputTokens).toBe(25);
+      // No intent_blocked event — the retry recovered real content.
+      expect(output.operatorEvents.some(e => e.type === "intent_blocked")).toBe(false);
+    });
+
+    it("falls back to no_op when the retry also repeats", async () => {
+      const runtime = new AgentRuntime({
+        "example-friend": { providerType: "qwen3", baseUrl: "http://localhost:11434/v1", modelName: "test-model" },
+      });
+
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse("kkkkk não acredito nesse take", 50, 10))
+        .mockResolvedValueOnce(jsonResponse("kkkkk não acredito nesse take", 40, 8)); // still a repeat
+      vi.stubGlobal("fetch", fetchMock);
+
+      const output = await runtime.generateIntent(repeatingInput, context);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(output.fallbackApplied).toBe(true);
+      expect(output.intent.intentType).toBe("no_op");
+      expect(output.intent.privateMotiveSummary).toContain("Repetition guard");
+      expect(output.intent.privateMotiveSummary).toContain("even after a retry");
+      expect(output.operatorEvents.some(e => e.type === "intent_blocked")).toBe(true);
+    });
   });
 });

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -70,6 +70,7 @@ describe("PromptBuilder", () => {
       agentId: "example-friend",
       triggeringEvent: triggeringEvent,
       visibleContextEvents: [triggeringEvent, contextEvent],
+      ownRecentUtterances: [],
       involvedPeople: ["agent-peer", "agent-peer"],
       relevantChannels: ["general"],
       relevantMemories: [

--- a/packages/server/src/agent/__tests__/repetition-guard.test.ts
+++ b/packages/server/src/agent/__tests__/repetition-guard.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isNearRepeat } from "../repetition-guard.js";
+
+describe("isNearRepeat", () => {
+  it("flags an exact repeat", () => {
+    expect(isNearRepeat("kkkkk não acredito nesse take", ["kkkkk não acredito nesse take"])).toBe(true);
+  });
+
+  it("flags a near-variation (punctuation/emoji-only diff)", () => {
+    expect(
+      isNearRepeat(
+        "e aí, bora falar sobre isso? :D",
+        ["e aí, bora falar sobre isso? :)"],
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag genuinely different content", () => {
+    expect(
+      isNearRepeat(
+        "acho que devíamos falar sobre outra coisa agora",
+        ["kkkkk não acredito nesse take"],
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag when there is no prior history", () => {
+    expect(isNearRepeat("qualquer coisa", [])).toBe(false);
+  });
+
+  it("does not flag empty candidate content", () => {
+    expect(isNearRepeat("", ["algo"])).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    // Partial overlap: shares some words but not enough at a strict threshold.
+    const candidate = "vi o episódio novo e achei incrível";
+    const prior = "vi o episódio antigo ontem à noite";
+    expect(isNearRepeat(candidate, [prior], 0.9)).toBe(false);
+  });
+});

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -48,7 +48,7 @@ Field notes by intentType — send_message/reply_to_message use "channelTarget" 
 Ensure:
 - "privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").
 - Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".
-- NEVER repeat a message you already sent, or a near-variation of it. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move the action somewhere else — or choose "no_op". Repeating yourself is the most out-of-character thing you can do.`);
+- NEVER repeat a message you already sent, or a near-variation of it. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move the action somewhere else — or choose "no_op". Repeating yourself is the most out-of-character thing you can do.${this.renderOwnUtterancesWarning(perceptionPacket.ownRecentUtterances)}`);
 
     const systemPrompt = systemSections.join("\n\n");
 
@@ -142,6 +142,11 @@ ${perceptionPacket.visibleContextEvents.map((e) => this.formatEvent(e)).join("\n
       perceptionPacket.relevantMemories.forEach((m) => {
         userSections.push(`- [Memory (${m.type})] ${m.summary} (Tone: ${m.emotionalTone})`);
       });
+      userSections.push(
+        "\nAt least one of these memories is relevant right now — let it actually shape what you do: " +
+          "bring it up, act warier or warmer because of it, reference it obliquely, or let it explain why " +
+          "you're reacting the way you are. Don't just have it sit in the background unused.",
+      );
     } else {
       userSections.push("No specific memories are active in your mind right now.");
     }
@@ -223,6 +228,17 @@ ${perceptionPacket.visibleContextEvents.map((e) => this.formatEvent(e)).join("\n
     }
 
     return blocks.filter((block) => block.length > 0).join("\n\n");
+  }
+
+  // Concrete, verbatim list of the agent's own last few messages — backs up
+  // the abstract "don't repeat yourself" instruction with something the
+  // model can actually check its draft output against, independent of
+  // whether those turns are still inside the shared visibleContextEvents
+  // window (which fills up fast with 5 agents committing events per pulse).
+  private static renderOwnUtterancesWarning(ownRecentUtterances: string[]): string {
+    if (ownRecentUtterances.length === 0) return "";
+    const quoted = ownRecentUtterances.map((u) => `  - "${u}"`).join("\n");
+    return `\n- You already sent these exact messages earlier in this conversation — do NOT repeat any of them or send a near-variation:\n${quoted}`;
   }
 
   private static renderListBlock(title: string, items: string[]): string {

--- a/packages/server/src/agent/agent-runtime.ts
+++ b/packages/server/src/agent/agent-runtime.ts
@@ -11,6 +11,7 @@ import type {
 import { PersonaLoader } from "./persona-loader.js";
 import { PromptBuilder } from "./prompt-builder.js";
 import { IntentParser } from "./intent-parser.js";
+import { isNearRepeat } from "./repetition-guard.js";
 import { llmBudget } from "../llm/llm-budget.js";
 import { MockLlmProvider } from "../llm/mock-llm-provider.js";
 import { OpenAiCompatibleProvider } from "../llm/openai-compatible-provider.js";
@@ -116,20 +117,73 @@ export class AgentRuntime {
     }
 
     // Parse and validate intent
-    const parseResult = IntentParser.parse(
+    let parseResult = IntentParser.parse(
       providerResult.content,
       agentId,
       input.availableActions,
       "no_op"
     );
 
-    // Track usage
+    // Repetition guard: the prompt already tells the model not to repeat
+    // itself and shows it the exact text to avoid (see
+    // action-intent-prompt-builder.ts), but empirically small local models
+    // repeat anyway — the instruction alone isn't sufficient enforcement.
+    // Give the model exactly one chance to try again with an explicit,
+    // pointed correction before falling back to no_op — a hard fallback on
+    // the first near-repeat just trades spam for silence; a targeted retry
+    // can recover real content instead.
+    let intent = parseResult.intent;
+    let fallbackApplied = parseResult.fallbackApplied;
+    let repetitionBlocked = false;
+    let repetitionRetried = false;
+    let totalInputTokens = providerResult.usage.inputTokens;
+    let totalOutputTokens = providerResult.usage.outputTokens;
+
+    const isRepeat = (candidateIntent: typeof intent): boolean =>
+      (candidateIntent.intentType === "send_message" || candidateIntent.intentType === "reply_to_message") &&
+      !!candidateIntent.visibleContent &&
+      isNearRepeat(candidateIntent.visibleContent, input.perceptionPacket.ownRecentUtterances);
+
+    if (!fallbackApplied && isRepeat(intent)) {
+      repetitionRetried = true;
+      const retryPrompt = {
+        ...prompt,
+        system: `${prompt.system}\n\nIMPORTANT: your last attempt this turn ("${intent.visibleContent}") was too close to something you already said. Say something genuinely different — a new angle, a reaction to someone else, a topic change — or choose "no_op" if you truly have nothing new to add.`,
+      };
+      try {
+        const retryResult = await provider.generateIntent(input, context, retryPrompt);
+        totalInputTokens += retryResult.usage.inputTokens;
+        totalOutputTokens += retryResult.usage.outputTokens;
+        const retryParse = IntentParser.parse(retryResult.content, agentId, input.availableActions, "no_op");
+        if (!retryParse.fallbackApplied && !isRepeat(retryParse.intent)) {
+          parseResult = retryParse;
+          intent = retryParse.intent;
+          fallbackApplied = retryParse.fallbackApplied;
+        } else {
+          repetitionBlocked = true;
+        }
+      } catch {
+        // Retry call itself failed — fall through to the block below.
+        repetitionBlocked = true;
+      }
+    }
+
+    if (repetitionBlocked) {
+      fallbackApplied = true;
+      intent = IntentParser.createFallback(
+        agentId,
+        "no_op",
+        "Repetition guard: near-duplicate of a message you already sent, even after a retry — blocked structurally.",
+      );
+    }
+
+    // Track usage (includes the retry call's tokens, if one happened)
     const usageRecord: LlmUsage = {
       simulationId,
       agentId,
       model: providerResult.model || llmConfig.modelName,
-      inputTokens: providerResult.usage.inputTokens,
-      outputTokens: providerResult.usage.outputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       latencyMs: providerResult.latencyMs,
       callType: purposeToCallType(prompt.purpose),
       pulseIndex: context.pulseIndex,
@@ -160,7 +214,7 @@ export class AgentRuntime {
       },
     });
 
-    if (parseResult.fallbackApplied) {
+    if (fallbackApplied && !repetitionBlocked) {
       operatorEvents.push({
         type: "llm_failure",
         simulationId,
@@ -177,11 +231,22 @@ export class AgentRuntime {
       });
     }
 
+    if (repetitionBlocked) {
+      operatorEvents.push({
+        type: "intent_blocked",
+        simulationId,
+        agentId,
+        pulseIndex: context.pulseIndex,
+        detail: `Repetition guard blocked a near-duplicate message from agent ${agentId}; substituted no_op.`,
+        createdAt: context.now,
+      });
+    }
+
     return {
-      intent: parseResult.intent,
+      intent,
       llmUsage: usageRecord,
       latencyMs: Date.now() - startTime,
-      fallbackApplied: parseResult.fallbackApplied,
+      fallbackApplied,
       operatorEvents,
     };
   }

--- a/packages/server/src/agent/repetition-guard.ts
+++ b/packages/server/src/agent/repetition-guard.ts
@@ -1,0 +1,54 @@
+/**
+ * Repetition guard — catches an agent repeating (or near-repeating) one of
+ * its own recent messages, structurally, instead of relying on the model to
+ * self-police a prompt instruction.
+ *
+ * Why this exists: the prompt already tells the model not to repeat itself
+ * and shows it the exact text to avoid (see action-intent-prompt-builder.ts
+ * SECTION 8 + renderOwnUtterancesWarning), but empirically small local
+ * models keep repeating anyway — the instruction alone isn't sufficient.
+ * This is the enforcement backstop.
+ */
+
+const STOPWORDS = new Set(["a", "o", "e", "de", "que", "do", "da", "em", "um", "uma", "and", "of", "to", "the"]);
+
+const COMBINING_DIACRITICS = new RegExp("[\\u0300-\\u036f]", "g");
+
+/** Lowercase, strip punctuation/emoji/diacritics, collapse whitespace, drop stopwords. */
+function normalizeWords(text: string): string[] {
+  const stripped = text
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(COMBINING_DIACRITICS, "")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ") // punctuation/emoji -> space
+    .trim();
+  if (stripped.length === 0) return [];
+  return stripped.split(/\s+/).filter((w) => w.length > 0 && !STOPWORDS.has(w));
+}
+
+/** Jaccard similarity over normalized word sets. 1.0 = identical content. */
+function similarity(a: string, b: string): number {
+  const wordsA = new Set(normalizeWords(a));
+  const wordsB = new Set(normalizeWords(b));
+  if (wordsA.size === 0 && wordsB.size === 0) return 1;
+  if (wordsA.size === 0 || wordsB.size === 0) return 0;
+  let intersection = 0;
+  for (const w of wordsA) if (wordsB.has(w)) intersection++;
+  const union = wordsA.size + wordsB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export const REPETITION_SIMILARITY_THRESHOLD = 0.7;
+
+/**
+ * Returns true if `candidate` is a near-duplicate of any of the agent's own
+ * recent utterances (word-overlap similarity >= threshold).
+ */
+export function isNearRepeat(
+  candidate: string,
+  ownRecentUtterances: readonly string[],
+  threshold: number = REPETITION_SIMILARITY_THRESHOLD,
+): boolean {
+  if (!candidate || candidate.trim().length === 0) return false;
+  return ownRecentUtterances.some((prior) => similarity(candidate, prior) >= threshold);
+}

--- a/packages/server/src/llm/__tests__/mock-llm-provider.test.ts
+++ b/packages/server/src/llm/__tests__/mock-llm-provider.test.ts
@@ -66,7 +66,7 @@ describe("MockLlmProvider", () => {
     perceptionPacket: {
       agentId: "agent-beta",
       triggeringEvent: null,
-      visibleContextEvents: [],
+      visibleContextEvents: [], ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],

--- a/packages/server/src/llm/__tests__/openai-compatible-provider.test.ts
+++ b/packages/server/src/llm/__tests__/openai-compatible-provider.test.ts
@@ -47,7 +47,7 @@ describe("OpenAiCompatibleProvider", () => {
     perceptionPacket: {
       agentId: "goulart",
       triggeringEvent: null,
-      visibleContextEvents: [],
+      visibleContextEvents: [], ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -105,7 +105,7 @@ function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").E
     newEvents: [],
     attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
     perceptionPacket: {
-      agentId: "agent_1", triggeringEvent: null, visibleContextEvents: [], involvedPeople: [],
+      agentId: "agent_1", triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
       relevantChannels: [], relevantMemories: [],
       translatedEmotionalState: { summary: "", emotions: [] },
       availableActions: [],

--- a/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
+++ b/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
@@ -59,7 +59,7 @@ function makeStepResult(): EngineStepResult {
     perceptionPacket: {
       agentId: "agent_1",
       triggeringEvent: null,
-      visibleContextEvents: [],
+      visibleContextEvents: [], ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: [],
       relevantMemories: [],

--- a/packages/shared/src/perception/perception.types.ts
+++ b/packages/shared/src/perception/perception.types.ts
@@ -7,6 +7,13 @@ export type PerceptionPacket = {
   agentId: string;
   triggeringEvent: CommittedEvent | null;
   visibleContextEvents: CommittedEvent[]; // 5-10 recent messages in visible channels
+  // The agent's own last few sent messages, verbatim, independent of
+  // visibleContextEvents' CONTEXT_WINDOW truncation. In a multi-agent room
+  // the shared window fills up fast (every agent's turn counts against it),
+  // so an agent's own prior utterance from even 1-2 pulses ago can already
+  // be pushed out — this is tracked separately so "don't repeat yourself"
+  // has something concrete to check against no matter how busy the room is.
+  ownRecentUtterances: string[];
   involvedPeople: string[]; // agent IDs relevant to triggering event
   relevantChannels: string[]; // channel IDs visible to agent
   relevantMemories: Memory[];


### PR DESCRIPTION
## What
The prompt already tells the model not to repeat itself and (as of this stack) shows it the exact text to avoid, but empirically small local models repeat anyway — live benchmark runs showed every agent repeating its own line verbatim for 5-10 straight pulses despite the instruction. A prompt instruction alone isn't sufficient enforcement; this adds a structural backstop.

- **`PerceptionPacket.ownRecentUtterances`**: the agent's own last few sent messages, computed from the *full* visible event history in `build-perception-packet.ts` (before `CONTEXT_WINDOW` truncation) rather than the shared windowed view — in a 5-agent room the shared window fills up within 1-2 pulses, so an agent's own prior utterance can already be gone from context by the time it matters.
- **`repetition-guard.ts`**: `isNearRepeat()` — Jaccard word-overlap similarity (threshold 0.7, stopword-filtered) between a candidate message and the agent's recent utterances. Pure, unit-tested.
- **`action-intent-prompt-builder.ts`**: renders `ownRecentUtterances` as a concrete "you already said these, don't repeat them" list, and adds an instruction to actually use a relevant memory rather than let it sit unused (`memory_continuity` was one of the two weakest benchmark axes).
- **`agent-runtime.ts`**: on a detected near-repeat, retries generation *once* with an appended correction before falling back to `no_op` — a hard fallback on the first near-repeat just trades spam for silence; the retry recovers real content when the model has something else to say. Usage/token tracking sums both calls. Falls back to `no_op` (clearly labeled as post-retry) only if the retry also repeats or fails.

## Verification
- 6 new `repetition-guard` unit tests, 2 new `agent-runtime` tests (retry-recovers-content, retry-also-repeats-so-fallback). 775/775 total.
- Re-ran the 16-scenario benchmark sweep: **zero literal duplicate messages committed** (down from every agent repeating verbatim for 5-10 straight pulses); `narrative_cohesion` mean 3.00→3.80 and `memory_continuity` 2.93→3.67.

Stacked on #21 (this branch's base) — that PR must merge first. **Last PR in the narrative-sharpening stack** (chain: main ← #19 ← #20 ← #21 ← this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)