### PR TITLE
feat(eval): generation-temperature sweep harness with pinned seed

### DIFF
--- a/docs/eval/evidence/temperature-sweep-mock.json
+++ b/docs/eval/evidence/temperature-sweep-mock.json
@@ -1,0 +1,77 @@
+{
+  "version": "temperature-sweep-v1",
+  "mode": "mock",
+  "generatedAt": "2026-08-22T12:14:53.583Z",
+  "scenarios": [
+    "motive_gossip",
+    "v1_exclusion_inferred",
+    "motive_conflict",
+    "stagnation_resentment_loop"
+  ],
+  "grid": [
+    {
+      "temperature": 0.25,
+      "runs": 4,
+      "guardBlocks": 92,
+      "contentRepetitionMean": 0.302,
+      "axisMeans": {
+        "in_character": 3.25,
+        "voice_match": 2.25,
+        "motive_authenticity": 5,
+        "interpretation": 5,
+        "creativity_unhinged": 4,
+        "memory_continuity": 4,
+        "no_ai_leak": 5,
+        "narrative_cohesion": 5
+      }
+    },
+    {
+      "temperature": 0.5,
+      "runs": 4,
+      "guardBlocks": 92,
+      "contentRepetitionMean": 0.302,
+      "axisMeans": {
+        "in_character": 3.25,
+        "voice_match": 2.25,
+        "motive_authenticity": 5,
+        "interpretation": 5,
+        "creativity_unhinged": 4,
+        "memory_continuity": 4,
+        "no_ai_leak": 5,
+        "narrative_cohesion": 5
+      }
+    },
+    {
+      "temperature": 0.7,
+      "runs": 4,
+      "guardBlocks": 92,
+      "contentRepetitionMean": 0.302,
+      "axisMeans": {
+        "in_character": 3.25,
+        "voice_match": 2.25,
+        "motive_authenticity": 5,
+        "interpretation": 5,
+        "creativity_unhinged": 4,
+        "memory_continuity": 4,
+        "no_ai_leak": 5,
+        "narrative_cohesion": 5
+      }
+    },
+    {
+      "temperature": 1,
+      "runs": 4,
+      "guardBlocks": 44,
+      "contentRepetitionMean": 0.078,
+      "axisMeans": {
+        "in_character": 3.75,
+        "voice_match": 2.75,
+        "motive_authenticity": 5,
+        "interpretation": 5,
+        "creativity_unhinged": 4.75,
+        "memory_continuity": 4,
+        "no_ai_leak": 5,
+        "narrative_cohesion": 5
+      }
+    }
+  ]
+}

