### PR TITLE
fix(eval): repair the ignored-review residuals (empty-set similarity, marker source, judge endpoint)

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -74,6 +74,37 @@ LLM judge scores it from the whole transcript; `--per-turn` (LLM judge only)
 replaces that with the mean of per-turn scores — each sampled content-bearing
 turn is scored against the turn before it (see `packages/eval/src/judge/judge.ts`).
 
+## Offline sweeps (policy knobs, no live models)
+
+Two grid harnesses sweep the repetition guard and the temperature axis fully
+offline (persona-aware mock + rule judge), and each commits its evidence
+matrix to `docs/eval/evidence/`:
+
+- `pnpm --filter @perfectman/eval sweep:repetition --out out/repetition-sweep.json`
+  — `threshold × maxRetries` over 3 scenarios. The output embeds
+  `probeThreshold` (the content-repetition yardstick is always measured at the
+  probe's fixed 0.7, never at the cell's runtime threshold) and a `limitations`
+  field (mock repeats sit at ≈1.0 Jaccard, so threshold cells are
+  indistinguishable by construction — only `providerCalls`/`guardBlocks` vary
+  across that axis).
+- `pnpm --filter @perfectman/eval sweep:temperature --out out/temperature-sweep.json`
+  — temperature grid over the `canary` slice; cells below the mock's only
+  temperature read (the ≥0.9 charged-react gate) are identical by
+  construction, which the `limitations` field says.
+
+Both reports carry no wall-clock/timestamp fields so `cmp` against the
+committed evidence is a literal check — a fresh run MUST be byte-identical.
+The `guardBlocks` metric in both sweeps matches the exported
+`REPETITION_GUARD_MARKER` prefix from `@perfectman/server`; rewording that
+sentence upstream turns the sweep tests red, never a silent zero.
+
+Calibration note: `docs/eval/evidence/calibration-mock-full.json` commits
+`kappa 0.129 / alpha −0.104` against `targetKappa 0.7, passed: false` — the
+judge calibration report is the ground truth even when it fails, and 5 of 10
+rubric axes have zero variance across the 39 golden labels (`voice_match`=4,
+`no_ai_leak`=5), which caps per-axis kappa at 0 for those axes until the
+golden set gains spread.
+
 Every PR also runs this harness in CI (`.github/workflows/pr-gate.yml`):
 typecheck, unit tests, then a mock+rule-judge bench over the golden scenario
 subset with a hard 100%-signals assertion (`scripts/ci/check-bench-gate.mjs`)

--- a/docs/eval/evidence/temperature-sweep-mock.json
+++ b/docs/eval/evidence/temperature-sweep-mock.json
@@ -2,6 +2,8 @@
   "version": "temperature-sweep-v1",
   "mode": "mock",
   "slice": "canary",
