### PR TITLE
ci: weekly full-suite benchmark with trend artifacts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,13 +15,18 @@ on:
           - rule
           - llm
 
+# A trend run should never lose a data point to a later dispatch, and the
+# scheduled cron shouldn't kill an in-flight opt-in deep run either — so
+# runs queue instead of cancelling each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    # The offline path runs anywhere; the opt-in LLM deep run needs a runner
+    # with model servers + keys configured, so it targets self-hosted only.
+    runs-on: ${{ github.event.inputs.judge == 'llm' && 'self-hosted' || 'ubuntu-latest' }}
     # The opt-in LLM deep run needs far more headroom than the offline path.
     timeout-minutes: ${{ github.event.inputs.judge == 'llm' && 240 || 30 }}
     steps:
@@ -62,8 +67,9 @@ jobs:
 
       # Opt-in deep run (self-hosted runner with models configured via env).
       # Signal rates legitimately vary under real-model generation, so this
-      # path asserts only structural sanity: no scenario run hard-failed and
-      # every expected scenario id is present.
+      # path asserts only structural sanity: no scenario run hard-failed.
+      # (No expected-ids CSV is passed — the full suite has no fixed golden
+      # subset to check coverage against, unlike the PR-gate run.)
       - name: Deep bench (LLM judge)
         if: ${{ github.event.inputs.judge == 'llm' }}
         run: pnpm --filter @perfectman/eval bench --mode local --judge llm --out "$GITHUB_WORKSPACE/out/bench-full.json"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,8 @@ concurrency:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The opt-in LLM deep run needs far more headroom than the offline path.
+    timeout-minutes: ${{ github.event.inputs.judge == 'llm' && 240 || 30 }}
     steps:
       - uses: actions/checkout@v4
 
@@ -60,9 +61,16 @@ jobs:
         run: node scripts/ci/check-bench-gate.mjs out/bench-full.json
 
       # Opt-in deep run (self-hosted runner with models configured via env).
+      # Signal rates legitimately vary under real-model generation, so this
+      # path asserts only structural sanity: no scenario run hard-failed and
+      # every expected scenario id is present.
       - name: Deep bench (LLM judge)
         if: ${{ github.event.inputs.judge == 'llm' }}
         run: pnpm --filter @perfectman/eval bench --mode local --judge llm --out "$GITHUB_WORKSPACE/out/bench-full.json"
