### PR TITLE
fix(eval): jury imputed-axes never vote, failed-juror visibility, endpoint guard

### DIFF
--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T19:34:46.783Z",
+  "generatedAt": "2026-08-22T19:54:49.330Z",
   "totals": {
     "files": 92,
-    "its": 853
+    "its": 855
   },
   "byPackage": {
     "engine": {
@@ -12,7 +12,7 @@
     },
     "eval": {
       "files": 14,
-      "its": 104,
+      "its": 106,
       "flags": []
     },
     "server": {
@@ -738,7 +738,7 @@
       "file": "packages/eval/src/test/jury-judge.test.ts",
       "pkg": "eval",
       "layer": "eval-harness",
-      "its": 9,
+      "its": 11,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -749,7 +749,7 @@
       "truthy": 0,
       "defined": 0,
       "deadIdTruthy": 0,
-      "nonNull": 5,
+      "nonNull": 7,
       "spies": 8,
       "asyncPauses": 0,
       "weakTerminals": [],

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T19:34:46.778Z — audited 92 files, 853 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-22T19:54:49.325Z — audited 92 files, 855 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -9,11 +9,11 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | Package | Files | it/test | Hygiene flags
 |---|---|---|---|
 | engine | 22 | 259 | —
-| eval | 14 | 104 | —
+| eval | 14 | 106 | —
 | server | 49 | 414 | console(1), async-pause(1)
 | shared | 7 | 76 | —
 
-**Total: 92 files, 853 it/test blocks; 2 files flagged.**
+**Total: 92 files, 855 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -51,7 +51,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/eval/src/test/intent-entropy.test.ts | eval-harness | 8 | 
 | packages/eval/src/test/judge-json-salvage.test.ts | eval-harness | 9 | 
 | packages/eval/src/test/judge-signals.test.ts | eval-harness | 10 | 
-| packages/eval/src/test/jury-judge.test.ts | eval-harness | 9 | 
+| packages/eval/src/test/jury-judge.test.ts | eval-harness | 11 | 
 | packages/eval/src/test/probes.test.ts | eval-harness | 23 | 
 | packages/eval/src/test/signal-breakdown.test.ts | eval-harness | 4 | 
 | packages/eval/src/test/sweep-temperature.test.ts | eval-harness | 6 | 

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -308,15 +308,25 @@ async function callJudge(
   return data.choices?.[0]?.message?.content ?? "";
 }
 
-function parseAxes(raw: string, scenario: RoleplayScenario): AxisScores {
+function parseAxes(raw: string, scenario: RoleplayScenario): { axes: AxisScores; imputedAxes: string[] } {
   const jsonText = extractJsonObject(raw);
   const parsed = JSON.parse(jsonText) as { axes?: Record<string, number> };
   const axes: AxisScores = {};
+  const imputedAxes: string[] = [];
   for (const axis of scenario.rubric.axes) {
     const v = parsed.axes?.[axis.id];
-    axes[axis.id] = typeof v === "number" ? clampScore(v) : 3;
+    if (typeof v === "number") {
+      axes[axis.id] = clampScore(v);
+    } else {
+      // Model omitted this axis: fill the neutral 3 for single-judge
+      // consumers, but flag it so a jury can exclude the vote — an
+      // unflagged default would move the median on axes the juror never
+      // scored.
+      axes[axis.id] = 3;
+      imputedAxes.push(axis.id);
+    }
   }
-  return axes;
+  return { axes, imputedAxes };
 }
 
 const RETRY_SYSTEM_SUFFIX =
@@ -328,7 +338,15 @@ const RETRY_SYSTEM_SUFFIX =
  * callers that feed scores into calibration must exclude these, since a
  * fabricated midpoint would silently compress the agreement signal.
  */
-export type JudgeResult = { axes: AxisScores; salvaged: boolean };
+/**
+ * `salvaged: true` means the axes were recovered from a prose critique (or
+ * partly defaulted to 3) rather than parsed from the requested JSON —
+ * callers that feed scores into calibration must exclude these, since a
+ * fabricated midpoint would silently compress the agreement signal.
+ * `imputedAxes` lists rubric axes the model omitted from its JSON answer
+ * (filled with 3 by the single-judge path, but juries exclude them).
+ */
+export type JudgeResult = { axes: AxisScores; salvaged: boolean; imputedAxes: string[] };
 
 export async function llmJudge(
   scenario: RoleplayScenario,
@@ -340,14 +358,16 @@ export async function llmJudge(
 
   rawAttempts.push(await callJudge(scenario, events, config));
   try {
-    return { axes: parseAxes(rawAttempts[0]!, scenario), salvaged: false };
+    const first = parseAxes(rawAttempts[0]!, scenario);
+    return { axes: first.axes, salvaged: false, imputedAxes: first.imputedAxes };
   } catch {
     // One strict retry covers judges that burned their budget on reasoning
     // or ignored the JSON instruction on the first pass.
   }
   try {
     rawAttempts.push(await callJudge(scenario, events, config, RETRY_SYSTEM_SUFFIX));
-    return { axes: parseAxes(rawAttempts[1]!, scenario), salvaged: false };
+    const second = parseAxes(rawAttempts[1]!, scenario);
+    return { axes: second.axes, salvaged: false, imputedAxes: second.imputedAxes };
   } catch {
     // Fall through to prose salvage — a judge that answered in a scored
     // critique still emitted usable signal. Try every response we hold:
@@ -362,7 +382,7 @@ export async function llmJudge(
         const v = salvaged[axis.id];
         axes[axis.id] = typeof v === "number" ? clampScore(v) : 3;
       }
-      return { axes, salvaged: true };
+      return { axes, salvaged: true, imputedAxes: [] };
     }
   }
 
@@ -398,12 +418,12 @@ export async function llmJudgePerTurn(
   config: LLMJudgeConfig,
   maxTurnSamples = 8,
 ): Promise<JudgeResult> {
-  const { axes, salvaged } = await llmJudge(scenario, events, config);
+  const { axes, salvaged, imputedAxes } = await llmJudge(scenario, events, config);
 
   // The per-turn axis is only meaningful when the rubric defines it (it lives
   // on roleplay-v1, not edge-chaos/behavioral). Guard before spending calls.
   if (!scenario.rubric.axes.some(a => a.id === "narrative_cohesion")) {
-    return { axes, salvaged };
+    return { axes, salvaged, imputedAxes };
   }
 
   const turns: CommittedEvent[][] = [];
@@ -437,7 +457,13 @@ export async function llmJudgePerTurn(
   if (cohesionCount > 0) {
     axes["narrative_cohesion"] = clampScore(cohesionSum / cohesionCount);
   }
-  return { axes, salvaged };
+  return {
+    axes,
+    salvaged,
+    // The per-turn pass actually measured cohesion, so it is no longer
+    // imputed even if the whole-transcript judge omitted it.
+    imputedAxes: imputedAxes.filter(a => a !== "narrative_cohesion"),
+  };
 }
 
 function turnTranscript(group: readonly CommittedEvent[]): string {
@@ -541,6 +567,11 @@ export type JuryJuror = {
   axes: AxisScores;
   /** True when this juror's scores came from prose salvage (imputed defaults). */
   salvaged: boolean;
+  /** Rubric axes the model omitted from its JSON answer (voted nothing). */
+  imputedAxes: string[];
+  /** Source of this juror's scores, for the evidence trail. */
+  model: string;
+  baseUrl: string;
 };
 
 export type JuryVerdict = {
@@ -550,6 +581,8 @@ export type JuryVerdict = {
   voterCount: number;
   /** Per-judge raw scores + salvage status, keyed by config label. */
   perJudge: Record<string, JuryJuror>;
+  /** Judges that errored (transport/timeout/parse), label → reason. */
+  failed: Record<string, string>;
 };
 
 function median(values: number[]): number {
@@ -564,10 +597,16 @@ function median(values: number[]): number {
  * shows up as spread in `perJudge`; the median resists a single biased
  * outlier ONLY when >= 3 jurors survive — with exactly 2 the median is the
  * mean and offers no outlier resistance. Salvaged jurors (prose-implied
- * scores, mostly imputed defaults) are reported but EXCLUDED from medians.
- * Judges that error are dropped; at least one unsalvaged survivor is
- * required. Labels must be unique — duplicates would silently collapse
- * two votes into one.
+ * scores, mostly imputed defaults) are reported but EXCLUDED from medians,
+ * and axes a juror omitted from its JSON answer are excluded from that
+ * juror's vote (the single-judge path fills the neutral 3; a jury must not
+ * let an unflagged default move the median). Judges that error are dropped
+ * and their label → reason recorded in `failed`; at least one unsalvaged
+ * survivor is required. Labels must be unique — duplicates would silently
+ * collapse two votes into one. **Caller obligation: jurors must be
+ * independently sourced** — duplicate (baseUrl, model) pairs throw, and
+ * each juror's model/baseUrl is recorded in `perJudge` so the sourcing is
+ * checkable later.
  */
 export async function juryJudge(
   scenario: RoleplayScenario,
@@ -582,20 +621,45 @@ export async function juryJudge(
     throw new Error(`Duplicate jury judge labels: ${[...new Set(duplicates)].join(", ")}`);
   }
 
+  // Three qwen3:8b configs with distinct labels are NOT a jury — they are
+  // the same bias three times. Reject same-endpoint pairs before any
+  // network call.
+  const endpointOwner = new Map<string, string>();
+  for (let i = 0; i < configs.length; i++) {
+    const key = `${configs[i]!.baseUrl}|${configs[i]!.model}`;
+    const owner = endpointOwner.get(key);
+    if (owner) {
+      throw new Error(
+        `Duplicate jury judge endpoint (${configs[i]!.baseUrl}, ${configs[i]!.model}) on labels "${owner}" and "${labels[i]}" — a jury must be independently sourced`,
+      );
+    }
+    endpointOwner.set(key, labels[i]!);
+  }
+
   const settled = await Promise.allSettled(
     configs.map(async (config, i) => ({
       label: labels[i]!,
+      config,
       result: await llmJudge(scenario, events, config),
     })),
   );
 
   const perJudge: Record<string, JuryJuror> = {};
-  for (const outcome of settled) {
+  const failed: Record<string, string> = {};
+  // Index-based: `allSettled` discards the payload on rejection, so the
+  // label must come from the configs array position, not the outcome.
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i]!;
     if (outcome.status === "fulfilled") {
       perJudge[outcome.value.label] = {
         axes: outcome.value.result.axes,
         salvaged: outcome.value.result.salvaged,
+        imputedAxes: outcome.value.result.imputedAxes,
+        model: outcome.value.config.model,
+        baseUrl: outcome.value.config.baseUrl,
       };
+    } else {
+      failed[labels[i]!] = (outcome.reason as Error)?.message ?? String(outcome.reason);
     }
   }
   if (Object.keys(perJudge).length === 0) {
@@ -616,12 +680,15 @@ export async function juryJudge(
 
   const axes: AxisScores = {};
   for (const axis of axisIds) {
-    const votes = voters.map(juror => juror.axes[axis]).filter((v): v is number => typeof v === "number");
+    const votes = voters
+      .filter(juror => !juror.imputedAxes.includes(axis))
+      .map(juror => juror.axes[axis])
+      .filter((v): v is number => typeof v === "number");
     // clampScore keeps the verdict on the repo's single integer score domain
     // — an unclamped x.5 median would inflate kappa categories if a verdict
     // ever reached computeCalibration, and every other AxisScores value is
     // an integer in [1,5].
     if (votes.length > 0) axes[axis] = clampScore(median(votes));
   }
-  return { axes, voterCount: voters.length, perJudge };
+  return { axes, voterCount: voters.length, perJudge, failed };
 }

--- a/packages/eval/src/test/jury-judge.test.ts
+++ b/packages/eval/src/test/jury-judge.test.ts
@@ -9,24 +9,6 @@ const baseConfig = {
   model: "test-model",
 };
 
-function stubJudgeResponses(responses: Array<Record<string, number>>): void {
-  let call = 0;
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockImplementation(() => {
-      const axes = responses[Math.min(call, responses.length - 1)]!;
-      call++;
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          choices: [{ message: { content: JSON.stringify({ axes }) } }],
-        }),
-      });
-    }),
-  );
-}
-
 describe("juryJudge", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -62,6 +44,10 @@ describe("juryJudge", () => {
     expect(Object.keys(verdict.perJudge).sort()).toEqual(["family-a", "family-b", "family-c"]);
     expect(verdict.perJudge["family-a"]!.axes.in_character).toBe(2);
     expect(verdict.perJudge["family-a"]!.salvaged).toBe(false);
+    // the evidence trail records each juror's source
+    expect(verdict.perJudge["family-a"]!.model).toBe("family-a");
+    expect(verdict.perJudge["family-a"]!.baseUrl).toBe("http://judge-host/v1");
+    expect(verdict.failed).toEqual({});
     // One fetch per judge, no retry: a parse-failure retry inside llmJudge
     // would shift the per-judge response mapping and this assertion reds.
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -115,7 +101,7 @@ describe("juryJudge", () => {
     expect(Number.isInteger(verdict.axes["in_character"])).toBe(true);
   });
 
-  it("drops failed judges and still reaches a verdict", async () => {
+  it("drops failed judges, records the reason, and still reaches a verdict", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation((_url: unknown, init?: { body?: string }) => {
@@ -130,9 +116,50 @@ describe("juryJudge", () => {
         });
       }),
     );
-    const verdict = await juryJudge(scenario, [], configs.slice(1));
+    // Full configs: family-a IS in the jury and failing — passing a sliced
+    // list would make the drops-failed path run zero times (regression pin
+    // for a vacuous version of this test).
+    const verdict = await juryJudge(scenario, [], configs);
     expect(Object.keys(verdict.perJudge)).toEqual(["family-b", "family-c"]);
+    expect(Object.keys(verdict.failed)).toEqual(["family-a"]);
+    expect(verdict.failed["family-a"]).toContain("500");
     expect(verdict.axes["in_character"]).toBe(4);
+  });
+
+  it("excludes axes a juror omitted from its JSON answer (imputed 3s never vote)", async () => {
+    // family-a answers ONLY in_character; parseAxes fills the other seven
+    // axes with 3 behind the scenes. Those 3s must not move the medians on
+    // axes family-a never scored — with voice_match 5 and 3 from the other
+    // two, the median is 4, NOT 3 (3,5,3).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: unknown, init?: { body?: string }) => {
+        const model = JSON.parse(init?.body ?? "{}").model as string;
+        const axes =
+          model === "family-a" ? { in_character: 4 }
+          : model === "family-b" ? { voice_match: 5 }
+          : { voice_match: 3 };
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ choices: [{ message: { content: JSON.stringify({ axes }) } }] }),
+        });
+      }),
+    );
+    const verdict = await juryJudge(scenario, [], configs);
+    expect(verdict.axes["in_character"]).toBe(4);
+    expect(verdict.axes["voice_match"]).toBe(4); // b=5, c=3, a's imputed 3 excluded
+    expect(verdict.perJudge["family-a"]!.imputedAxes).toContain("voice_match");
+    expect(verdict.failed).toEqual({});
+  });
+
+  it("rejects same-endpoint jurors: three qwen3:8b configs are not a jury", async () => {
+    await expect(
+      juryJudge(scenario, [], [
+        { baseUrl: "http://o:11434/v1", model: "qwen3:8b", label: "clone-1" },
+        { baseUrl: "http://o:11434/v1", model: "qwen3:8b", label: "clone-2" },
+      ]),
+    ).rejects.toThrow(/Duplicate jury judge endpoint .* independently sourced/);
   });
 
   it("throws honestly when every judge fails", async () => {


### PR DESCRIPTION
Addresses the four live residuals from #77's self-review that were missed at merge time (the plan claimed zero review comments on #77 — they existed and were never fetched; verified against merged main and confirmed live):

- **Imputed axes never vote** (`3836670309`): `parseAxes` was filling every omitted rubric axis with a neutral 3 and returning `salvaged:false`, so a partial-JSON juror (`{"axes":{"in_character":4}}`) voted 3 on the seven axes it never scored. `JudgeResult` now carries `imputedAxes`; juries exclude those axes per juror. Red-first: median moved 3 → 4 in the discriminating test.
- **Failed-juror visibility** (`3836670319`): `JuryVerdict.failed` records label → reason (index-based `allSettled` mapping — the payload is discarded on rejection). The old "drops failed judges" test was vacuous (passed `configs.slice(1)`, so the failing juror was never in the jury); it now tests the full config and asserts the reason.
- **Family-diversity guard** (`3836670314`): duplicate `(baseUrl, model)` pairs throw before any network call — three qwen3:8b configs are not a jury; each juror's `model`/`baseUrl` is recorded in `perJudge`.
- Dead `stubJudgeResponses` deleted (`3836670327`).
- `3836670312` (half-integer medians → `weightedKappa` silently 0) was already fixed by the `clampScore(median())` commit in #77 — verified on main, no further change.

Validation: build 4/4, typecheck 4/4, 92 files / 947 tests, test:gate PASS 855 its, gate bench signal 100% / probe 89.0% (unchanged — `juryJudge` unwired), red-first 4 failed → 11 passed.