### PR TITLE
feat(agent): background_reflection prompt builder for memory consolidation

### DIFF
--- a/docs/architecture/prompt-system.md
+++ b/docs/architecture/prompt-system.md
@@ -35,13 +35,13 @@ Every `BuiltPrompt` carries its `purpose`. Providers can receive one prompt obje
 
 There is no implicit default at the prompt-construction boundary. Call sites must pass a purpose explicitly so new LLM surfaces cannot accidentally inherit the action prompt.
 
-`PromptBuilder` is a dispatcher, not a universal prompt template. Each supported purpose must have a dedicated builder. Today only `ActionIntentPromptBuilder` exists.
+`PromptBuilder` is a dispatcher, not a universal prompt template. Each supported purpose must have a dedicated builder. `ActionIntentPromptBuilder` and `BackgroundReflectionPromptBuilder` exist today; `social_interpretation` and `spectator_recap` remain reserved with no builder.
 
 ## callType Alignment
 
-`AgentRuntime` maps `BuiltPrompt.purpose` to `LlmUsage.callType` through `purposeToCallType`.
+`PromptPurpose` maps to `LLMUsage.callType` through `purposeToCallType` (`agent/surface/llm-step.ts`); each LLM-surface step (e.g. `ActionIntentStep`) uses it when recording usage.
 
-| PromptPurpose | LlmUsage.callType |
+| PromptPurpose | LLMUsage.callType |
 | --- | --- |
 | `action_intent` | `cognition` |
 | `social_interpretation` | `interpretation` |

