### PR TITLE
refactor(eval): shared chat-completion primitive + all-edge gate coverage

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      GOLDEN_SCENARIOS: v1_casual_chat,v1_exclusion_inferred,v1_private_motive,motive_gossip,edge_public_mock,stagnation_resentment_loop,calibration_quiet_room,motive_flirting
+      GOLDEN_SCENARIOS: v1_casual_chat,v1_exclusion_inferred,v1_private_motive,motive_gossip,edge_public_mock,edge_exclusion_cascade,edge_gossip_catalyst,edge_mutation_pressure,stagnation_resentment_loop,calibration_quiet_room,motive_flirting
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -108,7 +108,9 @@ golden set gains spread.
 Every PR also runs this harness in CI (`.github/workflows/pr-gate.yml`):
 typecheck, unit tests, then a mock+rule-judge bench over the golden scenario
 subset with a hard 100%-signals assertion (`scripts/ci/check-bench-gate.mjs`)
-— free, deterministic, no model needed.
+— free, deterministic, no model needed. The subset carries all four
+`edge_chaos` scenarios (not just `edge_public_mock`), so axes like
+`believability_under_pressure` get more than a single n=1 sample per run.
 
 A second, weekly workflow (`.github/workflows/benchmark.yml`) runs the same
 gate over the *full* 123-task suite (Mondays 03:00 UTC, or on demand via

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T19:54:49.330Z",
+  "generatedAt": "2026-08-22T21:26:30.183Z",
   "totals": {
-    "files": 92,
-    "its": 855
+    "files": 93,
+    "its": 861
   },
   "byPackage": {
     "engine": {
@@ -11,8 +11,8 @@
       "flags": []
     },
     "eval": {
-      "files": 14,
-      "its": 106,
+      "files": 15,
+      "its": 112,
       "flags": []
     },
     "server": {
@@ -619,6 +619,28 @@
       "deadIdTruthy": 0,
       "nonNull": 0,
       "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/eval/src/test/chat-completion.test.ts",
+      "pkg": "eval",
+      "layer": "eval-harness",
+      "its": 6,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 6,
       "asyncPauses": 0,
       "weakTerminals": [],
       "flags": [],

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T19:54:49.325Z — audited 92 files, 855 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-22T21:26:30.178Z — audited 93 files, 861 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -9,11 +9,11 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | Package | Files | it/test | Hygiene flags
 |---|---|---|---|
 | engine | 22 | 259 | —
-| eval | 14 | 106 | —
+| eval | 15 | 112 | —
 | server | 49 | 414 | console(1), async-pause(1)
 | shared | 7 | 76 | —
 
-**Total: 92 files, 855 it/test blocks; 2 files flagged.**
+**Total: 93 files, 861 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -46,6 +46,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/eval/src/test/bench.test.ts | eval-harness | 7 | 
 | packages/eval/src/test/calibration-matching.test.ts | eval-harness | 4 | 
 | packages/eval/src/test/calibration-properties.test.ts | eval-harness | 6 | 
+| packages/eval/src/test/chat-completion.test.ts | eval-harness | 6 | 
 | packages/eval/src/test/echo-chamber-stability.test.ts | eval-harness | 2 | 
 | packages/eval/src/test/golden-labels-coverage.test.ts | eval-harness | 3 | 
 | packages/eval/src/test/intent-entropy.test.ts | eval-harness | 8 | 

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -14,6 +14,8 @@
 
 import type { CommittedEvent, JudgeRubric, RoleplayScenario } from "@perfectman/shared";
 import { PromptSection } from "@perfectman/shared";
+import { chatCompletion } from "../llm/chat-completion.js";
+
 import type { ProbeResult } from "../probes/types.js";
 
 export type AxisScores = Record<string, number>;
@@ -278,34 +280,22 @@ async function callJudge(
   const system = buildJudgeSystem(scenario.rubric) + systemSuffix;
   const user = buildJudgeUser(scenario, events);
 
-  const res = await fetch(`${config.baseUrl}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
-    },
-    body: JSON.stringify({
-      model: config.model,
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
-      ],
-      temperature: config.temperature ?? 0,
-      // Generous headroom: a thinking-mode model spends real tokens on
-      // <think>...</think> before it ever reaches the answer, and this
-      // endpoint can't suppress that (see extractJsonObject above).
-      max_tokens: 1500,
-    }),
-    signal: AbortSignal.timeout(config.timeoutMs ?? 60000),
+  return chatCompletion({
+    baseUrl: config.baseUrl,
+    model: config.model,
+    apiKey: config.apiKey,
+    label: "LLM judge",
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    temperature: config.temperature ?? 0,
+    // Generous headroom: a thinking-mode model spends real tokens on
+    //  thinking... response before it ever reaches the answer, and this
+    // endpoint can't suppress that (see extractJsonObject above).
+    maxTokens: 1500,
+    timeoutMs: config.timeoutMs ?? 60000,
   });
-
-  if (!res.ok) {
-    throw new Error(`LLM judge HTTP ${res.status}: ${await res.text()}`);
-  }
-  const data = (await res.json()) as {
-    choices?: { message?: { content?: string } }[];
-  };
-  return data.choices?.[0]?.message?.content ?? "";
 }
 
 function parseAxes(raw: string, scenario: RoleplayScenario): { axes: AxisScores; imputedAxes: string[] } {
@@ -503,33 +493,21 @@ async function scoreCohesion(
     .container("decision", (s) => s.raw("Score narrative_cohesion 1-5 from these two turns, returning ONLY the JSON object."))
     .toString();
 
-  const res = await fetch(`${config.baseUrl}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
-    },
-    body: JSON.stringify({
-      model: config.model,
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
-      ],
-      temperature: config.temperature ?? 1,
-      // See extractJsonObject's comment — a thinking-mode model needs
-      // headroom beyond the tiny {"narrative_cohesion": N} answer itself.
-      max_tokens: 800,
-    }),
-    signal: AbortSignal.timeout(config.timeoutMs ?? 60000),
+  const raw = await chatCompletion({
+    baseUrl: config.baseUrl,
+    model: config.model,
+    apiKey: config.apiKey,
+    label: "Cohesion judge",
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    temperature: config.temperature ?? 1,
+    // See extractJsonObject's comment — a thinking-mode model needs
+    // headroom beyond the tiny {"narrative_cohesion": N} answer itself.
+    maxTokens: 800,
+    timeoutMs: config.timeoutMs ?? 60000,
   });
-
-  if (!res.ok) {
-    throw new Error(`Cohesion judge HTTP ${res.status}: ${await res.text()}`);
-  }
-  const data = (await res.json()) as {
-    choices?: { message?: { content?: string } }[];
-  };
-  const raw = data.choices?.[0]?.message?.content ?? "";
   const jsonText = extractJsonObject(raw);
   const parsed = JSON.parse(jsonText) as {
     narrative_cohesion?: number;

--- a/packages/eval/src/llm/chat-completion.ts
+++ b/packages/eval/src/llm/chat-completion.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared minimal OpenAI-compatible chat-completion call.
+ *
+ * `judge.ts`'s callJudge/scoreCohesion and `narrator.ts` each hand-rolled
+ * the same POST /chat/completions fetch — same URL shape, same Bearer
+ * header handling, same `choices[0].message.content` parse. This is the
+ * one call path; callers keep building their own prompts (PromptSection)
+ * and own the response post-processing (axis parsing / JSON extraction).
+ *
+ * Behavior is identical to what each caller did before the extraction:
+ * a single request under full-request `AbortSignal.timeout`, and a
+ * non-2xx response throws a typed `ChatCompletionError` prefixed with the
+ * caller's `label`. The transport-retry / dual-timeout / response-header
+ * capabilities that `OpenAiCompatibleProvider` (server) has are the
+ * documented seam to adopt next — the provider and these callers can then
+ * share this primitive.
+ */
+
+export type ChatCompletionMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+export type ChatCompletionOptions = {
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  /** Caller label used as the error prefix, e.g. "LLM judge". */
+  label: string;
+  messages: ChatCompletionMessage[];
+  temperature?: number;
+  maxTokens: number;
+  responseFormatJson?: boolean;
+  timeoutMs?: number;
+};
+
+export class ChatCompletionError extends Error {
+  override readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "ChatCompletionError";
+    this.cause = cause;
+  }
+}
+
+/** Resolves to the raw assistant content ("" when the model sent none). */
+export async function chatCompletion(opts: ChatCompletionOptions): Promise<string> {
+  const body: Record<string, unknown> = {
+    model: opts.model,
+    messages: opts.messages,
+    max_tokens: opts.maxTokens,
+  };
+  if (opts.temperature !== undefined) body["temperature"] = opts.temperature;
+  if (opts.responseFormatJson) body["response_format"] = { type: "json_object" };
+
+  const res = await fetch(`${opts.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(opts.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : {}),
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 60000),
+  });
+  if (!res.ok) {
+    throw new ChatCompletionError(`${opts.label} HTTP ${res.status}: ${await res.text()}`);
+  }
+  const data = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+  return data.choices?.[0]?.message?.content ?? "";
+}

--- a/packages/eval/src/narrator/narrator.ts
+++ b/packages/eval/src/narrator/narrator.ts
@@ -9,6 +9,8 @@
 
 import type { CommittedEvent, RoleplayScenario } from "@perfectman/shared";
 import { PromptSection } from "@perfectman/shared";
+import { chatCompletion } from "../llm/chat-completion.js";
+
 
 export type Narration = {
   title: string;
@@ -67,34 +69,27 @@ export async function narrateTranscript(
   }
 
   try {
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: "system", content: NARRATOR_SYSTEM },
-          {
-            role: "user",
-            content: new PromptSection()
-              .container("scene", (s) => { s.raw(`Scene: ${name}`); s.raw(description); })
-              .container("transcript", (s) => s.raw(transcript))
-              .container("decision", (s) => s.raw("Escreva o resumo agora como JSON, conforme o contrato no prompt de sistema."))
-              .toString(),
-          },
-        ],
-        temperature: 0.9,
-        max_tokens: 350,
-        response_format: { type: "json_object" },
-      }),
-      signal: AbortSignal.timeout(90000),
+    const raw = await chatCompletion({
+      baseUrl,
+      model,
+      apiKey,
+      label: "narrator",
+      messages: [
+        { role: "system", content: NARRATOR_SYSTEM },
+        {
+          role: "user",
+          content: new PromptSection()
+            .container("scene", (s) => { s.raw(`Scene: ${name}`); s.raw(description); })
+            .container("transcript", (s) => s.raw(transcript))
+            .container("decision", (s) => s.raw("Escreva o resumo agora como JSON, conforme o contrato no prompt de sistema."))
+            .toString(),
+        },
+      ],
+      temperature: 0.9,
+      maxTokens: 350,
+      responseFormatJson: true,
+      timeoutMs: 90000,
     });
-    if (!res.ok) throw new Error(`narrator HTTP ${res.status}`);
-    const data = (await res.json()) as { choices?: { message?: { content?: string } }[] };
-    const raw = data.choices?.[0]?.message?.content ?? "";
     const jsonText = raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
     const parsed = JSON.parse(jsonText) as Partial<Narration>;
     return {

--- a/packages/eval/src/test/chat-completion.test.ts
+++ b/packages/eval/src/test/chat-completion.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { chatCompletion, ChatCompletionError } from "../llm/chat-completion.js";
+
+const opts = {
+  baseUrl: "http://judge-host/v1",
+  model: "qwen3:8b",
+  label: "Test caller",
+  messages: [{ role: "system" as const, content: "sys" }, { role: "user" as const, content: "user" }],
+  temperature: 0,
+  maxTokens: 800,
+};
+
+function fetchLike(overrides: Partial<{ ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> }>) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content: "answer" } }] }),
+    ...overrides,
+    text: overrides.text ?? (async () => ""),
+  } as Response;
+}
+
+describe("chatCompletion", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("posts the OpenAI-compatible shape and returns the assistant content", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fetchLike({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const content = await chatCompletion(opts);
+
+    expect(content).toBe("answer");
+    const [url, init] = fetchMock.mock.calls[0]! as [string, { method: string; headers: Record<string, string>; body: string }];
+    expect(url).toBe("http://judge-host/v1/chat/completions");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Authorization"]).toBeUndefined();
+    const body = JSON.parse(init.body);
+    expect(body.model).toBe("qwen3:8b");
+    expect(body.messages).toEqual(opts.messages);
+    expect(body.temperature).toBe(0);
+    expect(body.max_tokens).toBe(800);
+  });
+
+  it("sends Bearer auth when an apiKey is provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fetchLike({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await chatCompletion({ ...opts, apiKey: "sk-test" });
+
+    const init = fetchMock.mock.calls[0]![1] as { headers: Record<string, string> };
+    expect(init.headers["Authorization"]).toBe("Bearer sk-test");
+  });
+
+  it("sends response_format json_object only when requested (narrator path)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fetchLike({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await chatCompletion({ ...opts, responseFormatJson: true });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as { body: string }).body) as { response_format?: unknown };
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("resolves to empty content when the model sent none", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fetchLike({ json: async () => ({ choices: [] }) })));
+    expect(await chatCompletion(opts)).toBe("");
+  });
+
+  it("throws a typed ChatCompletionError with the caller label on non-2xx", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fetchLike({ ok: false, status: 500, text: async () => "boom" })));
+    await expect(chatCompletion(opts)).rejects.toThrow(ChatCompletionError);
+    await expect(chatCompletion(opts)).rejects.toThrow("Test caller HTTP 500: boom");
+  });
+
+  it("aborts the request after the caller timeout", async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Promise.reject(Object.assign(new Error("aborted"), { name: "TimeoutError" }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(chatCompletion({ ...opts, timeoutMs: 42 })).rejects.toThrow(/aborted/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Batch A of the partial-issue follow-ups (#66 + #30).

**#66 — shared AI-compatible call primitive.** `judge.ts` (`callJudge`, `scoreCohesion`) and `narrator.ts` each hand-rolled the identical `POST /chat/completions` fetch (Bearer header, `choices[0].message.content` parse, `AbortSignal.timeout`). Now one module: `packages/eval/src/llm/chat-completion.ts` with a typed `ChatCompletionError` (caller-label prefix keeps every error string identical). Behavior-preserving — same body shape, timeouts, error text; the transport-retry/dual-timeout/response-header capabilities of the server provider are the documented seam for the next adoption step. New unit tests pin the contract (shape, auth, response_format, typed errors, timeout).

**#30 — believability_under_pressure n=1.** PR-gate `GOLDEN_SCENARIOS` carried only `edge_public_mock`, so the edge axes rested on one sample per run. Added `edge_exclusion_cascade`, `edge_gossip_catalyst`, `edge_mutation_pressure` → the gate now runs **35 scenarios incl. all 12 edge runs**.

Validation: build 4/4, typecheck 4/4, 93 files / 953 tests (test:gate PASS 861 its, sweep evidence byte-identical — no substrate change), gate bench **35 scenarios, signal pass 100% across all categories, probe pass 89.9%** (`believability_under_pressure` mean 5 over the 12 edge runs), exit check clean.