### PR TITLE
feat(eval): per-signal-kind breakdown in bench report

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -51,7 +51,8 @@ pnpm --filter @perfectman/eval bench --scenarios v1_mention_reply,motive_gossip 
 ```
 
 The report (`bench-report-v1`) contains per-scenario signal/probe/judge
-results, probe averages, judge axis means vs targets, category splits, and
+results, probe averages, per-signal-kind pass rates with failing examples
+(`signalsByKind`), judge axis means vs targets, category splits, and
 the judge calibration report. Failing reports are committed, never hidden.
 The `narrative_cohesion` axis lives on the `roleplay-v1` rubric (anchored for
 turn-to-turn thread, callbacks, escalation, shifted meaning). By default the

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -24,6 +24,7 @@ import { ruleJudge, llmJudge, llmJudgePerTurn, type AxisScores } from "../judge/
 import { calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
+import { aggregateSignalsByKind } from "../run/signal-checker.js";
 
 /** LLM judge endpoint — DeepSeek by default when PERFECTMAN_LLM_PROVIDER=deepseek. */
 export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
@@ -62,6 +63,7 @@ export type BenchReport = {
   judgeAxisMeans: Record<string, number>;
   judgeAxisTargets: Record<string, { target: number; met: boolean }>;
   byCategory: Record<string, { runs: number; signalPassRate: number }>;
+  signalsByKind: Record<string, import("../run/signal-checker.js").SignalsByKindEntry>;
   calibration: ReturnType<typeof calibrateJudge>;
   perScenario: Array<{
     id: string;
@@ -119,6 +121,7 @@ export async function runBench(opts: {
     judgeAxisMeans: {},
     judgeAxisTargets: {},
     byCategory: {},
+    signalsByKind: {},
     calibration: calibrateJudge(new Map(), []),
     perScenario: [],
   };
@@ -126,6 +129,7 @@ export async function runBench(opts: {
   const judgeScores = new Map<string, AxisScores>();
   const probeAgg: Record<string, { sum: number; count: number; passed: number }> = {};
   const axisAgg: Record<string, { sum: number; count: number }> = {};
+  const signalKindResults: Array<Parameters<typeof aggregateSignalsByKind>[0][number]> = [];
   let signalsPassed = 0;
   let signalsTotal = 0;
   let probesPassed = 0;
@@ -153,6 +157,7 @@ export async function runBench(opts: {
 
       signalsPassed += artifact.passedSignals;
       signalsTotal += artifact.totalSignals;
+      signalKindResults.push(...artifact.signalResults);
       probesPassed += artifact.probeResults.filter(p => p.passed).length;
       probesTotal += artifact.probeResults.length;
       for (const p of artifact.probeResults) {
@@ -195,6 +200,7 @@ export async function runBench(opts: {
   }
 
   report.signalPassRate = signalsTotal > 0 ? signalsPassed / signalsTotal : 0;
+  report.signalsByKind = aggregateSignalsByKind(signalKindResults);
   report.probePassRate = probesTotal > 0 ? probesPassed / probesTotal : 0;
   report.probeAverages = Object.fromEntries(
     Object.entries(probeAgg).map(([id, a]) => [id, {
@@ -233,6 +239,14 @@ function printReport(report: BenchReport): void {
   console.log(`scenarios: ${report.scenariosRun} run, ${report.scenariosFailed} failed`);
   console.log(`signal pass rate: ${(report.signalPassRate * 100).toFixed(1)}%`);
   console.log(`probe pass rate: ${(report.probePassRate * 100).toFixed(1)}%`);
+  const byKind = Object.entries(report.signalsByKind).sort((a, b) => a[1].passRate - b[1].passRate);
+  if (byKind.length > 0) {
+    console.log("\nsignal pass rate by kind (worst first):");
+    for (const [kind, a] of byKind) {
+      console.log(`  ${kind.padEnd(26)} ${(a.passRate * 100).toFixed(0)}% (${a.passed}/${a.total})`);
+      for (const ex of a.failExamples.slice(0, 2)) console.log(`    - ${ex}`);
+    }
+  }
   console.log("\nprobe averages (mean | passed%):");
   for (const [id, a] of Object.entries(report.probeAverages)) {
     console.log(`  ${id.padEnd(26)} ${a.mean.toFixed(3)} | ${(a.passedPct * 100).toFixed(0)}%`);

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -24,7 +24,7 @@ import { ruleJudge, llmJudge, llmJudgePerTurn, type AxisScores } from "../judge/
 import { calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
-import { aggregateSignalsByKind } from "../run/signal-checker.js";
+import { aggregateSignalsByKind, type SignalOutcome } from "../run/signal-checker.js";
 
 /** LLM judge endpoint — DeepSeek by default when PERFECTMAN_LLM_PROVIDER=deepseek. */
 export function judgeConfig(): import("../judge/judge.js").LlmJudgeConfig {
@@ -129,7 +129,7 @@ export async function runBench(opts: {
   const judgeScores = new Map<string, AxisScores>();
   const probeAgg: Record<string, { sum: number; count: number; passed: number }> = {};
   const axisAgg: Record<string, { sum: number; count: number }> = {};
-  const signalKindResults: Array<Parameters<typeof aggregateSignalsByKind>[0][number]> = [];
+  const signalKindResults: SignalOutcome[] = [];
   let signalsPassed = 0;
   let signalsTotal = 0;
   let probesPassed = 0;

--- a/packages/eval/src/run/signal-checker.ts
+++ b/packages/eval/src/run/signal-checker.ts
@@ -20,6 +20,51 @@ export function checkExpectedSignals(
   return scenario.expectedSignals.map(sig => checkSignal(sig, events, states, llmCallsFor));
 }
 
+export type SignalsByKindEntry = {
+  passed: number;
+  total: number;
+  passRate: number;
+  failExamples: string[];
+};
+
+const MAX_FAIL_EXAMPLES = 3;
+
+/**
+ * Rolls SignalOutcome[] up per signal kind ("emotion_rises",
+ * "event_committed", …). Outcomes carry the full signal JSON-stringified in
+ * `signal`, so the kind is recovered by parsing it; anything unparsable
+ * lands under "unknown" rather than being dropped.
+ */
+export function aggregateSignalsByKind(
+  results: readonly SignalOutcome[],
+): Record<string, SignalsByKindEntry> {
+  const agg: Record<string, { passed: number; total: number; failExamples: string[] }> = {};
+  for (const outcome of results) {
+    let kind = "unknown";
+    try {
+      const parsed = JSON.parse(outcome.signal) as { kind?: unknown };
+      if (typeof parsed.kind === "string") kind = parsed.kind;
+    } catch {
+      // keep "unknown"
+    }
+    agg[kind] ??= { passed: 0, total: 0, failExamples: [] };
+    agg[kind]!.total++;
+    if (outcome.passed) {
+      agg[kind]!.passed++;
+    } else if (agg[kind]!.failExamples.length < MAX_FAIL_EXAMPLES) {
+      agg[kind]!.failExamples.push(outcome.detail);
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(agg).map(([kind, a]) => [kind, {
+      passed: a.passed,
+      total: a.total,
+      passRate: a.passed / a.total,
+      failExamples: a.failExamples,
+    }]),
+  );
+}
+
 function checkSignal(
   sig: ExpectedSignal,
   events: readonly CommittedEvent[],

--- a/packages/eval/src/test/signal-breakdown.test.ts
+++ b/packages/eval/src/test/signal-breakdown.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { aggregateSignalsByKind } from "../run/signal-checker.js";
+import type { SignalOutcome } from "../run/signal-checker.js";
+
+function outcome(kind: string, passed: boolean, detail = "detail"): SignalOutcome {
+  return { signal: JSON.stringify({ kind, agentId: "a" }), passed, detail };
+}
+
+describe("aggregateSignalsByKind (#42)", () => {
+  it("returns an empty record for no outcomes", () => {
+    expect(aggregateSignalsByKind([])).toEqual({});
+  });
+
+  it("groups pass/fail counts per kind", () => {
+    const agg = aggregateSignalsByKind([
+      outcome("emotion_rises", true),
+      outcome("emotion_rises", false, "bruno.jealousy = 0.1 (min 0.5)"),
+      outcome("emotion_rises", false, "no state for caio"),
+      outcome("event_committed", true),
+    ]);
+    expect(agg["emotion_rises"]).toEqual({
+      passed: 1,
+      total: 3,
+      passRate: 1 / 3,
+      failExamples: ["bruno.jealousy = 0.1 (min 0.5)", "no state for caio"],
+    });
+    expect(agg["event_committed"]).toEqual({
+      passed: 1,
+      total: 1,
+      passRate: 1,
+      failExamples: [],
+    });
+  });
+
+  it("caps failing examples at 3", () => {
+    const agg = aggregateSignalsByKind([
+      outcome("llm_calls_range", false, "f1"),
+      outcome("llm_calls_range", false, "f2"),
+      outcome("llm_calls_range", false, "f3"),
+      outcome("llm_calls_range", false, "f4"),
+      outcome("llm_calls_range", false, "f5"),
+    ]);
+    expect(agg["llm_calls_range"]!.total).toBe(5);
+    expect(agg["llm_calls_range"]!.passed).toBe(0);
+    expect(agg["llm_calls_range"]!.failExamples).toEqual(["f1", "f2", "f3"]);
+  });
+
+  it("lands unparsable signals under 'unknown' instead of dropping them", () => {
+    const agg = aggregateSignalsByKind([
+      { signal: "not-json{", passed: false, detail: "weird" },
+      { signal: '{"noKindHere":1}', passed: true, detail: "" },
+    ]);
+    expect(agg["unknown"]).toBeDefined();
+    expect(agg["unknown"]!.total).toBe(2);
+    expect(agg["unknown"]!.passRate).toBe(0.5);
+    expect(agg["unknown"]!.failExamples).toEqual(["weird"]);
+  });
+});


### PR DESCRIPTION
## What

Turns the bench's single rolled-up signal pass rate into a prioritized per-signal-kind breakdown:

- New pure helper `aggregateSignalsByKind()` groups signal outcomes by kind (`emotion_rises`, `event_committed`, …), producing `{ passed, total, passRate, failExamples }` per kind with up to three failing detail strings kept as examples; unparsable outcomes land under `"unknown"` rather than being dropped.
- `BenchReport` gains a persisted `signalsByKind` field, and the console summary prints kinds worst-pass-rate-first so the biggest offenders are the first thing you see.
- Four unit tests cover grouping, the example cap, the unknown fallback, and empty input.

## Validation

- `pnpm lint` ✅ · `pnpm test:all` ✅ 782 passed
- Live mock-mode slice renders the new console section and persists `signalsByKind` to the output JSON.