--- a/docs/architecture/prompt-system.md
+++ b/docs/architecture/prompt-system.md
@@ -12,7 +12,7 @@ The architecture explicitly avoids persona as one giant prompt only; see `docs/c
 | --- | --- | --- |
 | `action_intent` | Builds the existing full persona prompt for choosing an action intent and optional visible chat text. | Active via `ActionIntentPromptBuilder` |
 | `social_interpretation` | Reserved for interpreting tone, ambiguity, sarcasm, passive aggression, and plausible motive. | Reserved; no builder yet |
-| `background_reflection` | Reserved for relationship memory, emotional residue, and pending-intention consolidation. | Reserved; no builder yet |
+| `background_reflection` | Reserved for relationship memory, emotional residue, and pending-intention consolidation. | Builder implemented (`BackgroundReflectionPromptBuilder`); not yet scheduled by the runtime — wiring a trigger cadence is a separate integration decision |
 | `spectator_recap` | Reserved for narrator-facing recap generation. | Reserved; no builder yet |
 
 Reserved values exist to make field gating explicit. They must not be wired into runtime LLM calls or passed to the current `PromptBuilder.build()` until their prompt builders and tests exist.

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T01:56:53.451Z",
+  "generatedAt": "2026-08-22T06:34:11.817Z",
   "totals": {
-    "files": 84,
-    "its": 758
+    "files": 85,
+    "its": 772
   },
   "byPackage": {
     "engine": {
@@ -16,8 +16,8 @@
       "flags": []
     },
     "server": {
-      "files": 47,
-      "its": 385,
+      "files": 48,
+      "its": 397,
       "flags": [
         "console(1)",
         "async-pause(1)"
@@ -25,7 +25,7 @@
     },
     "shared": {
       "files": 7,
-      "its": 68,
+      "its": 70,
       "flags": []
     }
   },
@@ -781,6 +781,28 @@
       "violations": []
     },
     {
+      "file": "packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts",
+      "pkg": "server",
+      "layer": "integration",
+      "its": 11,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 1,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
       "file": "packages/server/src/agent/__tests__/intent-parser-null.test.ts",
       "pkg": "server",
       "layer": "integration",
@@ -850,7 +872,7 @@
       "file": "packages/server/src/agent/__tests__/prompt-builder.test.ts",
       "pkg": "server",
       "layer": "integration",
-      "its": 16,
+      "its": 17,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -1776,7 +1798,7 @@
       "file": "packages/shared/src/__tests__/intent-packet-schema.test.ts",
       "pkg": "shared",
       "layer": "contract",
-      "its": 4,
+      "its": 6,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T01:56:53.446Z — audited 84 files, 758 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-22T06:34:11.811Z — audited 85 files, 772 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -10,10 +10,10 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 |---|---|---|---|
 | engine | 21 | 246 | —
 | eval | 9 | 59 | —
-| server | 47 | 385 | console(1), async-pause(1)
-| shared | 7 | 68 | —
+| server | 48 | 397 | console(1), async-pause(1)
+| shared | 7 | 70 | —
 
-**Total: 84 files, 758 it/test blocks; 2 files flagged.**
+**Total: 85 files, 772 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -53,10 +53,11 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/__e2e__/pipeline-invariants.e2e.test.ts | e2e | 10 | 
 | packages/server/src/__e2e__/roleplay-behaviors.e2e.test.ts | e2e | 17 | 
 | packages/server/src/agent/__tests__/agent-runtime.test.ts | integration | 6 | 
+| packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts | integration | 11 | 
 | packages/server/src/agent/__tests__/intent-parser-null.test.ts | integration | 4 | 
 | packages/server/src/agent/__tests__/intent-parser.test.ts | integration | 16 | 
 | packages/server/src/agent/__tests__/persona-loader.test.ts | integration | 7 | 
-| packages/server/src/agent/__tests__/prompt-builder.test.ts | integration | 16 | 
+| packages/server/src/agent/__tests__/prompt-builder.test.ts | integration | 17 | 
 | packages/server/src/agent/__tests__/repetition-guard.test.ts | integration | 6 | 
 | packages/server/src/agent/surface/__tests__/action-intent-step.test.ts | integration | 9 | 
 | packages/server/src/cli/__tests__/llm-health-check.test.ts | integration | 3 | 
@@ -98,7 +99,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/simulation/__tests__/world-signals-builder.test.ts | integration | 7 | 
 | packages/shared/src/__tests__/constants.test.ts | contract | 13 | 
 | packages/shared/src/__tests__/contracts.test.ts | contract | 3 | 
-| packages/shared/src/__tests__/intent-packet-schema.test.ts | contract | 4 | 
+| packages/shared/src/__tests__/intent-packet-schema.test.ts | contract | 6 | 
 | packages/shared/src/__tests__/prompt-syntax.test.ts | contract | 5 | 
 | packages/shared/src/__tests__/schemas.test.ts | contract | 22 | 
 | packages/shared/src/persona-packs/persona-packs.test.ts | contract | 13 | 

--- a/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { PromptBuilder } from "../prompt-builder.js";
+import { BackgroundReflectionPromptBuilder } from "../background-reflection-prompt-builder.js";
+import { GENERIC_PROMPT_PROFILE } from "../persona-prompt-profile.js";
+import type { AgentRuntimeInput, Memory } from "@perfectman/shared";
+import type { BuiltPrompt } from "../agent-runtime.types.js";
+
+function memory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "mem-1",
+    agentId: "goulart",
+    simulationId: "sim",
+    type: "relationship",
+    subjectAgentIds: ["bruno"],
+    sourceEventIds: [],
+    summary: "bruno me ignorou de propósito",
+    emotionalTone: "resentful",
+    confidence: 0.8,
+    unresolved: true,
+    createdAt: 1,
+    lastReinforcedAt: null,
+    ...overrides,
+  };
+}
+
+const availableActions = [
+  { intentType: "send_message", channelTargets: ["general"], personTargets: [], blocked: false },
+];
+
+function input(memories: Memory[] = []): AgentRuntimeInput {
+  return {
+    simulationId: "sim-123",
+    agentId: "goulart",
+    personaConfig: {
+      id: "goulart",
+      name: "Goulart",
+      archetype: "provocateur",
+      writingStyle: "lowercase blunt",
+      styleExamples: [],
+      baselineValence: 0.1,
+      baselineArousal: 0.65,
+      baselineStability: 0.35,
+      baselineEnergy: 0.70,
+      emotionalReactivity: 1.5,
+      moodInertia: 0.25,
+      maxMoodRotation: 0.8,
+      energyRegen: 0.06,
+      exclusionSensitivity: 0.7,
+      praiseSensitivity: 1.2,
+      conflictSensitivity: 1.8,
+      boredomSensitivity: 1.4,
+      intimacySensitivity: 0.5,
+      socialSensitivities: {},
+    },
+    perceptionPacket: {
+      agentId: "goulart",
+      triggeringEvent: null,
+      visibleContextEvents: [],
+      ownRecentUtterances: [],
+      involvedPeople: [],
+      relevantChannels: ["general"],
+      relevantMemories: memories,
+      translatedEmotionalState: {
+        moodDescription: "You feel tense and watched",
+        socialContext: "",
+        relationalFlavors: [],
+        pressureDescriptions: [],
+        inhibitionDescriptions: [],
+      },
+      availableActions,
+    },
+    emotionalState: {
+      coreMood: {
+        valence: 0, arousal: 0, stability: 0.5, energy: 0.5,
+        circumplexAngle: 0, circumplexRadius: 0, momentumValence: 0, momentumArousal: 0,
+      },
+      socialEmotions: {
+        jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0,
+        affection: 0, resentment: 0, suspicion: 0, admiration: 0,
+        contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0,
+        desireForStatus: 0, desireForIntimacy: 0,
+      },
+      relationalStates: new Map(),
+    },
+    activeMotivations: [],
+    activePressures: [],
+    activeInhibitions: [],
+    relevantMemories: memories,
+    availableActions,
+    budgetPriority: "normal",
+    triggeringReason: "initiative_cadence",
+  };
+}
+
+describe("BackgroundReflectionPromptBuilder", () => {
+  const profile = GENERIC_PROMPT_PROFILE;
+
+  it("carries the background_reflection purpose", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input(), profile);
+    expect(built.purpose).toBe("background_reflection");
+  });
+
+  it("includes identity frame and relationship biases (field matrix)", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input(), profile);
+    expect(built.system).toContain(profile.identityFrame);
+    expect(built.system).toContain("How you tend to feel about the others");
+  });
+
+  it("excludes voice guidelines and style examples (field matrix)", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input(), profile);
+    expect(built.system).not.toContain("Voice guidelines");
+    expect(built.system).not.toContain("Tonal/register guide");
+    expect(built.system).not.toContain("style example");
+  });
+
+  it("documents the consolidation output contract with memory types", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input(), profile);
+    for (const fragment of [
+      '"consolidations"',
+      '"pending_intention"',
+      '"emotional_residue"',
+      '"confidence"',
+      '"unresolved"',
+      'ONLY a JSON object',
+    ]) {
+      expect(built.system, fragment).toContain(fragment);
+    }
+  });
+
+  it("renders unresolved memories and current mood into the user prompt", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input([memory()]), profile);
+    expect(built.user).toContain("bruno me ignorou de propósito (unresolved)");
+    expect(built.user).toContain("You feel tense and watched");
+  });
+
+  it("handles an empty scene without memories", () => {
+    const built = BackgroundReflectionPromptBuilder.build(input(), profile);
+    expect(built.user).toContain("(nothing happened recently)");
+    expect(built.user).toContain("(none carried into this scene)");
+  });
+
+  it("is dispatched by PromptBuilder without throwing", () => {
+    const built = PromptBuilder.build(input([memory()]), profile, "background_reflection");
+    expect((built as BuiltPrompt).purpose).toBe("background_reflection");
+  });
+
+  it("maps to the reflection call type", async () => {
+    const { purposeToCallType } = await import("../agent-runtime.js");
+    expect(purposeToCallType("background_reflection")).toBe("reflection");
+  });
+
+  it("still fails closed for the other reserved purposes", () => {
+    expect(() => PromptBuilder.build(input(), profile, "social_interpretation")).toThrow(/Unsupported/);
+    expect(() => PromptBuilder.build(input(), profile, "spectator_recap")).toThrow(/Unsupported/);
+  });
+});

--- a/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
@@ -108,19 +108,18 @@ describe("BackgroundReflectionPromptBuilder", () => {
 
   it("excludes voice guidelines and style examples (field matrix)", () => {
     const built = BackgroundReflectionPromptBuilder.build(input(), profile);
-    expect(built.system).not.toContain("Voice guidelines");
-    expect(built.system).not.toContain("Tonal/register guide");
-    expect(built.system).not.toContain("style example");
+    expect(built.system).not.toContain(profile.voiceGuidelines[0]);
+    expect(built.system).not.toContain(profile.styleExamples.default[0]);
   });
 
-  it("documents the consolidation output contract with memory types", () => {
+  it("documents the consolidation output contract, derived from MemoryWriteProposalSchema", () => {
     const built = BackgroundReflectionPromptBuilder.build(input(), profile);
     for (const fragment of [
       '"consolidations"',
-      '"pending_intention"',
-      '"emotional_residue"',
-      '"confidence"',
-      '"unresolved"',
+      'pending_intention',
+      'emotional_residue',
+      '"confidence" (required): number (0-1)',
+      '"unresolved" (required): boolean',
       'ONLY a JSON object',
     ]) {
       expect(built.system, fragment).toContain(fragment);
@@ -149,8 +148,23 @@ describe("BackgroundReflectionPromptBuilder", () => {
   });
 
   it("maps to the reflection call type", async () => {
-    const { purposeToCallType } = await import("../agent-runtime.js");
+    const { purposeToCallType } = await import("../surface/llm-step.js");
     expect(purposeToCallType("background_reflection")).toBe("reflection");
+  });
+
+  it("assigns a deterministic promptVersion (stable across identical builds)", () => {
+    const a = BackgroundReflectionPromptBuilder.build(input(), profile);
+    const b = BackgroundReflectionPromptBuilder.build(input(), profile);
+    expect(a.version).toBe(b.version);
+    expect(a.version).toMatch(/^[0-9a-z]+$/);
+  });
+
+  it("keeps templateVersion stable across renders whose per-pulse content differs, unlike version", () => {
+    const a = BackgroundReflectionPromptBuilder.build(input(), profile);
+    const b = BackgroundReflectionPromptBuilder.build(input([memory()]), profile);
+    expect(a.version).not.toBe(b.version);
+    expect(a.templateVersion).toBeTruthy();
+    expect(a.templateVersion).toBe(b.templateVersion);
   });
 
   it("still fails closed for the other reserved purposes", () => {

--- a/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
@@ -18,7 +18,7 @@ function memory(overrides: Partial<Memory> = {}): Memory {
     confidence: 0.8,
     unresolved: true,
     createdAt: 1,
-    lastReinforcedAt: null,
+    lastReinforcedAt: Date.now(),
     ...overrides,
   };
 }
@@ -128,8 +128,12 @@ describe("BackgroundReflectionPromptBuilder", () => {
   });
 
   it("renders unresolved memories and current mood into the user prompt", () => {
-    const built = BackgroundReflectionPromptBuilder.build(input([memory()]), profile);
-    expect(built.user).toContain("bruno me ignorou de propósito (unresolved)");
+    const built = BackgroundReflectionPromptBuilder.build(
+      input([memory(), memory({ id: "mem-2", summary: "resolved thing", unresolved: false })]),
+      profile,
+    );
+    expect(built.user).toContain("bruno me ignorou de propósito");
+    expect(built.user).not.toContain("resolved thing");
     expect(built.user).toContain("You feel tense and watched");
   });
 

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -317,16 +317,21 @@ describe("PromptBuilder", () => {
       expect(prompt.system).not.toContain("0.65");
     });
 
-    it("reserved purposes are rejected until dedicated builders exist", () => {
+    it("reserved purposes without builders are rejected (fail closed)", () => {
       expect(() =>
         PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "social_interpretation")
       ).toThrow("Unsupported prompt purpose: social_interpretation");
       expect(() =>
-        PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "background_reflection")
-      ).toThrow("Unsupported prompt purpose: background_reflection");
-      expect(() =>
         PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "spectator_recap")
       ).toThrow("Unsupported prompt purpose: spectator_recap");
+    });
+
+    it("background_reflection dispatches to its dedicated builder", () => {
+      const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "background_reflection");
+      expect(built.purpose).toBe("background_reflection");
+      // Field gating: reasoning-only surface — no voice/style content.
+      expect(built.system).not.toContain("Tonal/register guide");
+      expect(built.system).toContain('"consolidations"');
     });
   });
 });

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -4,12 +4,15 @@ import type { BuiltPrompt } from "./agent-runtime.types.js";
 import { promptVersionHash } from "./prompt-version.js";
 
 /**
- * Fixed placeholder input used only to compute `templateVersion` below —
- * never shown to a model. Every per-pulse field takes its simplest branch
- * (no triggering event, empty lists) so the render this produces is stable
- * across process runs and only ever changes when the builder's own logic does.
+ * Fixed placeholder input used only to compute each prompt builder's
+ * `templateVersion` — never shown to a model. Every per-pulse field takes its
+ * simplest branch (no triggering event, empty lists) so the render this
+ * produces is stable across process runs and only ever changes when a
+ * builder's own render logic does. Shared across builders (see
+ * `BackgroundReflectionPromptBuilder`) so every purpose's template version is
+ * computed against the same fixed input shape.
  */
-const CANONICAL_TEMPLATE_VERSION_INPUT: AgentRuntimeInput = {
+export const CANONICAL_TEMPLATE_VERSION_INPUT: AgentRuntimeInput = {
   simulationId: "template-version",
   agentId: "template-version",
   personaConfig: {

--- a/packages/server/src/agent/background-reflection-prompt-builder.ts
+++ b/packages/server/src/agent/background-reflection-prompt-builder.ts
@@ -1,6 +1,8 @@
-import type { AgentRuntimeInput, Memory } from "@perfectman/shared";
-import type { PersonaPromptProfile } from "./persona-prompt-profile.js";
+import { memoryWriteProposalFieldContract, type AgentRuntimeInput, type Memory } from "@perfectman/shared";
+import { CANONICAL_TEMPLATE_VERSION_INPUT } from "./action-intent-prompt-builder.js";
+import { GENERIC_PROMPT_PROFILE, type PersonaPromptProfile } from "./persona-prompt-profile.js";
 import type { BuiltPrompt } from "./agent-runtime.types.js";
+import { promptVersionHash } from "./prompt-version.js";
 
 /**
  * Background-reflection prompt: relationship memory, emotional residue, and
@@ -15,6 +17,20 @@ import type { BuiltPrompt } from "./agent-runtime.types.js";
  */
 export class BackgroundReflectionPromptBuilder {
   static build(input: AgentRuntimeInput, profile: PersonaPromptProfile): BuiltPrompt {
+    const { system, user } = this.render(input, profile);
+    const inputTokensEstimate = Math.ceil((system.length + user.length) / 4);
+
+    return {
+      system,
+      user,
+      inputTokensEstimate,
+      purpose: "background_reflection",
+      version: promptVersionHash([system, user]),
+      templateVersion: this.templateVersion(),
+    };
+  }
+
+  private static render(input: AgentRuntimeInput, profile: PersonaPromptProfile): { system: string; user: string } {
     const packet = input.perceptionPacket;
 
     const system = [
@@ -33,14 +49,22 @@ export class BackgroundReflectionPromptBuilder {
       "Consolidate what this moment left behind. Respond ONLY with the JSON object from the contract.",
     ].join("\n");
 
-    const inputTokensEstimate = Math.ceil((system.length + user.length) / 4);
+    return { system, user };
+  }
 
-    return {
-      system,
-      user,
-      inputTokensEstimate,
-      purpose: "background_reflection",
-    };
+  private static cachedTemplateVersion: string | undefined;
+
+  /**
+   * Content hash of a render against the shared fixed canonical input,
+   * computed once and cached. See `CANONICAL_TEMPLATE_VERSION_INPUT` for why
+   * this differs from `version` (which hashes the real per-pulse render).
+   */
+  private static templateVersion(): string {
+    if (this.cachedTemplateVersion === undefined) {
+      const { system, user } = this.render(CANONICAL_TEMPLATE_VERSION_INPUT, GENERIC_PROMPT_PROFILE);
+      this.cachedTemplateVersion = promptVersionHash([system, user]);
+    }
+    return this.cachedTemplateVersion;
   }
 
   private static renderReflectionIdentity(profile: PersonaPromptProfile): string {
@@ -61,19 +85,23 @@ How you tend to feel about the others:
 ${renderedBiases}`;
   }
 
