### PR TITLE
fix(docker): portable qwen3 compose default, NVIDIA GPU as opt-in override

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,34 @@ This uses `providerType: "mock"` by default — no API key or model needed to se
 
 You don't need a paid API key. Two free local options:
 
-**Local Qwen3 via Ollama** (recommended if you have a GPU, works on CPU too):
+**Native Ollama** (recommended on macOS / Apple Silicon):
+
+Docker Desktop has no GPU passthrough on macOS, and the Docker CPU path is
+dramatically slower (~1.2–1.5 tok/s vs ~40 tok/s native with Metal). Install
+Ollama directly instead — it's free and exposes the same API:
 
 ```bash
-pnpm qwen:dev          # pulls qwen3:1.7b, exposes an OpenAI-compatible API on :11434
-# or: pnpm qwen:dev:8b for the 8B model
+brew install ollama        # or download from https://ollama.com
+ollama pull qwen3:1.7b
+ollama serve               # API on :11434
 ```
 
 Then point `config/index.json` at `examples/simulations/qwen3-local.example.json`.
+
+**Local Qwen3 via Docker** (Linux machines with an NVIDIA GPU):
+
+```bash
+pnpm qwen:dev              # pulls qwen3:1.7b, portable CPU-safe default
+# or: pnpm qwen:dev:8b for the 8B model
+```
+
+On a machine with an NVIDIA driver, opt into GPU passthrough with the
+override file:
+
+```bash
+docker compose -f docker/qwen3/qwen3.compose.yml \
+               -f docker/qwen3/qwen3.gpu.compose.yml up -d
+```
 
 **FreeLLMAPI** (unified proxy for aggregating free-tier provider keys):
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This uses `providerType: "mock"` by default — no API key or model needed to se
 
 ### Running with a real model, for free
 
-You don't need a paid API key. Two free local options:
+You don't need a paid API key. Free local options:
 
 **Native Ollama** (recommended on macOS / Apple Silicon):
 

--- a/docker/qwen3/qwen3.compose.yml
+++ b/docker/qwen3/qwen3.compose.yml
@@ -12,13 +12,6 @@ services:
       OLLAMA_KV_CACHE_TYPE: ${OLLAMA_KV_CACHE_TYPE:-q8_0}
     ports:
       - "11434:11434"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     volumes:
       - qwen3-ollama-data:/root/.ollama
     entrypoint: ["/bin/sh", "-c"]

--- a/docker/qwen3/qwen3.gpu.compose.yml
+++ b/docker/qwen3/qwen3.gpu.compose.yml
@@ -1,0 +1,19 @@
+# Opt-in GPU passthrough for machines with an NVIDIA driver (typically
+# native Linux). The base qwen3.compose.yml is intentionally portable:
+# Docker Desktop on macOS has no GPU passthrough at all, so a hardcoded
+# NVIDIA reservation made the container fail to start there (#37).
+#
+# Usage:
+#   docker compose -f docker/qwen3/qwen3.compose.yml \
+#                  -f docker/qwen3/qwen3.gpu.compose.yml up -d
+name: perfectman
+
+services:
+  qwen3:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docs/README.md
+++ b/docs/README.md
@@ -227,13 +227,17 @@ pnpm freellm:dev
 
 The script builds the FreeLLMAPI container from `https://github.com/tashfeenahmed/freellmapi`, reads this repo's `.env`, exposes the API on `http://localhost:3001/v1`, and exposes the dashboard on `http://localhost:5173`. Set `FREELLMAPI_ENCRYPTION_KEY` in `.env` before first run so FreeLLMAPI can store provider keys. Use the dashboard to add provider keys and create the unified key, then store that value in `.env` as `FREELLMAPI_KEY`.
 
-For the local Qwen3 config, run the Ollama container first:
+For the local Qwen3 config, run Ollama first. On macOS, prefer native
+Ollama (`brew install ollama && ollama pull qwen3:1.7b && ollama serve`) —
+Docker Desktop has no GPU passthrough there and the CPU-only container is
+dramatically slower. On Linux machines with an NVIDIA GPU, use the Docker
+path:
 
 ```bash
 pnpm qwen:dev
 ```
 
-The script starts `ollama/ollama`, pulls `qwen3:1.7b` by default into a Docker-managed volume, and exposes the OpenAI-compatible API on `http://localhost:11434/v1`. Use it with `config/index.json` copied from `examples/simulations/qwen3-local.example.json`. For the 8B model, run `pnpm qwen:dev:8b` and use a config with `modelName: "qwen3:8b"`.
+The script starts `ollama/ollama` from the portable base compose file, pulls `qwen3:1.7b` by default into a Docker-managed volume, and exposes the OpenAI-compatible API on `http://localhost:11434/v1`. Use it with `config/index.json` copied from `examples/simulations/qwen3-local.example.json`. For the 8B model, run `pnpm qwen:dev:8b` and use a config with `modelName: "qwen3:8b"`. NVIDIA machines can opt into GPU passthrough with `-f docker/qwen3/qwen3.gpu.compose.yml` (see the root README).
 
 ## Current Open Questions
 


### PR DESCRIPTION
## What

Makes the Qwen3 Docker setup portable across machines:

- `docker/qwen3/qwen3.compose.yml` drops its hardcoded NVIDIA GPU reservation, which made the container fail to start anywhere without that driver (notably Docker Desktop on macOS, which has no GPU passthrough at all). The base file now starts everywhere.
- New opt-in override `docker/qwen3/qwen3.gpu.compose.yml` restores GPU passthrough for NVIDIA machines: `docker compose -f docker/qwen3/qwen3.compose.yml -f docker/qwen3/qwen3.gpu.compose.yml up -d`.
- README's "Running with a real model" section rewritten: native Ollama documented as the recommended Apple Silicon path (~30–40x faster than the Docker CPU path), Docker instructions kept for Linux + NVIDIA, override invocation shown; `docs/README.md` aligned with the same guidance.

## Validation

- `docker compose config -q` passes for base alone and base+override; rendered merged config still contains the nvidia/gpu reservation only when the override is included.
- `pnpm lint` ✅ · `pnpm test:all` ✅ 778 passed (no runtime code touched).