+
+      - name: Assert deep bench produced complete results
+        if: ${{ github.event.inputs.judge == 'llm' }}
+        run: node scripts/ci/check-bench-gate.mjs --skip-signal-gate out/bench-full.json
 
       - name: Upload report
         if: always() && hashFiles('out/bench-full.json') != ''

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,72 @@
+name: Benchmark
+
+on:
+  schedule:
+    # Weekly, Mondays 03:00 UTC — trend tracking, not a merge gate.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      judge:
+        description: "Judge backend. 'rule' is fully offline and works on hosted runners. 'llm' requires a runner with model servers + keys configured."
+        required: false
+        default: rule
+        type: choice
+        options:
+          - rule
+          - llm
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Workspace packages resolve each other through dist/ — build before gates.
+      - name: Build packages
+        run: pnpm -r build
+
+      - name: Typecheck (lint)
+        run: pnpm lint
+
+      - name: Unit + hygiene tests
+        run: pnpm test:all
+
+      # Full deterministic suite: all scenarios through variant rotation.
+      # The LLM-judged deep run is an explicit opt-in for runners that have
+      # model access; hosted CI stays offline by design.
+      - name: Full mock bench (rule judge)
+        if: ${{ github.event.inputs.judge != 'llm' }}
+        run: pnpm --filter @perfectman/eval bench --mode mock --judge rule --out "$GITHUB_WORKSPACE/out/bench-full.json"
+
+      - name: Assert signals held at 100%
+        if: ${{ github.event.inputs.judge != 'llm' }}
+        run: node scripts/ci/check-bench-gate.mjs out/bench-full.json
+
+      # Opt-in deep run (self-hosted runner with models configured via env).
+      - name: Deep bench (LLM judge)
+        if: ${{ github.event.inputs.judge == 'llm' }}
+        run: pnpm --filter @perfectman/eval bench --mode local --judge llm --out "$GITHUB_WORKSPACE/out/bench-full.json"
+
+      - name: Upload report
+        if: always() && hashFiles('out/bench-full.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ github.run_id }}
+          path: out/bench-full.json

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -46,14 +46,16 @@ jobs:
       # the golden-labeled scenario subset. No model, no API key. Signals
       # must hold at 100%; rule-judge axis scores stay advisory until the
       # judge clears its kappa >= 0.7 calibration gate.
+      # NOTE: pnpm --filter runs inside packages/eval, so --out gets an
+      # absolute workspace path to keep the later steps root-relative.
       - name: Golden-scenario bench (mock + rule judge)
-        run: pnpm --filter @perfectman/eval bench --mode mock --judge rule --scenarios "$GOLDEN_SCENARIOS" --out out/bench-pr-gate.json
+        run: pnpm --filter @perfectman/eval bench --mode mock --judge rule --scenarios "$GOLDEN_SCENARIOS" --out "$GITHUB_WORKSPACE/out/bench-pr-gate.json"
 
       - name: Assert bench gate
         run: node scripts/ci/check-bench-gate.mjs out/bench-pr-gate.json
 
       - name: Upload bench report
-        if: always()
+        if: always() && hashFiles('out/bench-pr-gate.json') != ''
         uses: actions/upload-artifact@v4
         with:
           name: bench-pr-gate

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,60 @@
+name: PR gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GOLDEN_SCENARIOS: v1_casual_chat,v1_exclusion_inferred,v1_private_motive,motive_gossip,edge_public_mock,stagnation_resentment_loop,calibration_quiet_room,motive_flirting
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Workspace packages resolve each other through dist/ — a stale build
+      # produces phantom typecheck/test failures (seen locally), so build
+      # everything before running the gates.
+      - name: Build packages
+        run: pnpm -r build
+
+      - name: Typecheck (lint)
+        run: pnpm lint
+
+      - name: Unit + hygiene tests
+        run: pnpm test:all
+
+      # Fast deterministic structural gate: mock generation + rule judge on
+      # the golden-labeled scenario subset. No model, no API key. Signals
+      # must hold at 100%; rule-judge axis scores stay advisory until the
+      # judge clears its kappa >= 0.7 calibration gate.
+      - name: Golden-scenario bench (mock + rule judge)
+        run: pnpm --filter @perfectman/eval bench --mode mock --judge rule --scenarios "$GOLDEN_SCENARIOS" --out out/bench-pr-gate.json
+
+      - name: Assert bench gate
+        run: node scripts/ci/check-bench-gate.mjs out/bench-pr-gate.json
+
+      - name: Upload bench report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-pr-gate
+          path: out/bench-pr-gate.json

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -52,7 +52,7 @@ jobs:
         run: pnpm --filter @perfectman/eval bench --mode mock --judge rule --scenarios "$GOLDEN_SCENARIOS" --out "$GITHUB_WORKSPACE/out/bench-pr-gate.json"
 
       - name: Assert bench gate
-        run: node scripts/ci/check-bench-gate.mjs out/bench-pr-gate.json
+        run: node scripts/ci/check-bench-gate.mjs out/bench-pr-gate.json "$GOLDEN_SCENARIOS"
 
       - name: Upload bench report
         if: always() && hashFiles('out/bench-pr-gate.json') != ''

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -64,6 +64,13 @@ typecheck, unit tests, then a mock+rule-judge bench over the golden scenario
 subset with a hard 100%-signals assertion (`scripts/ci/check-bench-gate.mjs`)
 — free, deterministic, no model needed.
 
+A second, weekly workflow (`.github/workflows/benchmark.yml`) runs the same
+gate over the *full* 123-task suite (Mondays 03:00 UTC, or on demand via
+`workflow_dispatch`) and uploads the report as a run artifact for trend
+tracking. Its `judge=llm` dispatch input is an opt-in deep run for
+self-hosted runners with model servers configured; hosted CI stays on the
+offline rule judge by default.
+
 ## Current baseline (mock, 123 tasks)
 
 - Signal pass rate: **100%** (all expected signals across all rotated scenes)

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -59,6 +59,11 @@ LLM judge scores it from the whole transcript; `--per-turn` (LLM judge only)
 replaces that with the mean of per-turn scores — each sampled content-bearing
 turn is scored against the turn before it (see `packages/eval/src/judge/judge.ts`).
 
+Every PR also runs this harness in CI (`.github/workflows/pr-gate.yml`):
+typecheck, unit tests, then a mock+rule-judge bench over the golden scenario
+subset with a hard 100%-signals assertion (`scripts/ci/check-bench-gate.mjs`)
+— free, deterministic, no model needed.
+
 ## Current baseline (mock, 123 tasks)
 
 - Signal pass rate: **100%** (all expected signals across all rotated scenes)

--- a/scripts/ci/check-bench-gate.mjs
+++ b/scripts/ci/check-bench-gate.mjs
@@ -41,14 +41,7 @@ if (report.scenariosFailed > 0) {
   failures.push(`${report.scenariosFailed} scenario run(s) failed:\n    ${failed.join("\n    ")}`);
 }
 if (report.signalPassRate < 1) {
-  const worst = Object.entries(report.signalsByKind ?? {})
-    .sort((a, b) => a[1].passRate - b[1].passRate)
-    .slice(0, 5)
-    .map(([kind, a]) => `${kind} ${(a.passRate * 100).toFixed(0)}% (${a.passed}/${a.total})`);
-  failures.push(
-    `signal pass rate ${(report.signalPassRate * 100).toFixed(1)}% < 100%` +
-      (worst.length ? `\n  worst kinds:\n    ${worst.join("\n    ")}` : ""),
-  );
+  failures.push(`signal pass rate ${(report.signalPassRate * 100).toFixed(1)}% < 100%`);
 }
 
 console.log(

--- a/scripts/ci/check-bench-gate.mjs
+++ b/scripts/ci/check-bench-gate.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * PR-gate assertion over a bench-report-v1 JSON file.
+ *
+ * Fails (exit 1) when:
+ *  - any scenario run failed outright, or
+ *  - the aggregate signal pass rate is below 1.0.
+ *
+ * The repo's iteration discipline requires expected signals to hold at
+ * 100%; rule-judge axis scores are advisory until the judge passes its
+ * kappa calibration gate, so they are NOT gated here.
+ *
+ * Usage: node scripts/ci/check-bench-gate.mjs <bench-report.json>
+ */
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) {
+  console.error("usage: node scripts/ci/check-bench-gate.mjs <bench-report.json>");
+  process.exit(2);
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(path, "utf8"));
+} catch (err) {
+  console.error(`cannot read bench report at ${path}: ${err.message}`);
+  process.exit(2);
+}
+
+if (report.version !== "bench-report-v1") {
+  console.error(`unexpected report version: ${report.version}`);
+  process.exit(2);
+}
+
+const failures = [];
+if (report.scenariosFailed > 0) {
+  const failed = (report.perScenario ?? [])
+    .filter(s => s.failed)
+    .map(s => `${s.id}: ${s.failed}`);
+  failures.push(`${report.scenariosFailed} scenario run(s) failed:\n    ${failed.join("\n    ")}`);
+}
+if (report.signalPassRate < 1) {
+  const worst = Object.entries(report.signalsByKind ?? {})
+    .sort((a, b) => a[1].passRate - b[1].passRate)
+    .slice(0, 5)
+    .map(([kind, a]) => `${kind} ${(a.passRate * 100).toFixed(0)}% (${a.passed}/${a.total})`);
+  failures.push(
+    `signal pass rate ${(report.signalPassRate * 100).toFixed(1)}% < 100%` +
+      (worst.length ? `\n  worst kinds:\n    ${worst.join("\n    ")}` : ""),
+  );
+}
+
+console.log(
+  `bench gate: ${report.scenariosRun} scenarios, signal pass ${(report.signalPassRate * 100).toFixed(1)}%, probe pass ${(report.probePassRate * 100).toFixed(1)}%`,
+);
+
+if (failures.length > 0) {
+  console.error(`\nBENCH GATE FAILED:\n  ${failures.join("\n  ")}`);
+  process.exit(1);
+}
+console.log("BENCH GATE PASSED");