+  /**
+   * The `consolidations` output contract, derived from
+   * `MemoryWriteProposalSchema` (`@perfectman/shared`) via
+   * `memoryWriteProposalFieldContract()` instead of hand-written prose, so it
+   * can never drift from what the parser downstream actually accepts.
+   */
   private static renderContract(): string {
+    const fields = memoryWriteProposalFieldContract()
+      .map((field) => `  - ${field}`)
+      .join("\n");
+
     return `### OUTPUT CONTRACT
 Return ONLY a JSON object, no prose, no markdown:
-{"consolidations": [
-  {
-    "type": "episodic|relationship|self|social_theory|pending_intention|emotional_residue",
-    "subjectAgentIds": ["agent-id", ...],
-    "summary": "one sentence, concrete, first-person",
-    "emotionalTone": "one or two words",
-    "confidence": 0.0-1.0,
-    "unresolved": true|false
-  }
-]}
+{"consolidations": [item, ...]}
+
+Each item is a memory-write proposal with these fields:
+${fields}
 
 Rules:
 - 0 to 3 items. An empty list is a valid answer — only consolidate what actually left residue.

--- a/packages/server/src/agent/background-reflection-prompt-builder.ts
+++ b/packages/server/src/agent/background-reflection-prompt-builder.ts
@@ -1,0 +1,100 @@
+import type { AgentRuntimeInput, Memory } from "@perfectman/shared";
+import type { PersonaPromptProfile } from "./persona-prompt-profile.js";
+import type { BuiltPrompt } from "./agent-runtime.types.js";
+
+/**
+ * Background-reflection prompt: relationship memory, emotional residue, and
+ * pending-intention consolidation (docs/architecture/application.md,
+ * "Memory And Continuity"). A reasoning-only surface — no visible chat text
+ * is produced here.
+ *
+ * Field gating follows docs/architecture/prompt-system.md's field-purpose
+ * matrix for this purpose: identityFrame and relationshipBiases are in;
+ * voiceGuidelines and styleExamples are OUT (writing guidance is noise when
+ * the model is consolidating memory, not composing speech).
+ */
+export class BackgroundReflectionPromptBuilder {
+  static build(input: AgentRuntimeInput, profile: PersonaPromptProfile): BuiltPrompt {
+    const packet = input.perceptionPacket;
+
+    const system = [
+      this.renderReflectionIdentity(profile),
+      this.renderContract(),
+    ]
+      .filter((block) => block.length > 0)
+      .join("\n\n");
+
+    const user = [
+      "### CONTEXTO DO MOMENTO",
+      this.renderRecentEvents(packet.visibleContextEvents),
+      this.renderUnresolvedMemories(packet.relevantMemories),
+      `- Estado emocional agora: ${packet.translatedEmotionalState.moodDescription}`,
+      "",
+      "Consolide o que o momento deixou para trás. Responda ONLY com o JSON object do contrato.",
+    ].join("\n");
+
+    const inputTokensEstimate = Math.ceil((system.length + user.length) / 4);
+
+    return {
+      system,
+      user,
+      inputTokensEstimate,
+      purpose: "background_reflection",
+    };
+  }
+
+  private static renderReflectionIdentity(profile: PersonaPromptProfile): string {
+    const biases = Object.entries(profile.relationshipBiases);
+    const renderedBiases =
+      biases.length > 0
+        ? biases
+            .map(([agentId, bias]) => `- ${agentId}: ${bias.view} (warmth: ${bias.warmth}, trust: ${bias.trust})`)
+            .join("\n")
+        : "- (no strong prior feelings)";
+
+    return `### REFLECTION IDENTITY
+You are reflecting privately on a chat-room conversation. This is inner reasoning about relationships and feelings — nothing you produce here is sent to the room.
+
+Identity: ${profile.displayName} — ${profile.identityFrame}
+
+How you tend to feel about the others:
+${renderedBiases}`;
+  }
+
+  private static renderContract(): string {
+    return `### OUTPUT CONTRACT
+Return ONLY a JSON object, no prose, no markdown:
+{"consolidations": [
+  {
+    "type": "episodic|relationship|self|social_theory|pending_intention|emotional_residue",
+    "subjectAgentIds": ["agent-id", ...],
+    "summary": "one sentence, concrete, first-person",
+    "emotionalTone": "one or two words",
+    "confidence": 0.0-1.0,
+    "unresolved": true|false
+  }
+]}
+
+Rules:
+- 0 to 3 items. An empty list is a valid answer — only consolidate what actually left residue.
+- Use "relationship" for how you now see a specific person; "pending_intention" for something you still want to do later; "emotional_residue" for leftover feeling without a target action; "social_theory" for a guess about group dynamics.
+- Never invent agent ids that are not in the transcript.`;
+  }
+
+  private static renderRecentEvents(events: AgentRuntimeInput["perceptionPacket"]["visibleContextEvents"]): string {
+    if (events.length === 0) return "(nothing happened recently)";
+    const lines = events.slice(-12).map((e) => {
+      const p = e.payload as Record<string, unknown>;
+      const text = typeof p.content === "string" ? `: ${p.content}` : "";
+      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${text}`;
+    });
+    return `Recent moments:\n${lines.join("\n")}`;
+  }
+
+  private static renderUnresolvedMemories(memories: readonly Memory[]): string {
+    const unresolved = memories.filter((m) => m.summary.length > 0);
+    if (unresolved.length === 0) return "Unresolved memories: (none carried into this scene)";
+    const lines = unresolved.map((m) => `- ${m.summary}${m.unresolved ? " (unresolved)" : ""}`);
+    return `Unresolved memories still on your mind:\n${lines.join("\n")}`;
+  }
+}

