### PR TITLE
feat(agent): derive the SECTION 8 output contract from ActionIntentSchema

### DIFF
--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -312,6 +312,7 @@ export function localLlmConfig(pack: import("@perfectman/shared").PersonaPack | 
     timeoutMs: 120000,
     retryCount: 2,
     responseFormatJson: true,
+    constrainedDecoding: !isDeepseek,
     extraBody: isDeepseek
       ? {
           seed: benchSeed(),

--- a/packages/server/src/agent/__tests__/output-contract.test.ts
+++ b/packages/server/src/agent/__tests__/output-contract.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { renderIntentOutputContract } from "../output-contract.js";
-import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
-
 import { renderIntentOutputContract, FIELD_NOTES } from "../output-contract.js";
+import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
 
 const properties = (ACTION_INTENT_JSON_SCHEMA.properties ?? {}) as Record<
   string,

--- a/packages/server/src/agent/__tests__/output-contract.test.ts
+++ b/packages/server/src/agent/__tests__/output-contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { renderIntentOutputContract } from "../output-contract.js";
+import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
+
+const properties = (ACTION_INTENT_JSON_SCHEMA.properties ?? {}) as Record<
+  string,
+  Record<string, unknown>
+>;
+
+describe("renderIntentOutputContract (#49 drift guard)", () => {
+  const contract = renderIntentOutputContract("");
+
+  it("renders every non-engine-stamped schema field exactly once", () => {
+    for (const [name, prop] of Object.entries(properties)) {
+      if (name === "id" || name === "actorId") continue;
+      const needle = `"${name}":`;
+      const count = contract.split(needle).length - 1;
+      expect(count, `${needle} appears once`).toBeGreaterThanOrEqual(1);
+      expect(prop).toBeDefined();
+    }
+  });
+
+  it("never requests engine-stamped fields or hardcodes their values", () => {
+    expect(contract).not.toContain('"id":');
+    expect(contract).not.toContain('"actorId":');
+    // The old hardcoded prose asked the model to invent ids and emit
+    // 'preferredDelay: 0' — those literal delegations must stay gone.
+    expect(contract).not.toContain('"preferredDelay": 0');
+    expect(contract).not.toContain("copy from the inputs");
+  });
+
+  it("renders enum choices exhaustively", () => {
+    const intentEnum = properties.intentType?.enum as string[];
+    expect(intentEnum).toBeDefined();
+    for (const value of intentEnum) {
+      expect(contract, `enum value ${value}`).toContain(`"${value}"`);
+    }
+  });
+
+  it("documents every field either via note or type placeholder", () => {
+    // Every rendered line must correspond to a real schema property —
+    // catches typos in curated notes drifting away from the schema.
+    const rendered = [...contract.matchAll(/"([a-zA-Z]+)":/g)].map(m => m[1]!);
+    for (const name of rendered) {
+      expect(properties[name], `"${name}" is a schema property`).toBeDefined();
+    }
+  });
+});

--- a/packages/server/src/agent/__tests__/output-contract.test.ts
+++ b/packages/server/src/agent/__tests__/output-contract.test.ts
@@ -24,9 +24,8 @@ describe("renderIntentOutputContract (#49 drift guard)", () => {
   it("has no dead curated notes (reverse drift guard)", () => {
     // A note whose schema property was renamed/removed must fail here —
     // otherwise the notes map silently stops rendering.
-    for (const key of Object.keys(FIELD_NOTES)) {
-      expect(properties[key], `FIELD_NOTES.${key} is a schema property`).toBeDefined();
-    }
+    const deadNotes = Object.keys(FIELD_NOTES).filter(k => !(k in properties));
+    expect(deadNotes).toEqual([]);
   });
 
   it("never requests engine-stamped fields or hardcodes their values", () => {
@@ -41,7 +40,7 @@ describe("renderIntentOutputContract (#49 drift guard)", () => {
   it("renders enum choices exhaustively", () => {
     for (const enumField of ["intentType", "channelType", "fallbackIfBlocked"]) {
       const values = properties[enumField]?.enum as string[] | undefined;
-      expect(values, `${enumField} is an enum in the schema`).toBeDefined();
+      expect(Array.isArray(values), `${enumField} is an enum in the schema`).toBe(true);
       for (const value of values!) {
         expect(contract, `${enumField} value ${value}`).toContain(`"${value}"`);
       }
@@ -52,8 +51,7 @@ describe("renderIntentOutputContract (#49 drift guard)", () => {
     // Every rendered line must correspond to a real schema property —
     // catches typos in curated notes drifting away from the schema.
     const rendered = [...contract.matchAll(/"([a-zA-Z]+)":/g)].map(m => m[1]!);
-    for (const name of rendered) {
-      expect(properties[name], `"${name}" is a schema property`).toBeDefined();
-    }
+    const foreign = rendered.filter(name => !(name in properties));
+    expect(foreign).toEqual([]);
   });
 });

--- a/packages/server/src/agent/__tests__/output-contract.test.ts
+++ b/packages/server/src/agent/__tests__/output-contract.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { renderIntentOutputContract } from "../output-contract.js";
 import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
 
+import { renderIntentOutputContract, FIELD_NOTES } from "../output-contract.js";
+
 const properties = (ACTION_INTENT_JSON_SCHEMA.properties ?? {}) as Record<
   string,
   Record<string, unknown>
@@ -11,12 +13,19 @@ describe("renderIntentOutputContract (#49 drift guard)", () => {
   const contract = renderIntentOutputContract("");
 
   it("renders every non-engine-stamped schema field exactly once", () => {
-    for (const [name, prop] of Object.entries(properties)) {
+    for (const [name] of Object.entries(properties)) {
       if (name === "id" || name === "actorId") continue;
       const needle = `"${name}":`;
       const count = contract.split(needle).length - 1;
-      expect(count, `${needle} appears once`).toBeGreaterThanOrEqual(1);
-      expect(prop).toBeDefined();
+      expect(count, `${needle} appears once`).toBe(1);
+    }
+  });
+
+  it("has no dead curated notes (reverse drift guard)", () => {
+    // A note whose schema property was renamed/removed must fail here —
+    // otherwise the notes map silently stops rendering.
+    for (const key of Object.keys(FIELD_NOTES)) {
+      expect(properties[key], `FIELD_NOTES.${key} is a schema property`).toBeDefined();
     }
   });
 
@@ -30,10 +39,12 @@ describe("renderIntentOutputContract (#49 drift guard)", () => {
   });
 
   it("renders enum choices exhaustively", () => {
-    const intentEnum = properties.intentType?.enum as string[];
-    expect(intentEnum).toBeDefined();
-    for (const value of intentEnum) {
-      expect(contract, `enum value ${value}`).toContain(`"${value}"`);
+    for (const enumField of ["intentType", "channelType", "fallbackIfBlocked"]) {
+      const values = properties[enumField]?.enum as string[] | undefined;
+      expect(values, `${enumField} is an enum in the schema`).toBeDefined();
+      for (const value of values!) {
+        expect(contract, `${enumField} value ${value}`).toContain(`"${value}"`);
+      }
     }
   });
 

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeInput, CommittedEvent } from "@perfectman/shared";
 import type { PersonaPromptProfile, ScenarioContextBlock } from "./persona-prompt-profile.js";
 import type { BuiltPrompt } from "./agent-runtime.types.js";
+import { renderIntentOutputContract } from "./output-contract.js";
 
 export class ActionIntentPromptBuilder {
   /**
@@ -19,36 +20,11 @@ export class ActionIntentPromptBuilder {
     systemSections.push(this.renderPersonaSection(profile));
 
     // --- SECTION 8: Output Contract (System) ---
-    systemSections.push(`### SECTION 8: OUTPUT CONTRACT & JSON FORMAT
-You must respond with a SINGLE valid JSON object matching the schema below.
-DO NOT include any conversational introduction, explanation, or markdown codeblocks (no \`\`\`json wrappers).
-DO NOT include any chain-of-thought, thinking blocks (<think>), or nested commentary. Return ONLY the JSON object.
-
-JSON Schema:
-{
-  "id": "A unique string representing this intent (copy from the inputs or generate a new unique string)",
-  "actorId": "${input.agentId}",
-  "intentType": "Must match one of the available intent types",
-  "channelTarget": "ONLY for send_message/reply_to_message/leave_channel/invite_agent — the existing channel ID you're acting in. OMIT this field entirely for create_channel (use channelName/channelType instead).",
-  "personTargets": "OMIT this field for send_message and create_channel — it does not apply to them. Only used for actions that target a specific person directly.",
-  "visibleContent": "Optional text message content (required for 'send_message' or 'reply_to_message')",
-  "privateMotiveSummary": "A highly specific natural-language thought explaining your real, raw, hidden motive behind this action. Never leave empty.",
-  "emotionDrivers": ["Emotion keywords driving this action (e.g. warmth, jealousy, irritation)"],
-  "motivationDrivers": ["Motivation keywords driving this action (e.g. affinity, gossip, exclusion)"],
-  "preferredDelay": 0,
-  "fallbackIfBlocked": "no_op",
-  "memoryWrites": [],
-  "channelName": "ONLY for create_channel — a short name for the new channel.",
-  "channelType": "ONLY for create_channel — usually \\"private_channel\\".",
-  "invitedAgentIds": ["ONLY for create_channel — array of agentIds to invite into the new channel."]
-}
-
-Field notes by intentType — send_message/reply_to_message use "channelTarget" (an existing channel); create_channel uses "channelName" + "channelType" (usually "private_channel") + "invitedAgentIds" instead, and has no "channelTarget" or "personTargets".
-
-Ensure:
-- "privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").
-- Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".
-- NEVER repeat a message you already sent, or a near-variation of it. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move the action somewhere else — or choose "no_op". Repeating yourself is the most out-of-character thing you can do.${this.renderOwnUtterancesWarning(perceptionPacket.ownRecentUtterances)}`);
+    // Derived from ActionIntentSchema (see output-contract.ts) — the zod
+    // schema is the single source of truth; the prose contract cannot drift.
+    systemSections.push(
+      renderIntentOutputContract(this.renderOwnUtterancesWarning(perceptionPacket.ownRecentUtterances)),
+    );
 
     const systemPrompt = systemSections.join("\n\n");
 

--- a/packages/server/src/agent/output-contract.ts
+++ b/packages/server/src/agent/output-contract.ts
@@ -8,8 +8,8 @@ import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
  * targetEventId, replyToEventId were never explained; preferredDelay and
  * channelType were hardcoded). The renderer below makes the field list
  * mechanically follow the schema so drift is a compile/test failure, not a
- * silent prompt change. Nested shapes (memoryWrites proposals) still render
- * as arrays — their inner contract is enforced by validation, not prose.
+ * silent prompt change. memoryWrites renders as a curated string describing
+ * its inner proposal shape; the shape itself stays enforced by validation.
  *
  * Engine-stamped fields (id, actorId) are NOT requested: the runtime owns
  * structure, the model owns language (see intent-parser's structural

--- a/packages/server/src/agent/output-contract.ts
+++ b/packages/server/src/agent/output-contract.ts
@@ -1,0 +1,101 @@
+import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
+
+/**
+ * SECTION 8 output contract, DERIVED from ActionIntentSchema.
+ *
+ * History: this contract existed twice — hand-written prose in the prompt
+ * and the zod schema in shared. They drifted (spectatorSummary, emoji,
+ * targetEventId, replyToEventId were never explained; preferredDelay and
+ * channelType were hardcoded; memoryWrites semantics were never described).
+ * The renderer below makes the field list mechanically follow the schema so
+ * drift is a compile/test failure, not a silent prompt change.
+ *
+ * Engine-stamped fields (id, actorId) are NOT requested: the runtime owns
+ * structure, the model owns language (see intent-parser's structural
+ * repairs, which already stamp them). Everything the model IS asked for is
+ * either semantic natural language or a choice among runtime options.
+ */
+
+/** Fields the engine stamps after parsing — never requested from the model. */
+const ENGINE_STAMPED = new Set(["id", "actorId"]);
+
+/** Curated per-field guidance, keyed by schema property name. String arrays are example lists. */
+const FIELD_NOTES: Record<string, string | string[]> = {
+  intentType: "one of the available intent types",
+  channelTarget:
+    'ONLY for send_message/reply_to_message/leave_channel/invite_agent — the existing channel ID you\'re acting in. OMIT entirely for create_channel (use channelName/channelType instead).',
+  personTargets:
+    "OMIT this field unless the action targets a specific person directly.",
+  visibleContent:
+    "Optional text message content (required for 'send_message' or 'reply_to_message')",
+  privateMotiveSummary:
+    "A highly specific natural-language thought explaining your real, raw, hidden motive behind this action. Never leave empty.",
+  emotionDrivers: ["warmth", "jealousy", "irritation"],
+  motivationDrivers: ["affinity", "gossip", "exclusion"],
+  fallbackIfBlocked:
+    "if your primary action is denied, the low-risk action to take instead (optional)",
+  channelName: "ONLY for create_channel — a short name for the new channel.",
+  channelType: 'ONLY for create_channel — usually "private_channel".',
+  invitedAgentIds:
+    "ONLY for create_channel — agentIds to invite into the new channel.",
+  spectatorSummary: "short neutral summary as seen by spectators (rarely needed)",
+  replyToEventId: "ONLY for reply_to_message — the event id you are replying to.",
+  emoji: "ONLY for react — a single emoji.",
+  targetEventId: "ONLY for react — the event id you are reacting to.",
+};
+
+function renderPlaceholder(fieldName: string, prop: Record<string, unknown>): string {
+  const note = FIELD_NOTES[fieldName];
+  // Enums render exhaustively — they are choices among runtime options,
+  // and the model must see every legal value.
+  if (Array.isArray(prop.enum)) {
+    const choices = prop.enum.map(v => `"${v}"`).join(" | ");
+    const hint = typeof note === "string" ? ` (${note})` : "";
+    return `"${fieldName}": one of ${choices}${hint}`;
+  }
+  if (note !== undefined && !Array.isArray(note)) {
+    return `"${fieldName}": "${note}"`;
+  }
+  if (note !== undefined && Array.isArray(note)) {
+    return `"${fieldName}": [examples like ${note.map(v => `"${v}"`).join(", ")}]`;
+  }
+  if (prop.type === "string") return `"${fieldName}": "..."`;
+  if (prop.type === "number" || prop.type === "integer") return `"${fieldName}": <${prop.type}>`;
+  if (prop.type === "boolean") return `"${fieldName}": <boolean>`;
+  if (prop.type === "array") return `"${fieldName}": [...]`;
+  return `"${fieldName}": ...`;
+}
+
+export function renderIntentOutputContract(ownUtterancesWarning: string): string {
+  const properties = (ACTION_INTENT_JSON_SCHEMA.properties ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
+
+  const requested = Object.keys(properties)
+    .filter(name => !ENGINE_STAMPED.has(name))
+    .map(name => `  ${renderPlaceholder(name, properties[name]!)}`);
+
+  const stampedLine =
+    ENGINE_STAMPED.size > 0
+      ? `\nThe runtime supplies "${[...ENGINE_STAMPED].join('"} and "')}" itself — do not include them.`
+      : "";
+
+  return `### SECTION 8: OUTPUT CONTRACT & JSON FORMAT
+You must respond with a SINGLE valid JSON object matching the schema below.
+DO NOT include any conversational introduction, explanation, or markdown codeblocks (no \`\`\`json wrappers).
+DO NOT include any chain-of-thought, thinking blocks (<think>), or nested commentary. Return ONLY the JSON object.
+
+JSON Schema:
+{
+${requested.join(",\n")}
+}
+${stampedLine}
+
+Field notes by intentType — send_message/reply_to_message use "channelTarget" (an existing channel); create_channel uses "channelName" + "channelType" + "invitedAgentIds" instead, and has no "channelTarget" or "personTargets".
+
+Ensure:
+- "privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").
+- Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".
+- NEVER repeat a message you already sent, or a near-variation of it. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move the action somewhere else — or choose "no_op". Repeating yourself is the most out-of-character thing you can do.${ownUtterancesWarning}`;
+}

--- a/packages/server/src/agent/output-contract.ts
+++ b/packages/server/src/agent/output-contract.ts
@@ -6,9 +6,10 @@ import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
  * History: this contract existed twice — hand-written prose in the prompt
  * and the zod schema in shared. They drifted (spectatorSummary, emoji,
  * targetEventId, replyToEventId were never explained; preferredDelay and
- * channelType were hardcoded; memoryWrites semantics were never described).
- * The renderer below makes the field list mechanically follow the schema so
- * drift is a compile/test failure, not a silent prompt change.
+ * channelType were hardcoded). The renderer below makes the field list
+ * mechanically follow the schema so drift is a compile/test failure, not a
+ * silent prompt change. Nested shapes (memoryWrites proposals) still render
+ * as arrays — their inner contract is enforced by validation, not prose.
  *
  * Engine-stamped fields (id, actorId) are NOT requested: the runtime owns
  * structure, the model owns language (see intent-parser's structural
@@ -20,10 +21,10 @@ import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
 const ENGINE_STAMPED = new Set(["id", "actorId"]);
 
 /** Curated per-field guidance, keyed by schema property name. String arrays are example lists. */
-const FIELD_NOTES: Record<string, string | string[]> = {
+export const FIELD_NOTES: Record<string, string | string[]> = {
   intentType: "one of the available intent types",
   channelTarget:
-    'ONLY for send_message/reply_to_message/leave_channel/invite_agent — the existing channel ID you\'re acting in. OMIT entirely for create_channel (use channelName/channelType instead).',
+    "ONLY for send_message/reply_to_message/leave_channel/invite_agent — the existing channel ID you're acting in. OMIT entirely for create_channel (use channelName/channelType instead).",
   personTargets:
     "OMIT this field unless the action targets a specific person directly.",
   visibleContent:
@@ -35,9 +36,11 @@ const FIELD_NOTES: Record<string, string | string[]> = {
   fallbackIfBlocked:
     "if your primary action is denied, the low-risk action to take instead (optional)",
   channelName: "ONLY for create_channel — a short name for the new channel.",
-  channelType: 'ONLY for create_channel — usually "private_channel".',
+  channelType: "ONLY for create_channel — usually private_channel.",
   invitedAgentIds:
     "ONLY for create_channel — agentIds to invite into the new channel.",
+  memoryWrites:
+    "optional list of {type: episodic|relationship|self|social_theory|pending_intention|emotional_residue, subjectAgentIds: [], summary: 'one sentence', emotionalTone: 'one or two words', confidence: 0.0-1.0, unresolved: true|false}",
   spectatorSummary: "short neutral summary as seen by spectators (rarely needed)",
   replyToEventId: "ONLY for reply_to_message — the event id you are replying to.",
   emoji: "ONLY for react — a single emoji.",
@@ -78,7 +81,7 @@ export function renderIntentOutputContract(ownUtterancesWarning: string): string
 
   const stampedLine =
     ENGINE_STAMPED.size > 0
-      ? `\nThe runtime supplies "${[...ENGINE_STAMPED].join('"} and "')}" itself — do not include them.`
+      ? `\nThe runtime supplies "${[...ENGINE_STAMPED].join('" and "')}" itself — do not include them.`
       : "";
 
   return `### SECTION 8: OUTPUT CONTRACT & JSON FORMAT

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -1033,6 +1033,10 @@ function parseLlmConfig(input: unknown, path: string): LlmConfig {
       llm["responseFormatJson"],
       `${path}.responseFormatJson`,
     ),
+    constrainedDecoding: optionalBoolean(
+      llm["constrainedDecoding"],
+      `${path}.constrainedDecoding`,
+    ),
     extraBody: parseExtraBody(llm["extraBody"], providerType, path),
   };
 }

--- a/packages/server/src/llm/__tests__/ollama-provider.test.ts
+++ b/packages/server/src/llm/__tests__/ollama-provider.test.ts
@@ -188,6 +188,36 @@ describe("OllamaProvider", () => {
     expect(body.format).toBe("json");
   });
 
+  it("sends the ActionIntent schema as format under constrained decoding", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(successResponse());
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await new OllamaProvider({
+      ...baseConfig,
+      responseFormatJson: true,
+      constrainedDecoding: true,
+    }).generateIntent(baseInput, context, prompt);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+
+    // The format target is the derived schema object, not the bare "json".
+    expect(typeof body.format).toBe("object");
+    expect(body.format.$schema).toContain("json-schema");
+    expect(body.format.properties.intentType.enum).toContain("send_message");
+    expect(body.format.properties.visibleContent.type).toBe("string");
+  });
+
+  it("ignores constrainedDecoding when responseFormatJson is off", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(successResponse());
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await new OllamaProvider({
+      ...baseConfig,
+      constrainedDecoding: true,
+    }).generateIntent(baseInput, context, prompt);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.format).toBeUndefined();
+  });
+
   it("returns the expected result structure on success", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse()));
 

--- a/packages/server/src/llm/llm-config.ts
+++ b/packages/server/src/llm/llm-config.ts
@@ -9,5 +9,12 @@ export type LlmConfig = {
   timeoutMs: number;
   retryCount: number;
   responseFormatJson?: boolean;
+  /**
+   * Structured decoding (Ollama native path only): send the full
+   * ActionIntent JSON Schema as the `format` target instead of bare "json",
+   * making shape-invalid output mechanically impossible. Requires
+   * responseFormatJson. Off by default — defense in depth, not a gate.
+   */
+  constrainedDecoding?: boolean;
   extraBody?: Record<string, unknown>;
 };

--- a/packages/server/src/llm/ollama-provider.ts
+++ b/packages/server/src/llm/ollama-provider.ts
@@ -1,3 +1,4 @@
+import { ACTION_INTENT_JSON_SCHEMA } from "@perfectman/shared";
 import type { AgentRuntimeInput } from "@perfectman/shared";
 import type { AgentRuntimeContext, BuiltPrompt } from "../agent/agent-runtime.types.js";
 import type { LlmConfig } from "./llm-config.js";
@@ -86,7 +87,13 @@ export class OllamaProvider implements LlmProvider {
     }
 
     if (this.config.responseFormatJson) {
-      body.format = "json";
+      // Constrained decoding: when enabled, the schema itself becomes the
+      // format target (Ollama >= 0.5) so shape-invalid JSON is mechanically
+      // impossible — defense in depth on top of IntentParser's repair
+      // ladder, which stays in place for non-constrained paths.
+      body.format = this.config.constrainedDecoding
+        ? ACTION_INTENT_JSON_SCHEMA
+        : "json";
     }
 
     let attempts = 0;

--- a/packages/server/src/llm/ollama-provider.ts
+++ b/packages/server/src/llm/ollama-provider.ts
@@ -88,9 +88,10 @@ export class OllamaProvider implements LlmProvider {
 
     if (this.config.responseFormatJson) {
       // Constrained decoding: when enabled, the schema itself becomes the
-      // format target (Ollama >= 0.5) so shape-invalid JSON is mechanically
-      // impossible — defense in depth on top of IntentParser's repair
-      // ladder, which stays in place for non-constrained paths.
+      // format target (Ollama >= 0.5) so STRUCTURALLY invalid JSON becomes
+      // impossible at decode time. Note Ollama's grammar enforces
+      // shape/types/enums but not value constraints (minLength, minimum) —
+      // IntentParser's repair ladder remains the backstop everywhere.
       body.format = this.config.constrainedDecoding
         ? ACTION_INTENT_JSON_SCHEMA
         : "json";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "nanoid": "^5.0.0",
-    "zod": "^3.23.0",
+    "zod": "^3.25.28",
     "zod-to-json-schema": "^3.25.2"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,8 @@
     "vitest": "^2.0.0"
   },
   "dependencies": {
+    "nanoid": "^5.0.0",
     "zod": "^3.23.0",
-    "nanoid": "^5.0.0"
+    "zod-to-json-schema": "^3.25.2"
   }
 }

--- a/packages/shared/src/__tests__/intent-json-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-json-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ACTION_INTENT_JSON_SCHEMA } from "../intent/intent-json-schema.js";
-import type { ActionIntent } from "./intent.types.js";
+import type { ActionIntent } from "../intent/intent.types.js";
 
 describe("ACTION_INTENT_JSON_SCHEMA", () => {
   const schema = ACTION_INTENT_JSON_SCHEMA as {

--- a/packages/shared/src/__tests__/intent-json-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-json-schema.test.ts
@@ -28,7 +28,8 @@ describe("ACTION_INTENT_JSON_SCHEMA", () => {
   });
 
   it("stays in sync with the zod schema on a known-good intent shape", () => {
-    // Smoke: every property of a canonical intent must exist in the schema.
+    // Smoke: every property of a canonical intent must exist in the schema
+    // with a concrete type mapping.
     const intent: ActionIntent = {
       id: "i1",
       actorId: "a1",
@@ -41,8 +42,10 @@ describe("ACTION_INTENT_JSON_SCHEMA", () => {
       motivationDrivers: [],
       memoryWrites: [],
     };
-    for (const key of Object.keys(intent)) {
-      expect(schema.properties[key], key).toBeDefined();
-    }
+    const unknownKeys = Object.keys(intent).filter(
+      k => !("type" in (schema.properties[k] ?? {})) && !("$ref" in (schema.properties[k] ?? {})) && !("anyOf" in (schema.properties[k] ?? {})),
+    );
+    expect(unknownKeys).toEqual([]);
+    expect(schema.properties.memoryWrites?.type).toBe("array");
   });
 });

--- a/packages/shared/src/__tests__/intent-json-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-json-schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { ACTION_INTENT_JSON_SCHEMA } from "../intent/intent-json-schema.js";
+import type { ActionIntent } from "./intent.types.js";
+
+describe("ACTION_INTENT_JSON_SCHEMA", () => {
+  const schema = ACTION_INTENT_JSON_SCHEMA as {
+    type: string;
+    properties: Record<string, { type?: string; enum?: string[]; anyOf?: unknown[] }>;
+    required: string[];
+    additionalProperties: boolean;
+  };
+
+  it("is a flat object schema with no dangling refs", () => {
+    expect(schema.type).toBe("object");
+    expect(JSON.stringify(schema)).not.toContain("$ref");
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("exposes the full intent-type enum", () => {
+    expect(schema.properties.intentType?.enum).toContain("send_message");
+    expect(schema.properties.intentType?.enum).toContain("no_op");
+  });
+
+  it("requires the core identity fields", () => {
+    for (const key of ["actorId", "intentType", "privateMotiveSummary"]) {
+      expect(schema.required, key).toContain(key);
+    }
+  });
+
+  it("stays in sync with the zod schema on a known-good intent shape", () => {
+    // Smoke: every property of a canonical intent must exist in the schema.
+    const intent: ActionIntent = {
+      id: "i1",
+      actorId: "a1",
+      intentType: "send_message",
+      channelTarget: "ch",
+      personTargets: [],
+      visibleContent: "oi",
+      privateMotiveSummary: "m",
+      emotionDrivers: [],
+      motivationDrivers: [],
+      memoryWrites: [],
+    };
+    for (const key of Object.keys(intent)) {
+      expect(schema.properties[key], key).toBeDefined();
+    }
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,6 +35,7 @@ export * from "./memory/memory.types.js";
 // Intent
 export * from "./intent/intent.types.js";
 export * from "./intent/intent.schema.js";
+export * from "./intent/intent-json-schema.js";
 
 // Decision
 export * from "./decision/decision.types.js";

--- a/packages/shared/src/intent/intent-json-schema.ts
+++ b/packages/shared/src/intent/intent-json-schema.ts
@@ -9,6 +9,8 @@ import { ActionIntentSchema } from "./intent.schema.js";
  * Consumed by OllamaProvider as a structured-output `format` target, so the
  * model can only emit tokens that fit the intent shape at decoding time.
  */
-export const ACTION_INTENT_JSON_SCHEMA = zodToJsonSchema(ActionIntentSchema, {
-  $refStrategy: "none",
-}) as Record<string, unknown>;
+export const ACTION_INTENT_JSON_SCHEMA: Readonly<Record<string, unknown>> = Object.freeze(
+  zodToJsonSchema(ActionIntentSchema, {
+    $refStrategy: "none",
+  }) as Record<string, unknown>,
+);

--- a/packages/shared/src/intent/intent-json-schema.ts
+++ b/packages/shared/src/intent/intent-json-schema.ts
@@ -1,0 +1,14 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { ActionIntentSchema } from "./intent.schema.js";
+
+/**
+ * JSON Schema derived from ActionIntentSchema — the single source of truth
+ * (see #49's drift concern: hand-written contract copies are how prompt and
+ * validation drifted apart historically).
+ *
+ * Consumed by OllamaProvider as a structured-output `format` target, so the
+ * model can only emit tokens that fit the intent shape at decoding time.
+ */
+export const ACTION_INTENT_JSON_SCHEMA = zodToJsonSchema(ActionIntentSchema, {
+  $refStrategy: "none",
+}) as Record<string, unknown>;

--- a/packages/shared/src/scenario/scenario-presets.ts
+++ b/packages/shared/src/scenario/scenario-presets.ts
@@ -1,0 +1,91 @@
+import type { ScenarioContext, ScenarioPreset } from "./scenario.types.js";
+
+export const SCENARIO_PRESETS: Record<Exclude<ScenarioPreset, "custom">, ScenarioContext> = {
+  friends_cold_open: {
+    scenario: "friends_cold_open",
+    relationshipMode: "established_friends",
+    roomContext: "This is a private friend-group chat. Everyone already knows each other.",
+    startingMood: "quiet, casual, slightly empty",
+    visibleIntro: "none",
+    agentIntroBehavior: "do_not_introduce_yourself_formally",
+    firstMoveGuidance: "If you speak first, act like someone reviving a familiar group chat.",
+    customNotes: [
+      "Silence is normal here.",
+      "No one should explain who they are unless the scenario says they are strangers.",
+    ],
+  },
+  strangers_first_meeting: {
+    scenario: "strangers_first_meeting",
+    relationshipMode: "total_strangers",
+    roomContext: "Agents are entering a new shared room and have no prior relationship.",
+    startingMood: "polite, new, lightly uncertain",
+    visibleIntro: "agent_intros",
+    agentIntroBehavior: "introduce_yourself_briefly",
+    firstMoveGuidance: "If you speak first, a short natural introduction is appropriate.",
+    customNotes: [
+      "Do not invent prior friendships, inside jokes, or shared history.",
+    ],
+  },
+  mixed_room: {
+    scenario: "mixed_room",
+    relationshipMode: "mixed",
+    roomContext: "Some agents already know each other; one or more people are new to the group.",
+    startingMood: "polite but uncertain",
+    visibleIntro: "agent_intros",
+    agentIntroBehavior: "introduce_yourself_only_to_people_you_do_not_know",
+    firstMoveGuidance: "Act familiar with known people and briefly introduce yourself only to unknown people.",
+    customNotes: [
+      "Use pair familiarity when provided; otherwise fall back to the mixed-room assumption.",
+    ],
+  },
+  returning_after_silence: {
+    scenario: "returning_after_silence",
+    relationshipMode: "established_friends",
+    roomContext: "The group exists and already knows each other, but nobody has talked for a while.",
+    startingMood: "quiet, stale, slightly awkward",
+    visibleIntro: "none",
+    agentIntroBehavior: "do_not_introduce_yourself_formally",
+    firstMoveGuidance: "If you speak first, treat it like reviving an existing chat after silence.",
+  },
+  post_event_tension: {
+    scenario: "post_event_tension",
+    relationshipMode: "established_friends",
+    roomContext: "Something minor happened before the simulation starts. Nobody has addressed it yet.",
+    startingMood: "tense, indirect, quiet",
+    visibleIntro: "none",
+    agentIntroBehavior: "do_not_introduce_yourself_formally",
+    firstMoveGuidance: "Let subtext, avoidance, repair, or silence feel natural; do not explain the whole backstory.",
+  },
+  introduced_by_host: {
+    scenario: "introduced_by_host",
+    relationshipMode: "mixed",
+    roomContext: "A host or system message frames the room before agents respond.",
+    startingMood: "structured but casual",
+    visibleIntro: "host_message_only",
+    agentIntroBehavior: "wait_for_context",
+    firstMoveGuidance: "Respond naturally to the host framing without over-explaining yourself.",
+  },
+  private_channel_seed: {
+    scenario: "private_channel_seed",
+    relationshipMode: "mixed",
+    roomContext: "Some agents may have access to private side channels, creating public/private asymmetry.",
+    startingMood: "casual on the surface, socially asymmetric underneath",
+    visibleIntro: "none",
+    agentIntroBehavior: "do_not_introduce_yourself_formally",
+    firstMoveGuidance: "Act from the public room context while allowing suspicion, exclusion, or alliance behavior to emerge naturally.",
+    customNotes: [
+      "Do not reveal private-channel facts in public unless the visible context supports it.",
+    ],
+  },
+};
+
+export function resolveScenarioPreset(
+  preset: Exclude<ScenarioPreset, "custom">,
+  overrides: Partial<ScenarioContext> = {},
+): ScenarioContext {
+  return {
+    ...SCENARIO_PRESETS[preset],
+    ...overrides,
+    scenario: overrides.scenario ?? preset,
+  };
+}

--- a/packages/shared/src/scenario/scenario.schema.ts
+++ b/packages/shared/src/scenario/scenario.schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const ScenarioPresetSchema = z.enum([
+  "friends_cold_open",
+  "strangers_first_meeting",
+  "mixed_room",
+  "returning_after_silence",
+  "post_event_tension",
+  "introduced_by_host",
+  "private_channel_seed",
+  "custom",
+]);
+
+export const RelationshipModeSchema = z.enum([
+  "established_friends",
+  "total_strangers",
+  "mixed",
+]);
+
+export const VisibleIntroPolicySchema = z.enum([
+  "none",
+  "system_intro",
+  "agent_intros",
+  "host_message_only",
+  "custom",
+]);
+
+export const AgentIntroBehaviorSchema = z.enum([
+  "do_not_introduce_yourself_formally",
+  "introduce_yourself_briefly",
+  "introduce_yourself_only_to_people_you_do_not_know",
+  "wait_for_context",
+]);
+
+export const ScenarioContextSchema = z.object({
+  scenario: ScenarioPresetSchema,
+  relationshipMode: RelationshipModeSchema,
+  roomContext: z.string().min(1),
+  startingMood: z.string().min(1),
+  visibleIntro: VisibleIntroPolicySchema,
+  agentIntroBehavior: AgentIntroBehaviorSchema,
+  firstMoveGuidance: z.string().min(1),
+  customNotes: z.array(z.string()).optional(),
+  pairFamiliarity: z.record(z.string()).optional(),
+  safePriorContext: z.array(z.string()).optional(),
+  startingPrompt: z.string().min(1).optional(),
+});

--- a/packages/shared/src/scenario/scenario.types.ts
+++ b/packages/shared/src/scenario/scenario.types.ts
@@ -1,0 +1,46 @@
+export type ScenarioPreset =
+  | "friends_cold_open"
+  | "strangers_first_meeting"
+  | "mixed_room"
+  | "returning_after_silence"
+  | "post_event_tension"
+  | "introduced_by_host"
+  | "private_channel_seed"
+  | "custom";
+
+export type RelationshipMode =
+  | "established_friends"
+  | "total_strangers"
+  | "mixed";
+
+export type VisibleIntroPolicy =
+  | "none"
+  | "system_intro"
+  | "agent_intros"
+  | "host_message_only"
+  | "custom";
+
+export type AgentIntroBehavior =
+  | "do_not_introduce_yourself_formally"
+  | "introduce_yourself_briefly"
+  | "introduce_yourself_only_to_people_you_do_not_know"
+  | "wait_for_context";
+
+export type ScenarioContext = {
+  scenario: ScenarioPreset;
+  relationshipMode: RelationshipMode;
+  roomContext: string;
+  startingMood: string;
+  visibleIntro: VisibleIntroPolicy;
+  agentIntroBehavior: AgentIntroBehavior;
+  firstMoveGuidance: string;
+  customNotes?: string[];
+  pairFamiliarity?: Record<string, string>;
+  safePriorContext?: string[];
+  startingPrompt?: string;
+};
+
+export type ScenarioPresetConfig = {
+  preset: Exclude<ScenarioPreset, "custom">;
+  overrides?: Partial<ScenarioContext>;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         specifier: ^5.0.0
         version: 5.1.11
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.25.28
         version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.25.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       zod:
         specifier: ^3.23.0
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       typescript:
         specifier: ^5.5.0
@@ -682,66 +685,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -1756,6 +1772,11 @@ packages:
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3360,6 +3381,10 @@ snapshots:
   ws@8.21.0: {}
 
   yoctocolors@2.2.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## What

Removes the prompt layer's second source of truth: the SECTION 8 JSON contract is now **derived from `ActionIntentSchema`** instead of hand-written prose that had already drifted from it.

- New `output-contract.ts`: field list, types, and enum choices render mechanically from the derived JSON schema; curated semantic notes are keyed by schema property name so unknown fields get a generic line rather than silence.
- Engine-stamped structure leaves the model's job per the repo's "engine owns structure, model owns language" rule: `id`/`actorId` are never requested (the parser already stamps them), and the old literal delegations ("copy from the inputs", `preferredDelay: 0`) are gone. `fallbackIfBlocked` remains advertised — it is a genuine model decision consumed by the resolver.
- **Drift-proof CI**: a guard test pins set-equality between schema properties and rendered contract fields in both directions (missing or extra field = red), asserts every enum choice renders exhaustively, and verifies no rendered field name exists outside the schema.

Deferred to their own atomic changes (noted in the issue thread): full semantic decision-packet shrink, bounded zod-feedback repair loop, transcript-renderer dedup across judge surfaces, token-estimate hardening.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS 816 passed (+4 drift-guard tests; existing prompt suites unchanged and green)
