### PR TITLE
fix(agent): reject content-bearing intents without visibleContent

### DIFF
--- a/packages/server/src/agent/__tests__/intent-parser-null.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser-null.test.ts
@@ -12,7 +12,26 @@ const ACTIONS: AvailableAction[] = [
 ];
 
 describe("IntentParser structural repair", () => {
-  it("coerces visibleContent: null to undefined (model quirk)", () => {
+  it("coerces visibleContent: null to undefined (model quirk) on non-content actions", () => {
+    const raw = JSON.stringify({
+      id: "i1",
+      actorId: "goulart",
+      intentType: "no_op",
+      personTargets: null,
+      visibleContent: null,
+      privateMotiveSummary: "quero ver a reação dele",
+      emotionDrivers: null,
+      motivationDrivers: null,
+    });
+    const result = IntentParser.parse(raw, "goulart", ACTIONS);
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.intentType).toBe("no_op");
+    expect(result.intent.visibleContent).toBeUndefined();
+    expect(result.intent.personTargets).toEqual([]);
+    expect(result.intent.emotionDrivers).toEqual([]);
+  });
+
+  it("falls back when send_message ends up without content after null coercion (#39)", () => {
     const raw = JSON.stringify({
       id: "i1",
       actorId: "goulart",
@@ -24,11 +43,9 @@ describe("IntentParser structural repair", () => {
       motivationDrivers: null,
     });
     const result = IntentParser.parse(raw, "goulart", ACTIONS);
-    expect(result.fallbackApplied).toBe(false);
-    expect(result.intent.intentType).toBe("send_message");
-    expect(result.intent.visibleContent).toBeUndefined();
-    expect(result.intent.personTargets).toEqual([]);
-    expect(result.intent.emotionDrivers).toEqual([]);
+    expect(result.fallbackApplied).toBe(true);
+    expect(result.intent.intentType).toBe("no_op");
+    expect(result.errorDetail).toContain("visibleContent must not be empty");
   });
 
   it("defaults missing memoryWrites", () => {

--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -150,6 +150,90 @@ Hope you like it!
     expect(result.intent.privateMotiveSummary).toContain("privateMotiveSummary must not be empty");
   });
 
+  describe("content-bearing actions require visibleContent (#39)", () => {
+    it("applies safe fallback when send_message has no visibleContent", () => {
+      const rawText = JSON.stringify({
+        id: "intent-no-content",
+        actorId,
+        intentType: "send_message",
+        channelTarget: "general-id",
+        personTargets: [],
+        privateMotiveSummary: "say something",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, availableActions);
+
+      expect(result.fallbackApplied).toBe(true);
+      expect(result.intent.intentType).toBe("no_op");
+      expect(result.errorDetail).toContain("visibleContent must not be empty for intent type 'send_message'");
+    });
+
+    it("applies safe fallback when visibleContent is whitespace-only", () => {
+      const rawText = JSON.stringify({
+        id: "intent-blank-content",
+        actorId,
+        intentType: "send_message",
+        channelTarget: "general-id",
+        personTargets: [],
+        visibleContent: "   ",
+        privateMotiveSummary: "say something",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, availableActions);
+
+      expect(result.fallbackApplied).toBe(true);
+      expect(result.intent.intentType).toBe("no_op");
+      expect(result.errorDetail).toContain("visibleContent must not be empty");
+    });
+
+    it("applies safe fallback when reply_to_message has no visibleContent", () => {
+      const rawText = JSON.stringify({
+        id: "intent-reply-no-content",
+        actorId,
+        intentType: "reply_to_message",
+        channelTarget: "general-id",
+        personTargets: [actorId],
+        replyToEventId: "evt-1",
+        privateMotiveSummary: "reply without content",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, availableActions);
+
+      expect(result.fallbackApplied).toBe(true);
+      expect(result.intent.intentType).toBe("no_op");
+      expect(result.errorDetail).toContain("visibleContent must not be empty for intent type 'reply_to_message'");
+    });
+
+    it("still accepts content-bearing send_message with real content", () => {
+      const rawText = JSON.stringify({
+        id: "intent-with-content",
+        actorId,
+        intentType: "send_message",
+        channelTarget: "general-id",
+        personTargets: [],
+        visibleContent: "fala sério",
+        privateMotiveSummary: "genuine message",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      });
+
+      const result = IntentParser.parse(rawText, actorId, availableActions);
+
+      expect(result.fallbackApplied).toBe(false);
+      expect(result.intent.visibleContent).toBe("fala sério");
+    });
+  });
+
   it("should apply safe fallback if targets are not allowed in availableActions", () => {
     const rawText = JSON.stringify({
       id: "intent-invalid-target",

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -93,6 +93,24 @@ export class IntentParser {
         throw new Error("privateMotiveSummary must not be empty");
       }
 
+      // 6b. Content-bearing actions must actually carry content. A model
+      // that declares send_message/reply_to_message but omits visibleContent
+      // (or fills it with whitespace) would otherwise pass both this parser
+      // and the engine validator (which only bounds max length) and commit
+      // a message_sent/reply_sent event with empty content — observed once
+      // in a real benchmark transcript (#39). Reject here so the turn falls
+      // into the safe fallback path instead.
+      if (
+        validatedIntent.intentType === "send_message" ||
+        validatedIntent.intentType === "reply_to_message"
+      ) {
+        if (!validatedIntent.visibleContent || validatedIntent.visibleContent.trim() === "") {
+          throw new Error(
+            `visibleContent must not be empty for intent type '${validatedIntent.intentType}'`
+          );
+        }
+      }
+
       // 7. Validate that intent targets exist in availableActions
       // Note: 'no_op' and 'delay_response' are always permitted system-level fallbacks.
       if (validatedIntent.intentType !== "no_op" && validatedIntent.intentType !== "delay_response") {


### PR DESCRIPTION
## What

Closes a transcript-integrity hole in intent handling: an agent declaring `send_message` or `reply_to_message` with a missing or whitespace-only `visibleContent` used to pass both the intent parser and the engine validator (which only bounds max length), committing `message_sent`/`reply_sent` events with empty content into transcripts.

- The parser's post-validation guards now require non-blank `visibleContent` for content-bearing actions; violations route through the existing safe fallback ladder (clean `no_op` + descriptive error detail), exactly like every other malformed intent. Channel creation, reactions, and no-op intents are untouched.
- Updated one pre-existing test that had codified the old acceptance of contentless send intents; null-coercion coverage is preserved via a non-content action.
- Four new parser tests: missing content, whitespace-only content, reply intents, and the happy path.

Deliberately no change to the engine's type-generic validator — it remains the second gate.

## Validation

- `pnpm lint` ✅ · `pnpm test:all` ✅ 783 passed (778 baseline + net 5)