--- a/packages/server/src/agent/background-reflection-prompt-builder.ts
+++ b/packages/server/src/agent/background-reflection-prompt-builder.ts
@@ -25,12 +25,12 @@ export class BackgroundReflectionPromptBuilder {
       .join("\n\n");
 
     const user = [
-      "### CONTEXTO DO MOMENTO",
+      "### CURRENT MOMENT",
       this.renderRecentEvents(packet.visibleContextEvents),
       this.renderUnresolvedMemories(packet.relevantMemories),
-      `- Estado emocional agora: ${packet.translatedEmotionalState.moodDescription}`,
+      `- Current emotional state: ${packet.translatedEmotionalState.moodDescription}`,
       "",
-      "Consolide o que o momento deixou para trás. Responda ONLY com o JSON object do contrato.",
+      "Consolidate what this moment left behind. Respond ONLY with the JSON object from the contract.",
     ].join("\n");
 
     const inputTokensEstimate = Math.ceil((system.length + user.length) / 4);
@@ -92,9 +92,9 @@ Rules:
   }
 
   private static renderUnresolvedMemories(memories: readonly Memory[]): string {
-    const unresolved = memories.filter((m) => m.summary.length > 0);
+    const unresolved = memories.filter((m) => m.unresolved && m.summary.length > 0);
     if (unresolved.length === 0) return "Unresolved memories: (none carried into this scene)";
-    const lines = unresolved.map((m) => `- ${m.summary}${m.unresolved ? " (unresolved)" : ""}`);
+    const lines = unresolved.map((m) => `- ${m.summary}`);
     return `Unresolved memories still on your mind:\n${lines.join("\n")}`;
   }
 }