--- a/docs/eval/evidence/temperature-sweep-mock.json
+++ b/docs/eval/evidence/temperature-sweep-mock.json
@@ -1,7 +1,7 @@
 {
   "version": "temperature-sweep-v1",
   "mode": "mock",
-  "generatedAt": "2026-08-22T12:14:53.583Z",
+  "slice": "canary",
   "scenarios": [
     "motive_gossip",
     "v1_exclusion_inferred",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -19,7 +19,8 @@
     "calibrate": "node dist/cli/calibrate.js",
     "narrate": "node dist/cli/narrate.js",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "sweep:temperature": "node dist/cli/sweep-temperature.js"
   },
   "dependencies": {
     "@perfectman/engine": "workspace:*",

--- a/packages/eval/src/cli/sweep-temperature.ts
+++ b/packages/eval/src/cli/sweep-temperature.ts
@@ -76,11 +76,15 @@ export async function main(): Promise<void> {
     for (const scenario of scenarios) {
       const artifact = await ScenarioRunner.run(scenario!, {
         llmMode: "mock",
-        providerFactory: (llmConfig, agentId): LLMProvider =>
-          new PersonaAwareMockProvider(
-            packs.get(agentId)!,
-            scenario!.seed,
-          ),
+        providerFactory: (llmConfig, agentId): LLMProvider => {
+          // Agents without a compiled pack degrade to the generic pack,
+          // matching the default factory's behavior.
+          const pack =
+            packs.get(agentId) ??
+            getPersonaPackById("generic") ??
+            packs.values().next().value!;
+          return new PersonaAwareMockProvider(pack, scenario!.seed);
+        },
       });
 
       cell.runs++;

--- a/packages/eval/src/cli/sweep-temperature.ts
+++ b/packages/eval/src/cli/sweep-temperature.ts
@@ -1,7 +1,14 @@
 /**
  * Generation-temperature sweep — the 0.25 default was never compared
- * against alternatives. Grid over temperatures x the canary scenario set,
- * seed pinned, fully offline (persona-aware mock + rule judge).
+ * against alternatives. Grid over temperatures x the canary slice, fully
+ * offline (persona-aware mock + rule judge).
+ *
+ * Determinism: the mock provider is seeded from `scenario.seed`, so a cell
+ * replays the same transcript on every run and the report is byte-identical
+ * across runs. `PERFECTMAN_LLM_SEED` cannot perturb it — that env var feeds
+ * `benchSeed()` inside `localLLMConfig`, which only the live-model path uses.
+ * The report carries no wall-clock field for the same reason: the committed
+ * evidence matrix has to diff cleanly against a fresh run.
  *
  * Honest scoping: the deterministic mock's only temperature sensitivity is
  * its charged-react gate (temperature >= 0.9), so sub-0.9 cells are
@@ -13,21 +20,37 @@
  */
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { PersonaPack } from "@perfectman/shared";
+import type { PersonaPack, RoleplayScenario } from "@perfectman/shared";
 import { getScenario, getPersonaPackById, ALL_PERSONAS } from "@perfectman/shared";
 import { ScenarioRunner } from "../run/scenario-runner.js";
 import { ruleJudge } from "../judge/judge.js";
-import { PersonaAwareMockProvider } from "../bench/persona-aware-mock.js";
-import type { LLMProvider } from "@perfectman/server";
+import { personaAwareProviderFactory } from "../bench/persona-aware-mock.js";
+import { resolveBenchSlice } from "../bench-slices.js";
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
   const i = args.indexOf(flag);
-  return i >= 0 ? args[i + 1] : undefined;
+  if (i < 0) return undefined;
+  const value = args[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
 }
 
 const TEMPERATURES = [0.25, 0.5, 0.7, 1.0];
-const SCENARIOS = ["motive_gossip", "v1_exclusion_inferred", "motive_conflict", "stagnation_resentment_loop"];
+
+/** The slice this sweep runs; `canary` is owned by `bench-slices.ts`. */
+const SLICE = "canary";
+
+/**
+ * The prefix `ActionIntentStep` stamps on a repetition-guard fallback's
+ * `privateMotiveSummary`. `guardBlocks` is the sweep's headline metric and
+ * this prose is its only signal, so rewording that sentence upstream would
+ * zero the metric with no other symptom — `sweep-temperature.test.ts` pins
+ * the marker against a real run so the reword fails loudly instead.
+ */
+export const REPETITION_GUARD_MOTIVE_MARKER = "Repetition guard";
 
 type Cell = {
   temperature: number;
@@ -36,6 +59,23 @@ type Cell = {
   contentRepetitionMean: number;
   axisMeans: Record<string, number>;
 };
+
+/**
+ * Exported for tests: an id that stops resolving must abort the sweep, not
+ * quietly shrink the grid's denominator.
+ */
+export function sweepScenarios(
+  ids: readonly string[] | undefined = resolveBenchSlice(SLICE),
+): RoleplayScenario[] {
+  if (!ids || ids.length === 0) {
+    throw new Error(`Slice "${SLICE}" resolved to no scenarios — nothing to sweep`);
+  }
+  return ids.map(id => {
+    const scenario = getScenario(id);
+    if (!scenario) throw new Error(`Slice "${SLICE}" references unknown scenario "${id}"`);
+    return scenario;
+  });
+}
 
 function packsAtTemperature(temperature: number): Map<string, PersonaPack> {
   const packs = new Map<string, PersonaPack>();
@@ -48,17 +88,21 @@ function packsAtTemperature(temperature: number): Map<string, PersonaPack> {
   return packs;
 }
 
-function countGuardBlocks(events: readonly { type: string; payload: Record<string, unknown> }[]): number {
-  return events.filter(
-    e =>
-      e.type === "no_op_recorded" &&
-      typeof e.payload["privateMotiveSummary"] === "string" &&
-      (e.payload["privateMotiveSummary"] as string).includes("Repetition guard"),
-  ).length;
+export function countGuardBlocks(
+  events: readonly { type: string; payload: Record<string, unknown> }[],
+): number {
+  return events.filter(e => {
+    if (e.type !== "no_op_recorded") return false;
+    const motive = e.payload["privateMotiveSummary"];
+    return typeof motive === "string" && motive.includes(REPETITION_GUARD_MOTIVE_MARKER);
+  }).length;
 }
 
 export async function main(): Promise<void> {
-  const scenarios = SCENARIOS.map(id => getScenario(id)).filter(s => s !== undefined);
+  // Resolved before the grid runs: a malformed --out must not cost 16 runs
+  // and then discard them.
+  const out = argValue("--out");
+  const scenarios = sweepScenarios();
   const grid: Cell[] = [];
 
   for (const temperature of TEMPERATURES) {
@@ -72,28 +116,25 @@ export async function main(): Promise<void> {
     };
     const axisSums: Record<string, { sum: number; count: number }> = {};
     let repetitionSum = 0;
+    let repetitionRuns = 0;
 
     for (const scenario of scenarios) {
-      const artifact = await ScenarioRunner.run(scenario!, {
+      const artifact = await ScenarioRunner.run(scenario, {
         llmMode: "mock",
-        providerFactory: (llmConfig, agentId): LLMProvider => {
-          // Agents without a compiled pack degrade to the generic pack,
-          // matching the default factory's behavior.
-          const pack =
-            packs.get(agentId) ??
-            getPersonaPackById("generic") ??
-            packs.values().next().value!;
-          return new PersonaAwareMockProvider(pack, scenario!.seed);
-        },
+        providerFactory: personaAwareProviderFactory(packs, scenario.seed),
       });
 
       cell.runs++;
       cell.guardBlocks += countGuardBlocks(artifact.events);
       const repetitionProbe = artifact.probeResults.find(p => p.probe === "content-repetition");
-      if (repetitionProbe) repetitionSum += repetitionProbe.measured;
+      if (!repetitionProbe) {
+        throw new Error(`content-repetition probe missing from ${scenario.id} — the cell mean would read 0`);
+      }
+      repetitionSum += repetitionProbe.measured;
+      repetitionRuns++;
 
       const scores = ruleJudge(
-        scenario!,
+        scenario,
         artifact.events,
         artifact.probeResults,
         artifact.passedSignals / Math.max(1, artifact.totalSignals),
@@ -105,8 +146,7 @@ export async function main(): Promise<void> {
       }
     }
 
-    cell.contentRepetitionMean =
-      Math.round((repetitionSum / Math.max(1, cell.runs)) * 1000) / 1000;
+    cell.contentRepetitionMean = Math.round((repetitionSum / repetitionRuns) * 1000) / 1000;
     for (const [axis, a] of Object.entries(axisSums)) {
       cell.axisMeans[axis] = Math.round((a.sum / a.count) * 1000) / 1000;
     }
@@ -122,11 +162,10 @@ export async function main(): Promise<void> {
   const report = {
     version: "temperature-sweep-v1" as const,
     mode: "mock" as const,
-    generatedAt: new Date().toISOString(),
-    scenarios: SCENARIOS,
+    slice: SLICE,
+    scenarios: scenarios.map(s => s.id),
     grid,
   };
-  const out = argValue("--out");
   if (out) {
     const outPath = resolve(out);
     mkdirSync(dirname(outPath), { recursive: true });

--- a/packages/eval/src/cli/sweep-temperature.ts
+++ b/packages/eval/src/cli/sweep-temperature.ts
@@ -1,0 +1,141 @@
+/**
+ * Generation-temperature sweep — the 0.25 default was never compared
+ * against alternatives. Grid over temperatures x the canary scenario set,
+ * seed pinned, fully offline (persona-aware mock + rule judge).
+ *
+ * Honest scoping: the deterministic mock's only temperature sensitivity is
+ * its charged-react gate (temperature >= 0.9), so sub-0.9 cells are
+ * expected to be identical. The harness exists so live-model sweeps drop
+ * straight in.
+ *
+ * Usage:
+ *   pnpm --filter @perfectman/eval sweep:temperature --out out/temperature-sweep.json
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { PersonaPack } from "@perfectman/shared";
+import { getScenario, getPersonaPackById, ALL_PERSONAS } from "@perfectman/shared";
+import { ScenarioRunner } from "../run/scenario-runner.js";
+import { ruleJudge } from "../judge/judge.js";
+import { PersonaAwareMockProvider } from "../bench/persona-aware-mock.js";
+import type { LLMProvider } from "@perfectman/server";
+
+const args = process.argv.slice(2);
+function argValue(flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+const TEMPERATURES = [0.25, 0.5, 0.7, 1.0];
+const SCENARIOS = ["motive_gossip", "v1_exclusion_inferred", "motive_conflict", "stagnation_resentment_loop"];
+
+type Cell = {
+  temperature: number;
+  runs: number;
+  guardBlocks: number;
+  contentRepetitionMean: number;
+  axisMeans: Record<string, number>;
+};
+
+function packsAtTemperature(temperature: number): Map<string, PersonaPack> {
+  const packs = new Map<string, PersonaPack>();
+  for (const persona of ALL_PERSONAS) {
+    const pack = getPersonaPackById(persona.id);
+    if (pack) {
+      packs.set(persona.id, { ...pack, sampling: { ...pack.sampling, temperature } });
+    }
+  }
+  return packs;
+}
+
+function countGuardBlocks(events: readonly { type: string; payload: Record<string, unknown> }[]): number {
+  return events.filter(
+    e =>
+      e.type === "no_op_recorded" &&
+      typeof e.payload["privateMotiveSummary"] === "string" &&
+      (e.payload["privateMotiveSummary"] as string).includes("Repetition guard"),
+  ).length;
+}
+
+export async function main(): Promise<void> {
+  const scenarios = SCENARIOS.map(id => getScenario(id)).filter(s => s !== undefined);
+  const grid: Cell[] = [];
+
+  for (const temperature of TEMPERATURES) {
+    const packs = packsAtTemperature(temperature);
+    const cell: Cell = {
+      temperature,
+      runs: 0,
+      guardBlocks: 0,
+      contentRepetitionMean: 0,
+      axisMeans: {},
+    };
+    const axisSums: Record<string, { sum: number; count: number }> = {};
+    let repetitionSum = 0;
+
+    for (const scenario of scenarios) {
+      const artifact = await ScenarioRunner.run(scenario!, {
+        llmMode: "mock",
+        providerFactory: (llmConfig, agentId): LLMProvider =>
+          new PersonaAwareMockProvider(
+            packs.get(agentId)!,
+            scenario!.seed,
+          ),
+      });
+
+      cell.runs++;
+      cell.guardBlocks += countGuardBlocks(artifact.events);
+      const repetitionProbe = artifact.probeResults.find(p => p.probe === "content-repetition");
+      if (repetitionProbe) repetitionSum += repetitionProbe.measured;
+
+      const scores = ruleJudge(
+        scenario!,
+        artifact.events,
+        artifact.probeResults,
+        artifact.passedSignals / Math.max(1, artifact.totalSignals),
+      );
+      for (const [axis, value] of Object.entries(scores)) {
+        axisSums[axis] ??= { sum: 0, count: 0 };
+        axisSums[axis]!.sum += value;
+        axisSums[axis]!.count++;
+      }
+    }
+
+    cell.contentRepetitionMean =
+      Math.round((repetitionSum / Math.max(1, cell.runs)) * 1000) / 1000;
+    for (const [axis, a] of Object.entries(axisSums)) {
+      cell.axisMeans[axis] = Math.round((a.sum / a.count) * 1000) / 1000;
+    }
+    grid.push(cell);
+    console.log(
+      `temperature=${temperature} | guardBlocks=${cell.guardBlocks} ` +
+        `contentRepetition=${cell.contentRepetitionMean} ` +
+        `creativity=${cell.axisMeans["creativity_unhinged"] ?? "-"} ` +
+        `cohesion=${cell.axisMeans["narrative_cohesion"] ?? "-"}`,
+    );
+  }
+
+  const report = {
+    version: "temperature-sweep-v1" as const,
+    mode: "mock" as const,
+    generatedAt: new Date().toISOString(),
+    scenarios: SCENARIOS,
+    grid,
+  };
+  const out = argValue("--out");
+  if (out) {
+    const outPath = resolve(out);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
+  }
+}
+
+if (
+  process.argv[1]?.endsWith("sweep-temperature.js") ||
+  process.argv[1]?.endsWith("sweep-temperature.ts")
+) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/eval/src/test/sweep-temperature.test.ts
+++ b/packages/eval/src/test/sweep-temperature.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { getScenario } from "@perfectman/shared";
+import { ScenarioRunner } from "../run/scenario-runner.js";
+import {
+  countGuardBlocks,
+  sweepScenarios,
+  REPETITION_GUARD_MOTIVE_MARKER,
+} from "../cli/sweep-temperature.js";
+import { resolveBenchSlice } from "../bench-slices.js";
+
+describe("temperature sweep: scenario resolution", () => {
+  it("takes its set from the canary slice rather than a second hardcoded list", () => {
+    expect(sweepScenarios().map(s => s.id)).toEqual(resolveBenchSlice("canary"));
+  });
+
+  it("aborts on an id that no longer resolves instead of shrinking the grid", () => {
+    expect(() => sweepScenarios(["motive_gossip", "renamed_away"])).toThrow(
+      /unknown scenario "renamed_away"/,
+    );
+  });
+
+  it("aborts on an empty set instead of reporting an all-zero grid", () => {
+    expect(() => sweepScenarios([])).toThrow(/no scenarios/);
+    expect(() => sweepScenarios(undefined)).not.toThrow();
+  });
+});
+
+/**
+ * `guardBlocks` is the sweep's headline metric and its only signal is prose
+ * that `ActionIntentStep` writes into a blocked intent's motive. Rewording
+ * that sentence would zero the metric with no other symptom, so the marker is
+ * asserted against a real pipeline run rather than a synthetic event.
+ */
+describe("temperature sweep: repetition-guard marker", () => {
+  it("counts guard blocks the real pipeline actually emits", async () => {
+    const scenario = getScenario("motive_gossip");
+    if (!scenario) throw new Error("motive_gossip missing from the scenario registry");
+    const artifact = await ScenarioRunner.run(scenario, { llmMode: "mock" });
+
+    const noOpMotives = artifact.events
+      .filter(e => e.type === "no_op_recorded")
+      .map(e => e.payload["privateMotiveSummary"])
+      .filter((m): m is string => typeof m === "string");
+
+    // Without no_ops the marker assertion below would be vacuous.
+    expect(noOpMotives.length).toBeGreaterThan(0);
+    expect(noOpMotives.some(m => m.includes(REPETITION_GUARD_MOTIVE_MARKER))).toBe(true);
+    expect(countGuardBlocks(artifact.events)).toBeGreaterThan(0);
+  });
+
+  it("ignores no_ops whose motive is not a guard block", () => {
+    expect(
+      countGuardBlocks([
+        { type: "no_op_recorded", payload: { privateMotiveSummary: "Chose to stay quiet." } },
+        { type: "message_sent", payload: { privateMotiveSummary: "Repetition guard: ..." } },
+        { type: "no_op_recorded", payload: {} },
+      ]),
+    ).toBe(0);
+  });
+});
+
+describe("temperature sweep: pinned seed", () => {
+  it("replays an identical transcript across runs of the same scenario", async () => {
+    const scenario = getScenario("motive_gossip");
+    if (!scenario) throw new Error("motive_gossip missing from the scenario registry");
+    const fingerprint = async (): Promise<string> => {
+      const artifact = await ScenarioRunner.run(scenario, { llmMode: "mock" });
+      return artifact.events
+        .map(e => `${e.type}|${e.actorId ?? ""}|${JSON.stringify(e.payload["visibleContent"] ?? e.payload["emoji"] ?? "")}`)
+        .join("\n");
+    };
+
+    const first = await fingerprint();
+    expect(first.length).toBeGreaterThan(0);
+    expect(await fingerprint()).toBe(first);
+  });
+});


### PR DESCRIPTION
## What

Measures the generation-temperature tradeoff that the 0.25 default never had:

- New offline CLI `pnpm --filter @perfectman/eval sweep:temperature`: grid [0.25, 0.5, 0.7, 1.0] × the canary scenario set, seed pinned (42) so cells differ only by temperature — the confound the reproducibility work removed.
- Each cell clones the persona packs with `sampling.temperature` overridden and runs through a custom provider factory; per-cell metrics from real artifacts: repetition-guard block count (the expected cost curve), content-repetition probe mean, and rule-judge axis means.
- Committed mock evidence already shows the expected shape: 0.25–0.7 identical (the deterministic mock's only sensitivity is its charged-react gate at ≥ 0.9), while 1.0 diverges — fewer guard blocks, lower content repetition, higher creativity. Honest scoping included; live-model sweeps drop straight into this harness.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS
- Sweep executed end-to-end offline; 4-cell matrix committed under docs/eval/evidence/.
