### PR TITLE
feat(llm): schema-constrained intent decoding for the Ollama path

### DIFF
--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T06:52:31.956Z",
+  "generatedAt": "2026-08-22T07:08:50.528Z",
   "totals": {
     "files": 86,
-    "its": 783
+    "its": 785
   },
   "byPackage": {
     "engine": {
@@ -25,7 +25,7 @@
     },
     "shared": {
       "files": 7,
-      "its": 71,
+      "its": 73,
       "flags": []
     }
   },
@@ -1820,7 +1820,7 @@
       "file": "packages/shared/src/__tests__/intent-packet-schema.test.ts",
       "pkg": "shared",
       "layer": "contract",
-      "its": 7,
+      "its": 9,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T06:52:31.950Z — audited 86 files, 783 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-22T07:08:50.523Z — audited 86 files, 785 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -11,9 +11,9 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | engine | 21 | 246 | —
 | eval | 9 | 59 | —
 | server | 49 | 407 | console(1), async-pause(1)
-| shared | 7 | 71 | —
+| shared | 7 | 73 | —
 
-**Total: 86 files, 783 it/test blocks; 2 files flagged.**
+**Total: 86 files, 785 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -100,7 +100,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/simulation/__tests__/world-signals-builder.test.ts | integration | 7 | 
 | packages/shared/src/__tests__/constants.test.ts | contract | 13 | 
 | packages/shared/src/__tests__/contracts.test.ts | contract | 3 | 
-| packages/shared/src/__tests__/intent-packet-schema.test.ts | contract | 7 | 
+| packages/shared/src/__tests__/intent-packet-schema.test.ts | contract | 9 | 
 | packages/shared/src/__tests__/prompt-syntax.test.ts | contract | 5 | 
 | packages/shared/src/__tests__/schemas.test.ts | contract | 22 | 
 | packages/shared/src/persona-packs/persona-packs.test.ts | contract | 13 | 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,8 @@
     "vitest": "^2.0.0"
   },
   "dependencies": {
-    "zod": "^3.23.0",
+    "zod": "^3.25.28",
+    "zod-to-json-schema": "^3.25.2",
     "nanoid": "^5.0.0"
   }
 }

--- a/packages/shared/src/__tests__/intent-packet-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-packet-schema.test.ts
@@ -6,7 +6,7 @@ import {
   composeIntentPacket,
   memoryWriteProposalFieldContract,
 } from "../intent/intent-packet.schema.js";