--- a/scripts/ci/check-bench-gate.mjs
+++ b/scripts/ci/check-bench-gate.mjs
@@ -10,7 +10,11 @@
  * 100%; rule-judge axis scores are advisory until the judge passes its
  * kappa calibration gate, so they are NOT gated here.
  *
- * Usage: node scripts/ci/check-bench-gate.mjs <bench-report.json> [expectedIdsCsv]
+ * Usage: node scripts/ci/check-bench-gate.mjs [--skip-signal-gate] <bench-report.json> [expectedIdsCsv]
+ *
+ * --skip-signal-gate: assert only structural sanity (no scenario run
+ * hard-failed, expected ids present). Used for real-model runs where
+ * signal rates legitimately vary; the offline gate keeps the 100% bar.
  *
  * When expectedIdsCsv is provided, every id must appear in the report's
  * perScenario list — protects against silent coverage shrink when a
@@ -18,9 +22,11 @@
  */
 import { readFileSync } from "node:fs";
 
-const path = process.argv[2];
+const skipSignalGate = process.argv.includes("--skip-signal-gate");
+const positional = process.argv.slice(2).filter(a => !a.startsWith("--"));
+const path = positional[0];
 if (!path) {
-  console.error("usage: node scripts/ci/check-bench-gate.mjs <bench-report.json> [expectedIdsCsv]");
+  console.error("usage: node scripts/ci/check-bench-gate.mjs [--skip-signal-gate] <bench-report.json> [expectedIdsCsv]");
   process.exit(2);
 }
 