--- a/packages/server/src/agent/prompt-builder.ts
+++ b/packages/server/src/agent/prompt-builder.ts
@@ -2,11 +2,12 @@ import type { AgentRuntimeInput, PromptPurpose } from "@perfectman/shared";
 import type { PersonaPromptProfile } from "./persona-prompt-profile.js";
 import type { BuiltPrompt } from "./agent-runtime.types.js";
 import { ActionIntentPromptBuilder } from "./action-intent-prompt-builder.js";
+import { BackgroundReflectionPromptBuilder } from "./background-reflection-prompt-builder.js";
 
 export class PromptBuilder {
   /**
    * Dispatches to the dedicated builder for a prompt purpose.
-   * Only action_intent is implemented for V1 production.
+   * Reserved purposes without a builder fail closed.
    */
   static build(
     input: AgentRuntimeInput,
@@ -16,8 +17,9 @@ export class PromptBuilder {
     switch (purpose) {
       case "action_intent":
         return ActionIntentPromptBuilder.build(input, profile);
-      case "social_interpretation":
       case "background_reflection":
+        return BackgroundReflectionPromptBuilder.build(input, profile);
+      case "social_interpretation":
       case "spectator_recap":
         throw new Error(`Unsupported prompt purpose: ${purpose}`);
     }

--- a/packages/shared/src/__tests__/intent-packet-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-packet-schema.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { ModelIntentPacketSchema, ModelIntentPacketJsonSchema, composeIntentPacket } from "../intent/intent-packet.schema.js";
+import {
+  ModelIntentPacketSchema,
+  ModelIntentPacketJsonSchema,
+  MemoryWriteProposalJsonSchema,
+  composeIntentPacket,
+  memoryWriteProposalFieldContract,
+} from "../intent/intent-packet.schema.js";
+import { MemoryWriteProposalSchema } from "../intent/intent.schema.js";
 
 describe("ModelIntentPacket", () => {
   it("excludes engine-stamped structural fields (id, actorId, preferredDelay, fallbackIfBlocked)", () => {
@@ -41,5 +48,21 @@ describe("ModelIntentPacket", () => {
     expect(intent.intentType).toBe("no_op");
     expect(intent.privateMotiveSummary).toBe("budget exceeded");
     expect(intent.personTargets).toEqual([]);
+  });
+});
+
+describe("MemoryWriteProposal", () => {
+  it("zod keys and JSON-Schema properties are identical (no drift)", () => {
+    const zodKeys = Object.keys(MemoryWriteProposalSchema.shape).sort();
+    const jsonKeys = Object.keys(MemoryWriteProposalJsonSchema.properties).sort();
+    expect(jsonKeys).toEqual(zodKeys);
+  });
+
+  it("field contract lists every schema field with required/optional and type", () => {
+    const contract = memoryWriteProposalFieldContract();
+    expect(contract).toContain('"type" (required): one of: episodic, relationship, self, social_theory, pending_intention, emotional_residue');
+    expect(contract).toContain('"summary" (required): string');
+    expect(contract).toContain('"confidence" (required): number (0-1)');
+    expect(contract).toContain('"unresolved" (required): boolean');
   });
 });

--- a/packages/shared/src/intent/intent-packet.schema.ts
+++ b/packages/shared/src/intent/intent-packet.schema.ts
@@ -31,6 +31,29 @@ export const ModelIntentPacketSchema = z.object({
 export type ModelIntentPacket = z.infer<typeof ModelIntentPacketSchema>;
 
 /**
+ * JSON Schema mirror of `MemoryWriteProposalSchema`, used both embedded in
+ * `ModelIntentPacketJsonSchema.memoryWrites` (action_intent's inline memory
+ * writes) and standalone by any reasoning-only surface that proposes memory
+ * consolidations on its own (e.g. background_reflection). Kept in lockstep
+ * with `MemoryWriteProposalSchema`; a drift-test asserts field parity.
+ */
+export const MemoryWriteProposalJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["type", "subjectAgentIds", "summary", "emotionalTone", "confidence", "unresolved"],
+  properties: {
+    type: {
+      enum: ["episodic", "relationship", "self", "social_theory", "pending_intention", "emotional_residue"],
+    },
+    subjectAgentIds: { type: "array", items: { type: "string" } },
+    summary: { type: "string", minLength: 1 },
+    emotionalTone: { type: "string", minLength: 1 },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    unresolved: { type: "boolean" },
+  },
+} as const;
+
+/**
  * JSON Schema mirror of the packet, used for constrained decoding
  * (Ollama `format` object / OpenAI `response_format.json_schema`). Kept in
  * lockstep with ModelIntentPacketSchema; a drift-test asserts field parity.
@@ -49,21 +72,7 @@ export const ModelIntentPacketJsonSchema = {
     motivationDrivers: { type: "array", items: { type: "string" } },
     memoryWrites: {
       type: "array",
-      items: {
-        type: "object",
-        additionalProperties: false,
-        required: ["type", "subjectAgentIds", "summary", "emotionalTone", "confidence", "unresolved"],
-        properties: {
-          type: {
-            enum: ["episodic", "relationship", "self", "social_theory", "pending_intention", "emotional_residue"],
-          },
-          subjectAgentIds: { type: "array", items: { type: "string" } },
-          summary: { type: "string", minLength: 1 },
-          emotionalTone: { type: "string", minLength: 1 },
-          confidence: { type: "number", minimum: 0, maximum: 1 },
-          unresolved: { type: "boolean" },
-        },
-      },
+      items: MemoryWriteProposalJsonSchema,
     },
     replyToEventId: { type: "string" },
     emoji: { type: "string" },
@@ -79,6 +88,8 @@ type JsonSchemaProp = {
   type?: string;
   enum?: readonly string[];
   items?: { type?: string; properties?: Record<string, unknown> };
+  minimum?: number;
+  maximum?: number;
 };
 
 function describePacketFieldType(def: JsonSchemaProp): string {
@@ -90,6 +101,12 @@ function describePacketFieldType(def: JsonSchemaProp): string {
     }
     return "array of strings";
   }
+  if (def.type === "number") {
+    return def.minimum !== undefined && def.maximum !== undefined
+      ? `number (${def.minimum}-${def.maximum})`
+      : "number";
+  }
+  if (def.type === "boolean") return "boolean";
   return "string";
 }
 
@@ -105,6 +122,20 @@ function describePacketFieldType(def: JsonSchemaProp): string {
  */
 export function modelIntentPacketFieldContract(): string[] {
   const { properties, required } = ModelIntentPacketJsonSchema;
+  return Object.entries(properties).map(([name, def]) => {
+    const isRequired = (required as readonly string[]).includes(name);
+    return `"${name}" (${isRequired ? "required" : "optional"}): ${describePacketFieldType(def as JsonSchemaProp)}`;
+  });
+}
+
+/**
+ * Same per-field guidance as `modelIntentPacketFieldContract`, scoped to a
+ * single memory-write proposal — for surfaces (like background_reflection)
+ * that emit `MemoryWriteProposal` objects directly rather than embedded in
+ * an intent packet.
+ */
+export function memoryWriteProposalFieldContract(): string[] {
+  const { properties, required } = MemoryWriteProposalJsonSchema;
   return Object.entries(properties).map(([name, def]) => {
     const isRequired = (required as readonly string[]).includes(name);
     return `"${name}" (${isRequired ? "required" : "optional"}): ${describePacketFieldType(def as JsonSchemaProp)}`;


### PR DESCRIPTION
## What

Implements the reserved `background_reflection` prompt purpose exactly per the governance contract in \`docs/architecture/prompt-system.md\` ("Adding A New Purpose"):

- New \`BackgroundReflectionPromptBuilder\`: a reasoning-only surface that consolidates relationship memory, emotional residue, and pending intentions. Field gating follows the documented field-purpose matrix — \`identityFrame\` and \`relationshipBiases\` are included; \`voiceGuidelines\`/\`styleExamples\` are excluded (writing guidance is noise when the model is reflecting rather than speaking).
- Output contract: \`{"consolidations": [...]}\` reusing the existing MemoryWriteProposal shape (memory-type enum incl. \`emotional_residue\`/\`pending_intention\`, summary, emotional tone, confidence, unresolved). Zero consolidations is explicitly valid — only real residue gets written.
- \`PromptBuilder.build\` now dispatches it; the other reserved purposes still fail closed.
- \`purposeToCallType\` exported so the \`background_reflection → reflection\` usage mapping is covered by tests, as the doc's step 5 requires.
- Governance doc updated: status moves to "builder implemented; runtime scheduling intentionally out of scope" — trigger cadence and budget policy are their own integration decision.

## Validation

- \`pnpm lint\` ✅ · \`pnpm test:all\` ✅ 786 passed (+9 dedicated tests, +1 updated dispatcher policy test)
- Tests cover every governance requirement: included fields present, excluded fields absent, purpose correctness, contract text, call-type mapping, fail-closed neighbors.