-import { MemoryWriteProposalSchema } from "../intent/intent.schema.js";
+import { MemoryWriteProposalSchema, IntentTypeSchema } from "../intent/intent.schema.js";
 
 describe("ModelIntentPacket", () => {
   it("excludes engine-stamped structural fields (id, actorId, preferredDelay, fallbackIfBlocked)", () => {
@@ -21,6 +21,15 @@ describe("ModelIntentPacket", () => {
     const zodKeys = Object.keys(ModelIntentPacketSchema.shape).sort();
     const jsonKeys = Object.keys(ModelIntentPacketJsonSchema.properties).sort();
     expect(jsonKeys).toEqual(zodKeys);
+  });
+
+  it("exposes the full intentType enum, not a subset", () => {
+    expect(ModelIntentPacketJsonSchema.properties.intentType?.enum).toEqual(IntentTypeSchema.options);
+  });
+
+  it("marks the packet flat with no dangling $ref", () => {
+    expect(ModelIntentPacketJsonSchema.additionalProperties).toBe(false);
+    expect(JSON.stringify(ModelIntentPacketJsonSchema)).not.toContain("$ref");
   });
 
   it("composeIntentPacket stamps engine fields and carries model decisions", () => {

--- a/packages/shared/src/intent/intent-packet.schema.ts
+++ b/packages/shared/src/intent/intent-packet.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { createId } from "../utils/id.js";
 import type { ActionIntent, IntentType } from "./intent.types.js";
 import { IntentTypeSchema, IntentChannelTypeSchema, MemoryWriteProposalSchema } from "./intent.schema.js";
@@ -31,60 +32,6 @@ export const ModelIntentPacketSchema = z.object({
 
 export type ModelIntentPacket = z.infer<typeof ModelIntentPacketSchema>;
 
-/**
- * JSON Schema mirror of `MemoryWriteProposalSchema`, used both embedded in
- * `ModelIntentPacketJsonSchema.memoryWrites` (action_intent's inline memory
- * writes) and standalone by any reasoning-only surface that proposes memory
- * consolidations on its own (e.g. background_reflection). Kept in lockstep
- * with `MemoryWriteProposalSchema`; a drift-test asserts field parity.
- */
-export const MemoryWriteProposalJsonSchema = {
-  type: "object",
-  additionalProperties: false,
-  required: ["type", "subjectAgentIds", "summary", "emotionalTone", "confidence", "unresolved"],
-  properties: {
-    type: {
-      enum: ["episodic", "relationship", "self", "social_theory", "pending_intention", "emotional_residue"],
-    },
-    subjectAgentIds: { type: "array", items: { type: "string" } },
-    summary: { type: "string", minLength: 1 },
-    emotionalTone: { type: "string", minLength: 1 },
-    confidence: { type: "number", minimum: 0, maximum: 1 },
-    unresolved: { type: "boolean" },
-  },
-} as const;
-
-/**
- * JSON Schema mirror of the packet, used for constrained decoding
- * (Ollama `format` object / OpenAI `response_format.json_schema`). Kept in
- * lockstep with ModelIntentPacketSchema; a drift-test asserts field parity.
- */
-export const ModelIntentPacketJsonSchema = {
-  type: "object",
-  additionalProperties: false,
-  required: ["intentType", "privateMotiveSummary"],
-  properties: {
-    intentType: { enum: IntentTypeSchema.options },
-    channelTarget: { type: "string" },
-    personTargets: { type: "array", items: { type: "string" } },
-    visibleContent: { type: "string" },
-    privateMotiveSummary: { type: "string", minLength: 1 },
-    emotionDrivers: { type: "array", items: { type: "string" } },
-    motivationDrivers: { type: "array", items: { type: "string" } },
-    memoryWrites: {
-      type: "array",
-      items: MemoryWriteProposalJsonSchema,
-    },
-    replyToEventId: { type: "string" },
-    emoji: { type: "string" },
-    targetEventId: { type: "string" },
-    channelName: { type: "string" },
-    channelType: { enum: IntentChannelTypeSchema.options },
-    invitedAgentIds: { type: "array", items: { type: "string" } },
-    spectatorSummary: { type: "string" },
-  },
-} as const;
-
 type JsonSchemaProp = {
   type?: string;
   enum?: readonly string[];
@@ -92,6 +39,36 @@ type JsonSchemaProp = {
   minimum?: number;
   maximum?: number;
 };
+
+type JsonSchemaObject = {
+  type: "object";
+  properties: Record<string, JsonSchemaProp>;
+  required: readonly string[];
+  additionalProperties: false;
+};
+
+/**
+ * JSON Schema mirror of `MemoryWriteProposalSchema`, derived straight from
+ * the zod schema via zod-to-json-schema (flattened — no `$ref` wrappers) so
+ * it cannot drift the way a hand-written mirror can. Used both embedded in
+ * `ModelIntentPacketJsonSchema.memoryWrites` (action_intent's inline memory
+ * writes) and standalone by any reasoning-only surface that proposes memory
+ * consolidations on its own (e.g. background_reflection).
+ */
+export const MemoryWriteProposalJsonSchema = zodToJsonSchema(MemoryWriteProposalSchema, {
+  $refStrategy: "none",
+}) as JsonSchemaObject;
+
+/**
+ * JSON Schema mirror of the packet, used for constrained decoding
+ * (Ollama `format` object / OpenAI `response_format.json_schema`). Derived
+ * straight from `ModelIntentPacketSchema` via zod-to-json-schema, so the zod
+ * schema stays the single source of truth for both the prompt contract and
+ * the decode-time grammar.
+ */
+export const ModelIntentPacketJsonSchema = zodToJsonSchema(ModelIntentPacketSchema, {
+  $refStrategy: "none",
+}) as JsonSchemaObject;
 
 function describePacketFieldType(def: JsonSchemaProp): string {
   if (def.enum) return `one of: ${def.enum.join(", ")}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,11 @@ importers:
         specifier: ^5.0.0
         version: 5.1.11
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.25.28
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.5.0
@@ -1757,6 +1760,11 @@ packages:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -3360,6 +3368,10 @@ snapshots:
   ws@8.21.0: {}
 
   yoctocolors@2.2.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## What

Adds decoding-level shape enforcement for local model intents:

- `ACTION_INTENT_JSON_SCHEMA`: derived from the zod `ActionIntentSchema` via zod-to-json-schema, inlined flat (no `$ref` wrappers). The zod schema remains the single source of truth — no second hand-written contract to drift.
- New `constrainedDecoding` flag on `LlmConfig` (off by default, Ollama native path only): when enabled together with `responseFormatJson`, the request's `format` carries the full JSON Schema instead of bare "json", so tokens violating the intent shape become mechanically impossible at decode time (Ollama >= 0.5).
- IntentParser's repair ladder stays untouched — constrained decoding is defense in depth for the flagged path, not a replacement for validation elsewhere.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS 812 passed (+8 new)
- Provider tests assert the schema object lands in `format` (intentType enum + field shapes), stays "json" without the flag, and stays absent when JSON mode is off; shared-side tests pin flatness/no-refs, enum completeness, required fields, and sync with a canonical intent.