@@ -44,11 +50,11 @@ if (report.scenariosFailed > 0) {
     .map(s => `${s.id}: ${s.failed}`);
   failures.push(`${report.scenariosFailed} scenario run(s) failed:\n    ${failed.join("\n    ")}`);
 }
-if (report.signalPassRate < 1) {
+if (!skipSignalGate && report.signalPassRate < 1) {
   failures.push(`signal pass rate ${(report.signalPassRate * 100).toFixed(1)}% < 100%`);
 }
 
-const expectedIds = (process.argv[3] ?? "").split(",").map(s => s.trim()).filter(Boolean);
+const expectedIds = (positional[1] ?? "").split(",").map(s => s.trim()).filter(Boolean);
 if (expectedIds.length > 0) {
   // Variant-expanded ids carry a __vN suffix (e.g. motive_gossip__v2);
   // match on the base id before the suffix.

--- a/scripts/ci/check-bench-gate.mjs
+++ b/scripts/ci/check-bench-gate.mjs
@@ -10,13 +10,17 @@
  * 100%; rule-judge axis scores are advisory until the judge passes its
  * kappa calibration gate, so they are NOT gated here.
  *
- * Usage: node scripts/ci/check-bench-gate.mjs <bench-report.json>
+ * Usage: node scripts/ci/check-bench-gate.mjs <bench-report.json> [expectedIdsCsv]
+ *
+ * When expectedIdsCsv is provided, every id must appear in the report's
+ * perScenario list — protects against silent coverage shrink when a
+ * scenario id gets renamed out of the requested slice.
  */
 import { readFileSync } from "node:fs";
 
 const path = process.argv[2];
 if (!path) {
-  console.error("usage: node scripts/ci/check-bench-gate.mjs <bench-report.json>");
+  console.error("usage: node scripts/ci/check-bench-gate.mjs <bench-report.json> [expectedIdsCsv]");
   process.exit(2);
 }
 
@@ -42,6 +46,19 @@ if (report.scenariosFailed > 0) {
 }
 if (report.signalPassRate < 1) {
   failures.push(`signal pass rate ${(report.signalPassRate * 100).toFixed(1)}% < 100%`);
+}
+
+const expectedIds = (process.argv[3] ?? "").split(",").map(s => s.trim()).filter(Boolean);
+if (expectedIds.length > 0) {
+  // Variant-expanded ids carry a __vN suffix (e.g. motive_gossip__v2);
+  // match on the base id before the suffix.
+  const seen = new Set(
+    (report.perScenario ?? []).map(s => s.id.split("__")[0]),
+  );
+  const missing = expectedIds.filter(id => !seen.has(id));
+  if (missing.length > 0) {
+    failures.push(`expected scenario id(s) missing from the run: ${missing.join(", ")}`);
+  }
 }
 
 console.log(


### PR DESCRIPTION
## What

Adds the recurring benchmark tier that complements the fast per-PR gate:

- `.github/workflows/benchmark.yml` runs weekly (Mondays 03:00 UTC) and on demand via `workflow_dispatch`: build → lint → tests → **full 123-task mock + rule-judge suite** (deterministic, offline, no model servers) → 100%-signals assertion → report artifact named per run, so quality trends become trackable over time instead of living in someone's session memory.
- The dispatch input exposes an explicit opt-in `judge=llm` mode for self-hosted runners that have model servers and keys configured — hosted CI stays offline by design; the deep LLM-judged narrative run gets a designed-in slot without wiring any live model into GitHub-hosted infrastructure.
- Reuses the shared bench-gate assertion script (this branch stacks on the PR-gate workflow branch; merge that one first).
- Report path uses an absolute workspace path (pnpm `--filter` executes inside the package dir); artifact upload is conditioned on report existence.

## Validation

- Full local reproduction: 123 scenarios, 0 failed, signal pass 100%, `BENCH GATE PASSED`.
- Workflow YAML validated; both dispatch branches (`rule` default / `llm` opt-in) reviewed.