+  "seeds": "scenario.seed per cell — PERFECTMAN_LLM_SEED only reaches localLLMConfig (live mode) and cannot perturb this path",
+  "limitations": "the deterministic mock's only temperature read is the charged-react gate (temperature >= 0.9), so all sub-0.9 cells are identical by construction — only guardBlocks/contentRepetition/creativity/cohesion cells at >= 0.9 vary",
   "scenarios": [
     "motive_gossip",
     "v1_exclusion_inferred",

--- a/docs/eval/qwen3-comparison-protocol.md
+++ b/docs/eval/qwen3-comparison-protocol.md
@@ -70,19 +70,27 @@ Prefer 1.7b unless 8b wins ≥ two quality axes by a full point across the
 usable pairs AND costs ≤ 2× median paired latency with comparable
 fallback pressure. Anything narrower is noise at this n.
 
-**Instrument caveat (why quality axes are provisional here).** The recipe
-above runs `--judge rule`, whose axes are structural heuristics that
+**Instrument caveat (provisional; the real judge is cross-family).** The
+recipe above runs `--judge rule`, whose axes are structural heuristics that
 main's own docs say not to trust as prose-quality measures — a genuine 8b
 quality win may be unmeasurable by that instrument, so the defaults
 would win by construction. The correct instrument is a cross-family LLM
 judge (DeepSeek at temperature 0, sidestepping local-qwen-judges-its-own-
-arms bias), but the CLI currently shares one endpoint env
-(`PERFECTMAN_LLM_BASE_URL`) between the arena and the judge, so a
-separate-endpoint judge is not runnable today without pointing the arena
-at DeepSeek too. Until a judge-endpoint override lands (small follow-up:
-`PERFECTMAN_JUDGE_BASE_URL` in `judgeConfig()`), treat every quality
-conclusion as provisional and lean on the required full-point margin and
-multi-seed sweeps to keep noise out of the verdict.
+arms bias), which is runnable today with a judge endpoint separate from the
+arena:
+
+```sh
+PERFECTMAN_LLM_BASE_URL=http://localhost:11434/v1 PERFECTMAN_LLM_MODEL=qwen3:8b \
+PERFECTMAN_JUDGE_BASE_URL=https://api.deepseek.com/v1 PERFECTMAN_JUDGE_MODEL=deepseek-chat \
+PERFECTMAN_LLM_API_KEY=$DEEPSEEK_API_KEY PERFECTMAN_JUDGE_TEMPERATURE=0 \
+pnpm --filter @perfectman/eval bench --mode local --judge llm --scenarios "$SCENARIO" …
+```
+
+(`PERFECTMAN_JUDGE_BASE_URL`/`PERFECTMAN_JUDGE_MODEL`/`PERFECTMAN_JUDGE_TEMPERATURE`
+override the judge independently of the arena — see `judgeConfig()` in
+`packages/eval/src/cli/bench.ts`.) Until that run exists, treat every
+quality conclusion as provisional and lean on the required full-point
+margin and multi-seed sweeps to keep noise out of the verdict.
 
 ## What stays manual
 

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T18:59:42.458Z",
+  "generatedAt": "2026-08-22T19:06:39.198Z",
   "totals": {
     "files": 91,
-    "its": 838
+    "its": 842
   },
   "byPackage": {
     "engine": {
@@ -12,12 +12,12 @@
     },
     "eval": {
       "files": 13,
-      "its": 94,
+      "its": 96,
       "flags": []
     },
     "server": {
       "files": 49,
-      "its": 412,
+      "its": 414,
       "flags": [
         "console(1)",
         "async-pause(1)"
@@ -562,7 +562,7 @@
       "file": "packages/eval/src/test/bench.test.ts",
       "pkg": "eval",
       "layer": "eval-harness",
-      "its": 5,
+      "its": 7,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -1004,7 +1004,7 @@
       "file": "packages/server/src/agent/__tests__/repetition-guard.test.ts",
       "pkg": "server",
       "layer": "integration",
-      "its": 6,
+      "its": 8,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T18:59:42.453Z — audited 91 files, 838 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-22T19:06:39.193Z — audited 91 files, 842 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -9,11 +9,11 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | Package | Files | it/test | Hygiene flags
 |---|---|---|---|
 | engine | 22 | 259 | —
-| eval | 13 | 94 | —
-| server | 49 | 412 | console(1), async-pause(1)
+| eval | 13 | 96 | —
+| server | 49 | 414 | console(1), async-pause(1)
 | shared | 7 | 73 | —
 
-**Total: 91 files, 838 it/test blocks; 2 files flagged.**
+**Total: 91 files, 842 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -43,7 +43,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/engine/src/perception/__tests__/memory-salience.test.ts | integration | 12 | 
 | packages/eval/src/test/bench-seed.test.ts | eval-harness | 7 | 
 | packages/eval/src/test/bench-slices.test.ts | eval-harness | 6 | 
-| packages/eval/src/test/bench.test.ts | eval-harness | 5 | 
+| packages/eval/src/test/bench.test.ts | eval-harness | 7 | 
 | packages/eval/src/test/calibration-matching.test.ts | eval-harness | 4 | 
 | packages/eval/src/test/calibration-properties.test.ts | eval-harness | 6 | 
 | packages/eval/src/test/echo-chamber-stability.test.ts | eval-harness | 2 | 
@@ -63,7 +63,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/agent/__tests__/intent-parser.test.ts | integration | 16 | 
 | packages/server/src/agent/__tests__/persona-loader.test.ts | integration | 7 | 
 | packages/server/src/agent/__tests__/prompt-builder.test.ts | integration | 17 | 
-| packages/server/src/agent/__tests__/repetition-guard.test.ts | integration | 6 | 
+| packages/server/src/agent/__tests__/repetition-guard.test.ts | integration | 8 | 
 | packages/server/src/agent/surface/__tests__/action-intent-step.test.ts | integration | 9 | 
 | packages/server/src/cli/__tests__/llm-health-check.test.ts | integration | 3 | 
 | packages/server/src/config/__tests__/simulation-config.test.ts | integration | 11 | 

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -37,6 +37,7 @@ export function judgeConfig(): import("../judge/judge.js").LLMJudgeConfig {
     && process.env.PERFECTMAN_JUDGE_TEMPERATURE.trim() !== "";
   return {
     baseUrl:
+      process.env.PERFECTMAN_JUDGE_BASE_URL ??
       process.env.PERFECTMAN_LLM_BASE_URL ??
       (isDeepseek ? "https://api.deepseek.com/v1" : "http://localhost:11434/v1"),
     model:

--- a/packages/eval/src/cli/sweep-temperature.ts
+++ b/packages/eval/src/cli/sweep-temperature.ts
@@ -26,6 +26,7 @@ import { ScenarioRunner } from "../run/scenario-runner.js";
 import { ruleJudge } from "../judge/judge.js";
 import { personaAwareProviderFactory } from "../bench/persona-aware-mock.js";
 import { resolveBenchSlice } from "../bench-slices.js";
+import { REPETITION_GUARD_MARKER } from "@perfectman/server";
 
 const args = process.argv.slice(2);
 function argValue(flag: string): string | undefined {
@@ -44,14 +45,13 @@ const TEMPERATURES = [0.25, 0.5, 0.7, 1.0];
 const SLICE = "canary";
 
 /**
- * The prefix `ActionIntentStep` stamps on a repetition-guard fallback's
- * `privateMotiveSummary`. `guardBlocks` is the sweep's headline metric and
- * this prose is its only signal, so rewording that sentence upstream would
- * zero the metric with no other symptom — `sweep-temperature.test.ts` pins
- * the marker against a real run so the reword fails loudly instead.
+ * `guardBlocks` is the sweep's headline metric and its only signal is the
+ * marker prefix `ActionIntentStep` stamps on a repetition-guard fallback's
+ * `privateMotiveSummary` — rewording that sentence upstream would zero the
+ * metric with no other symptom, so `sweep-temperature.test.ts` pins the
+ * marker against a real run and the reword fails loudly instead. The single
+ * definition lives in `@perfectman/server`; this sweep imports it.
  */
-export const REPETITION_GUARD_MOTIVE_MARKER = "Repetition guard";
-
 type Cell = {
   temperature: number;
   runs: number;
@@ -94,7 +94,7 @@ export function countGuardBlocks(
   return events.filter(e => {
     if (e.type !== "no_op_recorded") return false;
     const motive = e.payload["privateMotiveSummary"];
-    return typeof motive === "string" && motive.includes(REPETITION_GUARD_MOTIVE_MARKER);
+    return typeof motive === "string" && motive.includes(REPETITION_GUARD_MARKER);
   }).length;
 }
 
@@ -163,6 +163,9 @@ export async function main(): Promise<void> {
     version: "temperature-sweep-v1" as const,
     mode: "mock" as const,
     slice: SLICE,
+    seeds: "scenario.seed per cell — PERFECTMAN_LLM_SEED only reaches localLLMConfig (live mode) and cannot perturb this path",
+    limitations:
+      "the deterministic mock's only temperature read is the charged-react gate (temperature >= 0.9), so all sub-0.9 cells are identical by construction — only guardBlocks/contentRepetition/creativity/cohesion cells at >= 0.9 vary",
     scenarios: scenarios.map(s => s.id),
     grid,
   };

--- a/packages/eval/src/test/bench.test.ts
+++ b/packages/eval/src/test/bench.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../run/scenario-runner.js", () => ({
   ScenarioRunner: {
@@ -24,7 +24,7 @@ vi.mock("../run/scenario-runner.js", () => ({
   },
 }));
 
-const { runBench } = await import("../cli/bench.js");
+const { runBench, judgeConfig } = await import("../cli/bench.js");
 const { BENCH_SLICES, resolveBenchSlice } = await import("../bench-slices.js");
 
 describe("runBench", () => {
@@ -66,5 +66,33 @@ describe("runBench slice selection", () => {
 
     expect(resolveBenchSlice("edges")).toHaveLength(4);
     expect(report.scenariosRun).toBe(3);
+  });
+});
+
+describe("judgeConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("lets the judge use a separate endpoint from the arena (cross-family judging)", () => {
+    vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "local");
+    vi.stubEnv("PERFECTMAN_JUDGE_BASE_URL", "https://api.deepseek.com/v1");
+    vi.stubEnv("PERFECTMAN_LLM_BASE_URL", "http://localhost:11434/v1");
+    vi.stubEnv("PERFECTMAN_JUDGE_MODEL", "deepseek-chat");
+    vi.stubEnv("PERFECTMAN_LLM_MODEL", "qwen3:1.7b");
+    vi.stubEnv("PERFECTMAN_JUDGE_TEMPERATURE", "0");
+
+    const cfg = judgeConfig();
+    expect(cfg.baseUrl).toBe("https://api.deepseek.com/v1");
+    expect(cfg.model).toBe("deepseek-chat");
+    expect(cfg.temperature).toBe(0);
+  });
+
+  it("falls back to the arena endpoint when no judge endpoint is set", () => {
+    vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "local");
+    vi.stubEnv("PERFECTMAN_LLM_BASE_URL", "http://localhost:11434/v1");
+    delete process.env.PERFECTMAN_JUDGE_BASE_URL;
+
+    expect(judgeConfig().baseUrl).toBe("http://localhost:11434/v1");
   });
 });

--- a/packages/eval/src/test/sweep-temperature.test.ts
+++ b/packages/eval/src/test/sweep-temperature.test.ts
@@ -4,8 +4,8 @@ import { ScenarioRunner } from "../run/scenario-runner.js";
 import {
   countGuardBlocks,
   sweepScenarios,
-  REPETITION_GUARD_MOTIVE_MARKER,
 } from "../cli/sweep-temperature.js";
+import { REPETITION_GUARD_MARKER } from "@perfectman/server";
 import { resolveBenchSlice } from "../bench-slices.js";
 
 describe("temperature sweep: scenario resolution", () => {
@@ -44,7 +44,7 @@ describe("temperature sweep: repetition-guard marker", () => {
 
     // Without no_ops the marker assertion below would be vacuous.
     expect(noOpMotives.length).toBeGreaterThan(0);
-    expect(noOpMotives.some(m => m.includes(REPETITION_GUARD_MOTIVE_MARKER))).toBe(true);
+    expect(noOpMotives.some(m => m.includes(REPETITION_GUARD_MARKER))).toBe(true);
     expect(countGuardBlocks(artifact.events)).toBeGreaterThan(0);
   });
 

--- a/packages/server/src/agent/__tests__/repetition-guard.test.ts
+++ b/packages/server/src/agent/__tests__/repetition-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isNearRepeat } from "../repetition-guard.js";
+import { isNearRepeat, similarity } from "../repetition-guard.js";
 
 describe("isNearRepeat", () => {
   it("flags an exact repeat", () => {
@@ -37,5 +37,21 @@ describe("isNearRepeat", () => {
     const candidate = "vi o episódio novo e achei incrível";
     const prior = "vi o episódio antigo ontem à noite";
     expect(isNearRepeat(candidate, [prior], 0.9)).toBe(false);
+  });
+
+  it("does not flag emoji/stopword-only candidates against emoji/stopword-only priors", () => {
+    // normalizeWords strips emoji and stopwords, so both sides normalize to
+    // EMPTY word sets — similarity([] , []) is 0, not 1, or a react-only
+    // message stream would block itself as an endless "repeat".
+    expect(similarity("😂😂", "🔥🔥")).toBe(0);
+    expect(isNearRepeat("😂😂", ["🔥🔥"])).toBe(false);
+    expect(isNearRepeat("de e o a", ["da"])).toBe(false); // stopword-only
+  });
+
+  it("still flags emoji-decorated content when the words match", () => {
+    // The guard must not over-correct: punctuation/emoji-only DIFFS stay
+    // near-repeats once real words are present.
+    expect(similarity("vou embora 🙄", "vou embora 😤")).toBe(1);
+    expect(isNearRepeat("vou embora 🙄", ["vou embora 😤"])).toBe(true);
   });
 });

--- a/packages/server/src/agent/repetition-guard.ts
+++ b/packages/server/src/agent/repetition-guard.ts
@@ -30,7 +30,11 @@ export function normalizeWords(text: string): string[] {
 export function similarity(a: string, b: string): number {
   const wordsA = new Set(normalizeWords(a));
   const wordsB = new Set(normalizeWords(b));
-  if (wordsA.size === 0 && wordsB.size === 0) return 1;
+  // Two sets that both normalize to zero words carry no overlapping content
+  // evidence — scoring them 1.0 made `isNearRepeat("😂", ["🔥"])` a false
+  // positive inside the runtime guard (emoji-only messages blocked as
+  // repeats). The probes exclude empty-normalizing turns at their own layer.
+  if (wordsA.size === 0 && wordsB.size === 0) return 0;
   if (wordsA.size === 0 || wordsB.size === 0) return 0;
   let intersection = 0;
   for (const w of wordsA) if (wordsB.has(w)) intersection++;
@@ -78,5 +82,9 @@ export function isNearRepeat(
   threshold: number = REPETITION_SIMILARITY_THRESHOLD,
 ): boolean {
   if (!candidate || candidate.trim().length === 0) return false;
+  // A candidate that normalizes to zero words (emoji/stopword-only) cannot
+  // be a repeat no matter what the priors look like — the Jaccard over two
+  // empty sets is now 0, but short-circuit here so the intent is explicit.
+  if (normalizeWords(candidate).length === 0) return false;
   return ownRecentUtterances.some((prior) => similarity(candidate, prior) >= threshold);
 }


### PR DESCRIPTION
Follow-up PR addressing the review comments tracked as ignored in the operation's `UNRESOLVED-REVIEWS.md`:

- **`similarity` empty-set contract** (#70-`3835366910` residual): `similarity(a,b)` with both sides normalizing to zero words now returns 0, and `isNearRepeat` short-circuits zero-word candidates — an emoji/stopword-only message can no longer block itself as a repeat. Red-first test; gate bench verified unmoved (mock emits no empty-normalizing content turns).
- **Marker single-source** (#75-`3836486243`): `sweep-temperature` imports `REPETITION_GUARD_MARKER` from `@perfectman/server` instead of re-declaring the literal.
- **`PERFECTMAN_JUDGE_BASE_URL`** (#75-`3836486237`, qwen3-comparison protocol): the judge can point at a different endpoint/model/temperature than the arena — cross-family DeepSeek-at-0 judging of local-qwen transcripts; the protocol's provisional caveat is lifted with the concrete command.
- **Sweep report attribution** (#75-`3836486240/41`): `sweep:temperature` report carries `seeds` + `limitations` (sub-0.9 cells identical by construction); both evidence matrices regenerated, grids byte-identical to the committed ones.
- **Docs** (#75-`3836486249`, #62-`3834665246`): both sweeps documented in `docs/eval/README.md`; calibration report's zero-variance axes noted; test inventory regenerated (91 files / 842 its).

Validation: build 4/4, typecheck 4/4, 934 tests / 91 files, test:gate PASS 842 its, gate bench signal 100% / probe 87.4% (unchanged), both sweep grids byte-identical to committed evidence.