### PR TITLE
feat(judge): judge as a config-file section — shared schema, server loader, eval precedence

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -148,6 +148,51 @@ yet — invoke it from a node one-liner). It fans every config out
 concurrently via `Promise.allSettled`, so keep the judge list small and
 point it at one local Ollama host at a time.
 
+### The judge as a config section
+
+The judge is resolved like every other LLM surface in the project — the
+config file describes the experiment, the `.env` holds the secrets:
+
+1. `--judge-config <path>` — an explicit standalone judge config file;
+2. otherwise the `judge` section of the walk-up `config/index.json`;
+3. otherwise the environment (`PERFECTMAN_JUDGE_BASE_URL` / `_MODEL` /
+   `_TEMPERATURE`, `PERFECTMAN_LLM_*`, `PERFECTMAN_LLM_PROVIDER=deepseek`
+   shortcut) — the env layer stays exactly as documented above;
+4. otherwise defaults (local qwen3:8b endpoint; bench temperature 1.0,
+   calibration 0).
+
+`providerType` is `"openai-compatible" | "rule" | "mock"` — DeepSeek is
+not a type, it is an openai-compatible endpoint in a file. Secrets are
+referenced by NAME through `apiKeyEnv`; never inline a key. The `jury`
+array is the first-class cross-family jury — the same loader instantiates
+every member, so `bench --judge llm` with a jury in the file runs the
+median verdict instead of one judge.
+
+```jsonc
+// config/index.json (or the file given to --judge-config)
+{
+  "judge": {
+    "providerType": "openai-compatible",
+    "baseUrl": "https://api.deepseek.com/v1",
+    "modelName": "deepseek-chat",
+    "apiKeyEnv": "DEEPSEEK_API_KEY",
+    "temperature": 0,
+    "timeoutMs": 90000,
+    "jury": [
+      { "providerType": "openai-compatible", "baseUrl": "http://localhost:11434/v1",
+        "modelName": "qwen3:8b", "temperature": 0, "label": "local-qwen" },
+      { "providerType": "openai-compatible", "baseUrl": "https://api.deepseek.com/v1",
+        "modelName": "deepseek-chat", "apiKeyEnv": "DEEPSEEK_API_KEY",
+        "temperature": 0, "label": "deepseek" }
+    ]
+  }
+}
+```
+
+The `--judge rule|llm` CLI flag survives as a shorthand that overrides
+`judge.providerType` only when passed explicitly; with no file and no
+flag, every CLI keeps its offline rule-judge default.
+
 
 ## Current baseline (mock, 123 tasks)
 

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-22T21:26:30.183Z",
+  "generatedAt": "2026-08-23T00:21:57.132Z",
   "totals": {
-    "files": 93,
-    "its": 861
+    "files": 97,
+    "its": 909
   },
   "byPackage": {
     "engine": {
@@ -11,21 +11,21 @@
       "flags": []
     },
     "eval": {
-      "files": 15,
-      "its": 112,
+      "files": 17,
+      "its": 131,
       "flags": []
     },
     "server": {
-      "files": 49,
-      "its": 414,
+      "files": 50,
+      "its": 431,
       "flags": [
         "console(1)",
         "async-pause(1)"
       ]
     },
     "shared": {
-      "files": 7,
-      "its": 76,
+      "files": 8,
+      "its": 88,
       "flags": []
     }
   },
@@ -515,6 +515,28 @@
       "violations": []
     },
     {
+      "file": "packages/eval/src/test/bench-dispatch.test.ts",
+      "pkg": "eval",
+      "layer": "eval-harness",
+      "its": 3,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 1,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
       "file": "packages/eval/src/test/bench-seed.test.ts",
       "pkg": "eval",
       "layer": "eval-harness",
@@ -562,7 +584,7 @@
       "file": "packages/eval/src/test/bench.test.ts",
       "pkg": "eval",
       "layer": "eval-harness",
-      "its": 7,
+      "its": 8,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -695,6 +717,28 @@
       "pkg": "eval",
       "layer": "eval-harness",
       "its": 8,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/eval/src/test/judge-config.test.ts",
+      "pkg": "eval",
+      "layer": "eval-harness",
+      "its": 15,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -1111,10 +1155,32 @@
       "violations": []
     },
     {
+      "file": "packages/server/src/config/__tests__/judge-config.test.ts",
+      "pkg": "server",
+      "layer": "integration",
+      "its": 14,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
       "file": "packages/server/src/config/__tests__/simulation-config.test.ts",
       "pkg": "server",
       "layer": "integration",
-      "its": 11,
+      "its": 14,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -1975,6 +2041,28 @@
       "pkg": "shared",
       "layer": "contract",
       "its": 9,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/shared/src/__tests__/judge-config.test.ts",
+      "pkg": "shared",
+      "layer": "contract",
+      "its": 12,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-22T21:26:30.178Z — audited 93 files, 861 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-23T00:21:57.128Z — audited 97 files, 909 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -9,11 +9,11 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | Package | Files | it/test | Hygiene flags
 |---|---|---|---|
 | engine | 22 | 259 | —
-| eval | 15 | 112 | —
-| server | 49 | 414 | console(1), async-pause(1)
-| shared | 7 | 76 | —
+| eval | 17 | 131 | —
+| server | 50 | 431 | console(1), async-pause(1)
+| shared | 8 | 88 | —
 
-**Total: 93 files, 861 it/test blocks; 2 files flagged.**
+**Total: 97 files, 909 it/test blocks; 2 files flagged.**
 
 ## Per-file inventory
 
@@ -41,15 +41,17 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/engine/src/__tests__/visibility-security.test.ts | integration | 18 | 
 | packages/engine/src/__tests__/visibility.test.ts | integration | 20 | 
 | packages/engine/src/perception/__tests__/memory-salience.test.ts | integration | 12 | 
+| packages/eval/src/test/bench-dispatch.test.ts | eval-harness | 3 | 
 | packages/eval/src/test/bench-seed.test.ts | eval-harness | 7 | 
 | packages/eval/src/test/bench-slices.test.ts | eval-harness | 6 | 
-| packages/eval/src/test/bench.test.ts | eval-harness | 7 | 
+| packages/eval/src/test/bench.test.ts | eval-harness | 8 | 
 | packages/eval/src/test/calibration-matching.test.ts | eval-harness | 4 | 
 | packages/eval/src/test/calibration-properties.test.ts | eval-harness | 6 | 
 | packages/eval/src/test/chat-completion.test.ts | eval-harness | 6 | 
 | packages/eval/src/test/echo-chamber-stability.test.ts | eval-harness | 2 | 
 | packages/eval/src/test/golden-labels-coverage.test.ts | eval-harness | 3 | 
 | packages/eval/src/test/intent-entropy.test.ts | eval-harness | 8 | 
+| packages/eval/src/test/judge-config.test.ts | eval-harness | 15 | 
 | packages/eval/src/test/judge-json-salvage.test.ts | eval-harness | 9 | 
 | packages/eval/src/test/judge-signals.test.ts | eval-harness | 10 | 
 | packages/eval/src/test/jury-judge.test.ts | eval-harness | 11 | 
@@ -68,7 +70,8 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/agent/__tests__/repetition-guard.test.ts | integration | 8 | 
 | packages/server/src/agent/surface/__tests__/action-intent-step.test.ts | integration | 9 | 
 | packages/server/src/cli/__tests__/llm-health-check.test.ts | integration | 3 | 
-| packages/server/src/config/__tests__/simulation-config.test.ts | integration | 11 | 
+| packages/server/src/config/__tests__/judge-config.test.ts | integration | 14 | 
+| packages/server/src/config/__tests__/simulation-config.test.ts | integration | 14 | 
 | packages/server/src/discord/__tests__/bot-registry.test.ts | integration | 9 | 
 | packages/server/src/discord/__tests__/channel-map.test.ts | integration | 6 | 
 | packages/server/src/discord/__tests__/discord-config.test.ts | integration | 13 | 
@@ -108,6 +111,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/shared/src/__tests__/constants.test.ts | contract | 13 | 
 | packages/shared/src/__tests__/contracts.test.ts | contract | 3 | 
 | packages/shared/src/__tests__/intent-packet-schema.test.ts | contract | 9 | 
+| packages/shared/src/__tests__/judge-config.test.ts | contract | 12 | 
 | packages/shared/src/__tests__/prompt-syntax.test.ts | contract | 5 | 
 | packages/shared/src/__tests__/schemas.test.ts | contract | 22 | 
 | packages/shared/src/persona-packs/persona-packs.test.ts | contract | 16 | 

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -20,37 +20,22 @@ import {
   type RoleplayScenario,
 } from "@perfectman/shared";
 import { ScenarioRunner } from "../run/scenario-runner.js";
-import { ruleJudge, llmJudge, llmJudgePerTurn, type AxisScores } from "../judge/judge.js";
+import { ruleJudge, llmJudge, llmJudgePerTurn, juryJudge, type AxisScores } from "../judge/judge.js";
+import { MockJudgeProvider } from "../judge/mock-judge-provider.js";
 import { calibrateJudge, baseScenarioId } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
+import { loadJudgeConfig, applyJudgeShorthand } from "../llm/judge-config.js";
 import type { ScenarioRunArtifact } from "../run/scenario-runner.js";
 import { aggregateSignalsByKind, type SignalOutcome } from "../run/signal-checker.js";
 import { BENCH_SLICES, resolveBenchSlice } from "../bench-slices.js";
 
-/** LLM judge endpoint — DeepSeek by default when PERFECTMAN_LLM_PROVIDER=deepseek. */
-export function judgeConfig(): import("../judge/judge.js").LLMJudgeConfig {
-  const provider = process.env.PERFECTMAN_LLM_PROVIDER ?? "local";
-  const isDeepseek = provider === "deepseek";
-  // Empty/unset → default; only an explicit numeric value (incl. "0") wins.
-  const tempRaw = Number(process.env.PERFECTMAN_JUDGE_TEMPERATURE);
-  const tempSet = process.env.PERFECTMAN_JUDGE_TEMPERATURE !== undefined
-    && process.env.PERFECTMAN_JUDGE_TEMPERATURE.trim() !== "";
-  return {
-    baseUrl:
-      process.env.PERFECTMAN_JUDGE_BASE_URL ??
-      process.env.PERFECTMAN_LLM_BASE_URL ??
-      (isDeepseek ? "https://api.deepseek.com/v1" : "http://localhost:11434/v1"),
-    model:
-      process.env.PERFECTMAN_JUDGE_MODEL ??
-      process.env.PERFECTMAN_LLM_MODEL ??
-      (isDeepseek ? "deepseek-chat" : "qwen3:8b"),
-    apiKey: process.env.PERFECTMAN_LLM_API_KEY,
-    // Heuristic LLM-as-judge: temperature UP by default (varied, creative
-    // reads expose cohesion/voice failures a strict low-temp judge misses).
-    // Set PERFECTMAN_JUDGE_TEMPERATURE=0 for deterministic calibration runs.
-    temperature: tempSet && Number.isFinite(tempRaw) ? tempRaw : 1.0,
-    timeoutMs: 90000,
-  };
+/**
+ * Compatibility view of the judge loader for programmatic callers: the
+ * env-resolved endpoint config, exactly as the pre-pivot judgeConfig()
+ * returned it (no file, no CLI shorthand).
+ */
+export function judgeConfig(): Promise<import("../judge/judge.js").LLMJudgeConfig> {
+  return loadJudgeConfig([]).then((resolved) => resolved.config);
 }
 
 export type BenchReport = {
@@ -94,12 +79,18 @@ export async function runBench(opts: {
   category?: string;
   limit?: number;
   out?: string;
+  /** `--judge rule|llm` shorthand; absent → the resolved config's providerType. */
   judge?: "rule" | "llm";
   perTurn?: boolean;
+  /** CLI args for --judge-config resolution (defaults to the module args). */
+  args?: string[];
 }): Promise<BenchReport> {
   const mode = opts.mode ?? "mock";
-  const judgeMode = opts.judge ?? "rule";
   const perTurn = opts.perTurn ?? false;
+
+  const resolvedJudge = await loadJudgeConfig(opts.args ?? args);
+  const judgeMode = applyJudgeShorthand(resolvedJudge, opts.judge);
+  const mockJudge = new MockJudgeProvider();
 
   let selected: RoleplayScenario[];
   if (opts.slice !== undefined && opts.scenarios && opts.scenarios.length > 0) {
@@ -176,11 +167,18 @@ export async function runBench(opts: {
       artifact.templateVersions.forEach((v) => allTemplateVersions.add(v));
 
       const judgeResult =
-        judgeMode === "llm"
-          ? perTurn
-            ? await llmJudgePerTurn(scenario, artifact.events, judgeConfig())
-            : await llmJudge(scenario, artifact.events, judgeConfig())
-          : { axes: ruleJudge(scenario, artifact.events, artifact.probeResults, artifact.passedSignals / Math.max(1, artifact.totalSignals)), salvaged: false };
+        judgeMode === "openai-compatible"
+          ? resolvedJudge.jury && resolvedJudge.jury.length > 0
+            ? {
+                axes: (await juryJudge(scenario, artifact.events, resolvedJudge.jury)).axes,
+                salvaged: false,
+              }
+            : perTurn
+              ? await llmJudgePerTurn(scenario, artifact.events, resolvedJudge.config)
+              : await llmJudge(scenario, artifact.events, resolvedJudge.config)
+          : judgeMode === "mock"
+            ? mockJudge.judge(scenario)
+            : { axes: ruleJudge(scenario, artifact.events, artifact.probeResults, artifact.passedSignals / Math.max(1, artifact.totalSignals)), salvaged: false };
       const axisScores = judgeResult.axes;
 
       // A salvaged score is a fabricated/imputed read, not a clean parse —
@@ -329,7 +327,9 @@ export async function main(): Promise<void> {
     category: argValue("--category"),
     limit: argValue("--limit") ? Number(argValue("--limit")) : undefined,
     out: argValue("--out"),
-    judge: (argValue("--judge") as "rule" | "llm") ?? "rule",
+    // The shorthand overrides the file's providerType only when the flag is
+    // actually passed — absent, the file (and the rule default) decides.
+    judge: args.includes("--judge") ? (argValue("--judge") as "rule" | "llm") : undefined,
     perTurn: args.includes("--per-turn"),
   });
   printReport(report);

--- a/packages/eval/src/cli/calibrate.ts
+++ b/packages/eval/src/cli/calibrate.ts
@@ -13,9 +13,11 @@
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { ScenarioRunner } from "../run/scenario-runner.js";
-import { ruleJudge, llmJudge, type LLMJudgeConfig } from "../judge/judge.js";
+import { ruleJudge, llmJudge } from "../judge/judge.js";
+import { MockJudgeProvider } from "../judge/mock-judge-provider.js";
 import { calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
+import { loadJudgeConfig, applyJudgeShorthand } from "../llm/judge-config.js";
 import { getScenario } from "@perfectman/shared";
 
 const args = process.argv.slice(2);
@@ -24,30 +26,19 @@ function argValue(flag: string): string | undefined {
   return i >= 0 ? args[i + 1] : undefined;
 }
 
-function judgeConfig(): LLMJudgeConfig {
-  const provider = process.env.PERFECTMAN_LLM_PROVIDER ?? "local";
-  const isDeepseek = provider === "deepseek";
-  const tempRaw = process.env.PERFECTMAN_JUDGE_TEMPERATURE;
-  // Calibration is an agreement measurement — determinism by default.
-  const temperature = tempRaw !== undefined && Number.isFinite(Number(tempRaw)) ? Number(tempRaw) : 0;
-  return {
-    baseUrl:
-      process.env.PERFECTMAN_LLM_BASE_URL ??
-      (isDeepseek ? "https://api.deepseek.com/v1" : "http://localhost:11434/v1"),
-    model: process.env.PERFECTMAN_JUDGE_MODEL ?? process.env.PERFECTMAN_LLM_MODEL ?? (isDeepseek ? "deepseek-chat" : "qwen3:8b"),
-    apiKey: process.env.PERFECTMAN_LLM_API_KEY,
-    temperature,
-    timeoutMs: 90000,
-  };
-}
-
 export async function main(): Promise<void> {
-  const judgeMode = (argValue("--judge") as "rule" | "llm") ?? "rule";
-  if (judgeMode !== "rule" && judgeMode !== "llm") {
-    console.error(`unknown --judge value: ${judgeMode} (expected rule|llm)`);
+  const judgeFlag = argValue("--judge");
+  if (judgeFlag !== undefined && judgeFlag !== "rule" && judgeFlag !== "llm") {
+    console.error(`unknown --judge value: ${judgeFlag} (expected rule|llm)`);
     process.exit(2);
   }
   const out = argValue("--out");
+
+  // Calibration is an agreement measurement — determinism by default
+  // (temperature 0 rather than bench's heuristic 1.0).
+  const resolvedJudge = await loadJudgeConfig(args, { defaultTemperature: 0 });
+  const providerType = applyJudgeShorthand(resolvedJudge, judgeFlag);
+  const mockJudge = new MockJudgeProvider();
 
   const judgeScores = new Map<string, import("../judge/judge.js").AxisScores>();
   const perScenario: Array<{ id: string; pulses: number; axes: Record<string, number>; judgeSalvaged: boolean }> = [];
@@ -62,17 +53,19 @@ export async function main(): Promise<void> {
     // pulse count unless a pulseLimit override is passed — none is here.
     const artifact = await ScenarioRunner.run(scenario, { llmMode: "mock" });
     const judgeResult =
-      judgeMode === "llm"
-        ? await llmJudge(scenario, artifact.events, judgeConfig())
-        : {
-            axes: ruleJudge(
-              scenario,
-              artifact.events,
-              artifact.probeResults,
-              artifact.passedSignals / Math.max(1, artifact.totalSignals),
-            ),
-            salvaged: false,
-          };
+      providerType === "openai-compatible"
+        ? await llmJudge(scenario, artifact.events, resolvedJudge.config)
+        : providerType === "mock"
+          ? mockJudge.judge(scenario)
+          : {
+              axes: ruleJudge(
+                scenario,
+                artifact.events,
+                artifact.probeResults,
+                artifact.passedSignals / Math.max(1, artifact.totalSignals),
+              ),
+              salvaged: false,
+            };
     const scores = judgeResult.axes;
     // A salvaged score is a fabricated/imputed read, not a clean parse — the
     // calibration gate this CLI measures must never be fed invented scores.
@@ -94,7 +87,7 @@ export async function main(): Promise<void> {
     // scored the transcripts. Golden labels were authored against the mock
     // baseline, so LLM-judged calibration reads mock transcripts too.
     mode: "mock" as const,
-    judge: judgeMode,
+    judge: providerType === "openai-compatible" ? "llm" : "rule",
     generatedAt: new Date().toISOString(),
     transcriptLength: "full",
     calibration: calibrateJudge(judgeScores, GOLDEN_LABELS, 0.7),

--- a/packages/eval/src/judge/mock-judge-provider.ts
+++ b/packages/eval/src/judge/mock-judge-provider.ts
@@ -1,0 +1,19 @@
+import type { RoleplayScenario } from "@perfectman/shared";
+import type { AxisScores, JudgeResult } from "./judge.js";
+
+/**
+ * Deterministic judge for tests and dry runs: every rubric axis scores the
+ * same neutral value, never salvaged, no network. The judge-config's
+ * providerType: "mock" dispatches here.
+ */
+export class MockJudgeProvider {
+  constructor(private readonly score = 3) {}
+
+  judge(scenario: RoleplayScenario): JudgeResult {
+    const axes: AxisScores = {};
+    for (const axis of scenario.rubric.axes) {
+      axes[axis.id] = this.score;
+    }
+    return { axes, salvaged: false, imputedAxes: [] };
+  }
+}

--- a/packages/eval/src/llm/judge-config.ts
+++ b/packages/eval/src/llm/judge-config.ts
@@ -1,0 +1,135 @@
+/**
+ * Judge config loader — file > section > env > defaults.
+ *
+ * The judge is now a first-class config section (same schema the agents
+ * use), so the eval CLIs resolve it the same way the server does:
+ *   1. `--judge-config <path>` — an explicit standalone judge config,
+ *   2. the `judge` section of the walk-up `config/index.json`,
+ *   3. environment (`PERFECTMAN_JUDGE_BASE_URL`/`MODEL`/`TEMPERATURE`,
+ *      `PERFECTMAN_LLM_*`, the `deepseek` endpoint shortcut),
+ *   4. defaults (local qwen3 endpoint, bench temperature 1.0 / calibration
+ *      temperature 0).
+ * The env tier is byte-identical to the pre-pivot `judgeConfig()` — zero
+ * file + env only behaves exactly as before. Secrets resolve by NAME via
+ * `apiKeyEnv` (the agent pattern); the runtime `LLMJudgeConfig` shape is
+ * unchanged.
+ */
+
+import {
+  getJudgeConfigPath,
+  loadJudgeConfig as loadJudgeConfigFile,
+  loadJudgeSectionFromSimulationConfig,
+} from "@perfectman/server";
+import type { JudgeAppConfig, JudgeConfigBase, JudgeProviderType } from "@perfectman/shared";
+import type { LLMJudgeConfig } from "../judge/judge.js";
+
+export type JudgeConfigLoaderOptions = {
+  /** Default temperature when neither file nor env sets one (bench: 1.0, calibration: 0). */
+  defaultTemperature?: number;
+  /** Walk-up start for the config/index.json section tier (tests). */
+  cwd?: string;
+};
+
+export type ResolvedJudgeConfig = {
+  providerType: JudgeProviderType;
+  /** The endpoint config — always resolved, used by the openai-compatible path. */
+  config: LLMJudgeConfig;
+  /** The file's cross-family jury, resolved through the same defaults. */
+  jury?: Array<LLMJudgeConfig & { label?: string }>;
+};
+
+type EnvJudgeDefaults = {
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  temperature: number;
+  timeoutMs: number;
+};
+
+function envJudgeDefaults(defaultTemperature: number): EnvJudgeDefaults {
+  const provider = process.env.PERFECTMAN_LLM_PROVIDER ?? "local";
+  const isDeepseek = provider === "deepseek";
+  // Empty/unset → default; only an explicit numeric value (incl. "0") wins.
+  const tempRaw = Number(process.env.PERFECTMAN_JUDGE_TEMPERATURE);
+  const tempSet =
+    process.env.PERFECTMAN_JUDGE_TEMPERATURE !== undefined &&
+    process.env.PERFECTMAN_JUDGE_TEMPERATURE.trim() !== "";
+  return {
+    baseUrl:
+      process.env.PERFECTMAN_JUDGE_BASE_URL ??
+      process.env.PERFECTMAN_LLM_BASE_URL ??
+      (isDeepseek ? "https://api.deepseek.com/v1" : "http://localhost:11434/v1"),
+    model:
+      process.env.PERFECTMAN_JUDGE_MODEL ??
+      process.env.PERFECTMAN_LLM_MODEL ??
+      (isDeepseek ? "deepseek-chat" : "qwen3:8b"),
+    apiKey: process.env.PERFECTMAN_LLM_API_KEY,
+    temperature: tempSet && Number.isFinite(tempRaw) ? tempRaw : defaultTemperature,
+    timeoutMs: 90000,
+  };
+}
+
+function resolveEntry(
+  entry: JudgeConfigBase,
+  envDefaults: EnvJudgeDefaults,
+): LLMJudgeConfig {
+  return {
+    baseUrl: entry.baseUrl ?? envDefaults.baseUrl,
+    model: entry.modelName,
+    apiKey: entry.apiKeyEnv ? process.env[entry.apiKeyEnv] : envDefaults.apiKey,
+    temperature: entry.temperature ?? envDefaults.temperature,
+    timeoutMs: entry.timeoutMs ?? envDefaults.timeoutMs,
+  };
+}
+
+export async function loadJudgeConfig(
+  args: string[],
+  options: JudgeConfigLoaderOptions = {},
+): Promise<ResolvedJudgeConfig> {
+  const cwd = options.cwd ?? process.cwd();
+  const envDefaults = envJudgeDefaults(options.defaultTemperature ?? 1.0);
+
+  const explicitPath = getJudgeConfigPath(args, cwd);
+  const appConfig =
+    explicitPath !== undefined
+      ? await loadJudgeConfigFile(explicitPath)
+      : await loadJudgeSectionFromSimulationConfig(cwd);
+
+  if (appConfig !== undefined) {
+    return {
+      providerType: appConfig.providerType,
+      config: resolveEntry(appConfig, envDefaults),
+      jury: appConfig.jury?.map((entry) => ({
+        ...resolveEntry(entry, envDefaults),
+        label: entry.label,
+      })),
+    };
+  }
+
+  // env tier — and with a clean env, the defaults tier. Provider type is
+  // "rule" (the offline default of every eval CLI); `--judge llm` flips it.
+  return {
+    providerType: "rule",
+    config: {
+      baseUrl: envDefaults.baseUrl,
+      model: envDefaults.model,
+      apiKey: envDefaults.apiKey,
+      temperature: envDefaults.temperature,
+      timeoutMs: envDefaults.timeoutMs,
+    },
+  };
+}
+
+/**
+ * The `--judge rule|llm` CLI flag as a shorthand override of the resolved
+ * `providerType`: "llm" → openai-compatible, "rule" → rule, absent → the
+ * file-driven value (rule when no file describes the judge).
+ */
+export function applyJudgeShorthand(
+  resolved: ResolvedJudgeConfig,
+  flag: string | undefined,
+): JudgeProviderType {
+  if (flag === "llm") return "openai-compatible";
+  if (flag === "rule") return "rule";
+  return resolved.providerType;
+}

--- a/packages/eval/src/test/bench-dispatch.test.ts
+++ b/packages/eval/src/test/bench-dispatch.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../judge/judge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../judge/judge.js")>();
+  return {
+    ...actual,
+    juryJudge: vi.fn().mockResolvedValue({ axes: { in_character: 4 }, voterCount: 1, perJudge: {}, failed: {} }),
+  };
+});
+
+const { runBench } = await import("../cli/bench.js");
+const { juryJudge } = await import("../judge/judge.js");
+
+async function tempJudgeFile(config: Record<string, unknown>): Promise<{ dir: string; path: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bench-dispatch-test-"));
+  const path = join(dir, "judge.json");
+  await writeFile(path, JSON.stringify(config));
+  return { dir, path };
+}
+
+describe("runBench judge provider dispatch", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches providerType mock from a judge-config file to the deterministic mock judge", async () => {
+    const { dir, path } = await tempJudgeFile({ providerType: "mock", modelName: "mock" });
+    try {
+      const report = await runBench({ mode: "mock", args: ["--judge-config", path] });
+      const axes = report.perScenario[0]!.axisScores;
+      expect(Object.values(axes).length).toBeGreaterThan(0);
+      for (const v of Object.values(axes)) expect(v).toBe(3);
+      expect(report.perScenario[0]!.judgeSalvaged).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("wires the file's jury into the openai-compatible path (--judge llm shorthand)", async () => {
+    const { dir, path } = await tempJudgeFile({
+      providerType: "rule",
+      modelName: "rule",
+      jury: [
+        { providerType: "openai-compatible", modelName: "a", label: "one" },
+        { providerType: "openai-compatible", modelName: "b", label: "two" },
+      ],
+    });
+    try {
+      const report = await runBench({ mode: "mock", judge: "llm", limit: 1, args: ["--judge-config", path] });
+      expect(juryJudge).toHaveBeenCalledTimes(1);
+      const configs = (juryJudge as ReturnType<typeof vi.fn>).mock.calls[0]![2] as Array<{ model: string; label?: string }>;
+      expect(configs.map((c) => c.label)).toEqual(["one", "two"]);
+      expect(report.perScenario[0]!.axisScores.in_character).toBe(4);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the rule judge when the file says rule and no shorthand is passed", async () => {
+    const { dir, path } = await tempJudgeFile({ providerType: "rule", modelName: "rule" });
+    try {
+      const report = await runBench({ mode: "mock", limit: 1, args: ["--judge-config", path] });
+      // The file's providerType decides — the jury must not have been
+      // consulted and the rule judge must have scored the (empty) artifact.
+      expect(juryJudge).not.toHaveBeenCalled();
+      expect(report.perScenario[0]!.judgeSalvaged).toBe(false);
+      expect(Object.keys(report.perScenario[0]!.axisScores).length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/eval/src/test/bench.test.ts
+++ b/packages/eval/src/test/bench.test.ts
@@ -74,7 +74,7 @@ describe("judgeConfig", () => {
     vi.unstubAllEnvs();
   });
 
-  it("lets the judge use a separate endpoint from the arena (cross-family judging)", () => {
+  it("lets the judge use a separate endpoint from the arena (cross-family judging)", async () => {
     vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "local");
     vi.stubEnv("PERFECTMAN_JUDGE_BASE_URL", "https://api.deepseek.com/v1");
     vi.stubEnv("PERFECTMAN_LLM_BASE_URL", "http://localhost:11434/v1");
@@ -82,17 +82,28 @@ describe("judgeConfig", () => {
     vi.stubEnv("PERFECTMAN_LLM_MODEL", "qwen3:1.7b");
     vi.stubEnv("PERFECTMAN_JUDGE_TEMPERATURE", "0");
 
-    const cfg = judgeConfig();
+    const cfg = await judgeConfig();
     expect(cfg.baseUrl).toBe("https://api.deepseek.com/v1");
     expect(cfg.model).toBe("deepseek-chat");
     expect(cfg.temperature).toBe(0);
   });
 
-  it("falls back to the arena endpoint when no judge endpoint is set", () => {
+  it("falls back to the arena endpoint when no judge endpoint is set", async () => {
     vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "local");
     vi.stubEnv("PERFECTMAN_LLM_BASE_URL", "http://localhost:11434/v1");
     delete process.env.PERFECTMAN_JUDGE_BASE_URL;
 
-    expect(judgeConfig().baseUrl).toBe("http://localhost:11434/v1");
+    expect((await judgeConfig()).baseUrl).toBe("http://localhost:11434/v1");
+  });
+
+  it("keeps the deepseek endpoint shortcut for env-only runs", async () => {
+    vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "deepseek");
+    vi.stubEnv("PERFECTMAN_LLM_API_KEY", "sk-test");
+
+    const cfg = await judgeConfig();
+    expect(cfg.baseUrl).toBe("https://api.deepseek.com/v1");
+    expect(cfg.model).toBe("deepseek-chat");
+    expect(cfg.apiKey).toBe("sk-test");
+    expect(cfg.timeoutMs).toBe(90000);
   });
 });

--- a/packages/eval/src/test/judge-config.test.ts
+++ b/packages/eval/src/test/judge-config.test.ts
@@ -1,0 +1,234 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyJudgeShorthand,
+  loadJudgeConfig,
+} from "../llm/judge-config.js";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "eval-judge-config-test-"));
+}
+
+async function writeSimConfig(dir: string, judge?: unknown): Promise<void> {
+  await mkdir(join(dir, "config"), { recursive: true });
+  const body: Record<string, unknown> = { simulation: {}, agents: [] };
+  if (judge !== undefined) body["judge"] = judge;
+  await writeFile(join(dir, "config", "index.json"), JSON.stringify(body));
+}
+
+const section = {
+  providerType: "openai-compatible",
+  modelName: "section-model",
+  temperature: 0.25,
+};
+
+const standalone = {
+  providerType: "openai-compatible",
+  modelName: "file-model",
+  apiKeyEnv: "DEEPSEEK_API_KEY",
+  temperature: 0,
+  timeoutMs: 12345,
+  jury: [
+    { providerType: "openai-compatible", modelName: "jury-model", label: "jury-a" },
+    { providerType: "openai-compatible", modelName: "jury-model-2", label: "jury-b", apiKeyEnv: "JURY_KEY" },
+  ],
+};
+
+describe("loadJudgeConfig precedence", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("tier 1: an explicit --judge-config file wins over the config/index.json section", async () => {
+    const dir = await tempDir();
+    await writeSimConfig(dir, section);
+    const filePath = join(dir, "judge.json");
+    await writeFile(filePath, JSON.stringify(standalone));
+    try {
+      const resolved = await loadJudgeConfig(["--judge-config", filePath], { cwd: dir });
+      expect(resolved.config.model).toBe("file-model");
+      expect(resolved.config.timeoutMs).toBe(12345);
+      expect(resolved.jury?.map((j) => j.label)).toEqual(["jury-a", "jury-b"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tier 1: --judge-config resolves relative paths against the cwd", async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, "judge.json"), JSON.stringify(standalone));
+    try {
+      const resolved = await loadJudgeConfig(["--judge-config", "judge.json"], { cwd: dir });
+      expect(resolved.config.model).toBe("file-model");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tier 2: the walk-up config/index.json judge section is used when no --judge-config", async () => {
+    const dir = await tempDir();
+    await writeSimConfig(dir, section);
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.providerType).toBe("openai-compatible");
+      expect(resolved.config.model).toBe("section-model");
+      expect(resolved.config.temperature).toBe(0.25);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tier 2: a config/index.json without a judge section falls through to env", async () => {
+    const dir = await tempDir();
+    await writeSimConfig(dir);
+    vi.stubEnv("PERFECTMAN_JUDGE_BASE_URL", "https://api.deepseek.com/v1");
+    vi.stubEnv("PERFECTMAN_JUDGE_MODEL", "deepseek-chat");
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config.baseUrl).toBe("https://api.deepseek.com/v1");
+      expect(resolved.config.model).toBe("deepseek-chat");
+      expect(resolved.providerType).toBe("rule");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves apiKeyEnv by name into the runtime apiKey (file tier)", async () => {
+    const dir = await tempDir();
+    vi.stubEnv("DEEPSEEK_API_KEY", "sk-file-secret");
+    await writeFile(join(dir, "judge.json"), JSON.stringify(standalone));
+    try {
+      const resolved = await loadJudgeConfig(["--judge-config", "judge.json"], { cwd: dir });
+      expect(resolved.config.apiKey).toBe("sk-file-secret");
+      expect(resolved.jury![0]!.apiKey).toBeUndefined();
+      expect(resolved.jury![1]!.apiKey).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves each jury entry's own apiKeyEnv", async () => {
+    const dir = await tempDir();
+    vi.stubEnv("JURY_KEY", "sk-jury-secret");
+    await writeFile(join(dir, "judge.json"), JSON.stringify(standalone));
+    try {
+      const resolved = await loadJudgeConfig(["--judge-config", "judge.json"], { cwd: dir });
+      expect(resolved.jury![1]!.apiKey).toBe("sk-jury-secret");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tier 3: env-only resolution is byte-identical to the pre-pivot judgeConfig()", async () => {
+    const dir = await tempDir();
+    vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "local");
+    vi.stubEnv("PERFECTMAN_JUDGE_BASE_URL", "https://api.deepseek.com/v1");
+    vi.stubEnv("PERFECTMAN_LLM_BASE_URL", "http://localhost:11434/v1");
+    vi.stubEnv("PERFECTMAN_JUDGE_MODEL", "deepseek-chat");
+    vi.stubEnv("PERFECTMAN_LLM_MODEL", "qwen3:1.7b");
+    vi.stubEnv("PERFECTMAN_JUDGE_TEMPERATURE", "0");
+    vi.stubEnv("PERFECTMAN_LLM_API_KEY", "sk-env");
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config).toEqual({
+        baseUrl: "https://api.deepseek.com/v1",
+        model: "deepseek-chat",
+        apiKey: "sk-env",
+        temperature: 0,
+        timeoutMs: 90000,
+      });
+      expect(resolved.providerType).toBe("rule");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("env tier: PERFECTMAN_LLM_PROVIDER=deepseek is the endpoint shortcut, not a provider type", async () => {
+    const dir = await tempDir();
+    vi.stubEnv("PERFECTMAN_LLM_PROVIDER", "deepseek");
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config.baseUrl).toBe("https://api.deepseek.com/v1");
+      expect(resolved.config.model).toBe("deepseek-chat");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tier 4: defaults — clean env + no file yields the local qwen3 endpoint with the bench default temperature", async () => {
+    const dir = await tempDir();
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config).toEqual({
+        baseUrl: "http://localhost:11434/v1",
+        model: "qwen3:8b",
+        apiKey: undefined,
+        temperature: 1.0,
+        timeoutMs: 90000,
+      });
+      expect(resolved.providerType).toBe("rule");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the calibration default at temperature 0 (defaultTemperature option)", async () => {
+    const dir = await tempDir();
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir, defaultTemperature: 0 });
+      expect(resolved.config.temperature).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("env temperature parsing matches the pre-pivot judgeConfig exactly (empty/unset → default)", async () => {
+    const dir = await tempDir();
+    vi.stubEnv("PERFECTMAN_JUDGE_TEMPERATURE", "");
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config.temperature).toBe(1.0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+    const dir2 = await tempDir();
+    vi.stubEnv("PERFECTMAN_JUDGE_TEMPERATURE", "  ");
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir2 });
+      expect(resolved.config.temperature).toBe(1.0);
+    } finally {
+      await rm(dir2, { recursive: true, force: true });
+    }
+  });
+
+  it("intentionally does NOT read a judge.json without --judge-config (section is the only file fallback)", async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, "judge.json"), JSON.stringify(standalone));
+    try {
+      const resolved = await loadJudgeConfig([], { cwd: dir });
+      expect(resolved.config.model).toBe("qwen3:8b");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyJudgeShorthand", () => {
+  const resolved = { providerType: "openai-compatible" as const, config: { baseUrl: "x", model: "m" } };
+
+  it("maps --judge llm to openai-compatible", () => {
+    expect(applyJudgeShorthand(resolved, "llm")).toBe("openai-compatible");
+  });
+
+  it("maps --judge rule to rule", () => {
+    expect(applyJudgeShorthand(resolved, "rule")).toBe("rule");
+  });
+
+  it("keeps the resolved providerType when no flag is passed", () => {
+    expect(applyJudgeShorthand(resolved, undefined)).toBe("openai-compatible");
+    expect(applyJudgeShorthand({ ...resolved, providerType: "mock" }, undefined)).toBe("mock");
+  });
+});

--- a/packages/server/src/cli/config-path.ts
+++ b/packages/server/src/cli/config-path.ts
@@ -2,34 +2,80 @@ import { existsSync } from "node:fs";
 import { dirname, isAbsolute, join, parse, resolve } from "node:path";
 import {
   DEFAULT_SIMULATION_CONFIG_FILENAME,
-  findDefaultSimulationConfigPath,
+  findDefaultConfigPath,
 } from "../config/simulation-config.js";
+
+const JUDGE_CONFIG_USAGE =
+  "Usage: --judge-config path/to/judge.json (or the judge section of config/index.json)\n" +
+  `Default config path: ${DEFAULT_SIMULATION_CONFIG_FILENAME}`;
+
+/**
+ * Shared resolution for `getConfigPath` / `getJudgeConfigPath`: an explicit
+ * flag wins (loud error on a missing value), `defaultFile` provides the
+ * walk-up fallback when no other positional args are present, and a missing
+ * flag with no default yields `undefined` (the next source tier decides).
+ */
+function resolveConfigPath(
+  args: string[],
+  options: {
+    flag: string;
+    shortFlag?: string;
+    defaultFile?: string;
+    requiredWhenArgsPresent: boolean;
+    usage: string;
+  },
+  startDir: string,
+): string | undefined {
+  for (const flag of options.shortFlag ? [options.flag, options.shortFlag] : [options.flag]) {
+    const flagIndex = args.indexOf(flag);
+    if (flagIndex !== -1) {
+      const value = args[flagIndex + 1];
+      if (!value) throw new Error(`${flag} requires a path`);
+      return resolveExplicitConfigPath(value, startDir);
+    }
+  }
+
+  if (args.length === 0 && options.defaultFile !== undefined) {
+    return findDefaultConfigPath(options.defaultFile, startDir);
+  }
+  if (options.requiredWhenArgsPresent) {
+    throw new Error(options.usage);
+  }
+  return undefined;
+}
 
 export function getConfigPath(
   args: string[],
   startDir = process.cwd(),
 ): string {
-  const configIndex = args.indexOf("--config");
-  if (configIndex !== -1) {
-    const value = args[configIndex + 1];
-    if (!value) throw new Error("--config requires a path");
-    return resolveExplicitConfigPath(value, startDir);
-  }
+  return resolveConfigPath(
+    args,
+    {
+      flag: "--config",
+      shortFlag: "-c",
+      defaultFile: DEFAULT_SIMULATION_CONFIG_FILENAME,
+      requiredWhenArgsPresent: true,
+      usage:
+        `Usage: pnpm --filter @perfectman/server run simulation -- [--config path/to/config.json]\n` +
+        `Default config path: ${DEFAULT_SIMULATION_CONFIG_FILENAME}`,
+    },
+    startDir,
+  )!;
+}
 
-  const shortIndex = args.indexOf("-c");
-  if (shortIndex !== -1) {
-    const value = args[shortIndex + 1];
-    if (!value) throw new Error("-c requires a path");
-    return resolveExplicitConfigPath(value, startDir);
-  }
-
-  if (args.length === 0) {
-    return findDefaultSimulationConfigPath(startDir);
-  }
-
-  throw new Error(
-    `Usage: pnpm --filter @perfectman/server run simulation -- [--config path/to/config.json]\n` +
-      `Default config path: ${DEFAULT_SIMULATION_CONFIG_FILENAME}`,
+/** `--judge-config <path>`; absent → undefined (the config section / env tiers decide). */
+export function getJudgeConfigPath(
+  args: string[],
+  startDir = process.cwd(),
+): string | undefined {
+  return resolveConfigPath(
+    args,
+    {
+      flag: "--judge-config",
+      requiredWhenArgsPresent: false,
+      usage: JUDGE_CONFIG_USAGE,
+    },
+    startDir,
   );
 }
 

--- a/packages/server/src/config/__tests__/judge-config.test.ts
+++ b/packages/server/src/config/__tests__/judge-config.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  loadJudgeConfig,
+  loadJudgeSectionFromSimulationConfig,
+  parseJudgeConfig,
+} from "../judge-config.js";
+import { getJudgeConfigPath } from "../../cli/config-path.js";
+
+const validJudgeConfig = {
+  providerType: "openai-compatible",
+  baseUrl: "https://api.deepseek.com/v1",
+  modelName: "deepseek-chat",
+  apiKeyEnv: "DEEPSEEK_API_KEY",
+  temperature: 0,
+  timeoutMs: 90000,
+  retryCount: 1,
+  jury: [
+    {
+      providerType: "openai-compatible",
+      baseUrl: "http://localhost:11434/v1",
+      modelName: "qwen3:8b",
+      temperature: 0,
+      label: "local-qwen",
+    },
+  ],
+};
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "judge-config-test-"));
+  return dir;
+}
+
+describe("parseJudgeConfig", () => {
+  it("parses a full judge config", () => {
+    const config = parseJudgeConfig(validJudgeConfig);
+    expect(config.providerType).toBe("openai-compatible");
+    expect(config.jury).toHaveLength(1);
+    expect(config.jury![0]!.label).toBe("local-qwen");
+  });
+
+  it("rejects an invalid judge config with a path-prefixed error", () => {
+    expect(() => parseJudgeConfig({ providerType: "deepseek", modelName: "x" }, "judge")).toThrow(
+      /judge: /,
+    );
+    expect(() => parseJudgeConfig({ providerType: "deepseek", modelName: "x" }, "judge")).toThrow(
+      /deepseek/,
+    );
+  });
+});
+
+describe("loadJudgeConfig", () => {
+  it("loads a judge config file (readFile → JSON.parse → schema)", async () => {
+    const dir = await tempDir();
+    const path = join(dir, "judge.json");
+    await writeFile(path, JSON.stringify(validJudgeConfig));
+    try {
+      const config = await loadJudgeConfig(path);
+      expect(config.providerType).toBe("openai-compatible");
+      expect(config.jury![0]!.modelName).toBe("qwen3:8b");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly on a missing judge config file", async () => {
+    const dir = await tempDir();
+    try {
+      await expect(loadJudgeConfig(join(dir, "nope.json"))).rejects.toThrow(/Unable to read judge config/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly on invalid judge config JSON, naming the path", async () => {
+    const dir = await tempDir();
+    const path = join(dir, "judge.json");
+    await writeFile(path, "{ not json");
+    try {
+      await expect(loadJudgeConfig(path)).rejects.toThrow(
+        new RegExp(`Invalid judge config JSON at ${path}`),
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly on a schema-invalid judge config", async () => {
+    const dir = await tempDir();
+    const path = join(dir, "judge.json");
+    await writeFile(path, JSON.stringify({ providerType: "bogus", modelName: "x" }));
+    try {
+      await expect(loadJudgeConfig(path)).rejects.toThrow(/Invalid judge config at /);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadJudgeSectionFromSimulationConfig", () => {
+  it("returns undefined when no config/index.json exists in the walk-up", async () => {
+    const dir = await tempDir();
+    try {
+      const section = await loadJudgeSectionFromSimulationConfig(dir);
+      expect(section).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when config/index.json has no judge section", async () => {
+    const dir = await tempDir();
+    await mkdir(join(dir, "config"), { recursive: true });
+    await writeFile(join(dir, "config", "index.json"), JSON.stringify({ simulation: {}, agents: [] }));
+    try {
+      const section = await loadJudgeSectionFromSimulationConfig(dir);
+      expect(section).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the judge section from config/index.json (walk-up from nested cwd)", async () => {
+    const dir = await tempDir();
+    await mkdir(join(dir, "config"), { recursive: true });
+    await writeFile(
+      join(dir, "config", "index.json"),
+      JSON.stringify({ simulation: {}, agents: [], judge: validJudgeConfig }),
+    );
+    const nested = join(dir, "a", "b");
+    await mkdir(nested, { recursive: true });
+    try {
+      const section = await loadJudgeSectionFromSimulationConfig(nested);
+      expect(section?.providerType).toBe("openai-compatible");
+      expect(section?.jury).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly when config/index.json carries an invalid judge section", async () => {
+    const dir = await tempDir();
+    await mkdir(join(dir, "config"), { recursive: true });
+    await writeFile(
+      join(dir, "config", "index.json"),
+      JSON.stringify({ simulation: {}, agents: [], judge: { providerType: "bogus", modelName: "x" } }),
+    );
+    try {
+      await expect(loadJudgeSectionFromSimulationConfig(dir)).rejects.toThrow(/judge: /);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("getJudgeConfigPath", () => {
+  it("resolves --judge-config to an absolute path", () => {
+    expect(getJudgeConfigPath(["--judge-config", "/abs/judge.json"])).toBe("/abs/judge.json");
+  });
+
+  it("throws when --judge-config has no value", () => {
+    expect(() => getJudgeConfigPath(["--judge-config"])).toThrow(/--judge-config requires a path/);
+  });
+
+  it("returns undefined when the flag is absent (walk-up section is the next tier)", () => {
+    expect(getJudgeConfigPath(["--mode", "mock"])).toBeUndefined();
+  });
+
+  it("resolves relative --judge-config against the start dir", async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, "judge.json"), JSON.stringify(validJudgeConfig));
+    try {
+      expect(getJudgeConfigPath(["--judge-config", "judge.json"], dir)).toBe(join(dir, "judge.json"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/config/__tests__/simulation-config.test.ts
+++ b/packages/server/src/config/__tests__/simulation-config.test.ts
@@ -98,6 +98,51 @@ describe("simulation config", () => {
     })).toThrow("env field names only");
   });
 
+  it("parses an optional judge section with a jury", () => {
+    const config = baseConfig();
+    const parsed = parseSimulationConfig({
+      ...config,
+      judge: {
+        providerType: "openai-compatible",
+        baseUrl: "https://api.deepseek.com/v1",
+        modelName: "deepseek-chat",
+        apiKeyEnv: "DEEPSEEK_API_KEY",
+        temperature: 0,
+        timeoutMs: 90000,
+        retryCount: 1,
+        jury: [
+          { providerType: "openai-compatible", modelName: "qwen3:8b", label: "local-qwen" },
+        ],
+      },
+    });
+    expect(parsed.judge?.providerType).toBe("openai-compatible");
+    expect(parsed.judge?.jury).toHaveLength(1);
+    expect(parsed.judge?.jury![0]!.label).toBe("local-qwen");
+  });
+
+  it("rejects an invalid judge section with the same error style", () => {
+    const config = baseConfig();
+    expect(() => parseSimulationConfig({
+      ...config,
+      judge: { providerType: "deepseek", modelName: "x" },
+    })).toThrow(/judge: /);
+  });
+
+  it("rejects duplicate jury labels inside the judge section", () => {
+    const config = baseConfig();
+    expect(() => parseSimulationConfig({
+      ...config,
+      judge: {
+        providerType: "openai-compatible",
+        modelName: "deepseek-chat",
+        jury: [
+          { providerType: "openai-compatible", modelName: "a", label: "same" },
+          { providerType: "openai-compatible", modelName: "b", label: "same" },
+        ],
+      },
+    })).toThrow(/Duplicate jury judge labels: same/);
+  });
+
   it("accepts the generic qwen3 provider type", () => {
     const config = baseConfig();
     const parsed = parseSimulationConfig({

--- a/packages/server/src/config/judge-config.ts
+++ b/packages/server/src/config/judge-config.ts
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import {
+  JudgeAppConfigSchema,
+  type JudgeAppConfig,
+} from "@perfectman/shared";
+import { findDefaultSimulationConfigPath } from "./simulation-config.js";
+
+export function parseJudgeConfig(input: unknown, path = "judge"): JudgeAppConfig {
+  const parsed = JudgeAppConfigSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new Error(`${path}: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export async function loadJudgeConfig(path: string): Promise<JudgeAppConfig> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    throw new Error(`Unable to read judge config at ${path}: ${errorMessage(err)}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid judge config JSON at ${path}: ${errorMessage(err)}`,
+    );
+  }
+  try {
+    return parseJudgeConfig(parsed, path);
+  } catch (err) {
+    throw new Error(`Invalid judge config at ${path}: ${errorMessage(err)}`);
+  }
+}
+
+/**
+ * The eval fallback file source: the `judge` section of the walk-up
+ * `config/index.json` (the same file that describes the agents). Only the
+ * section is read — persona hydration belongs to the simulation runner.
+ * Absent config file OR absent section both resolve to undefined so the
+ * caller falls through to the env tier.
+ */
+export async function loadJudgeSectionFromSimulationConfig(
+  startDir = process.cwd(),
+): Promise<JudgeAppConfig | undefined> {
+  let configPath: string;
+  try {
+    configPath = findDefaultSimulationConfigPath(startDir);
+  } catch {
+    return undefined;
+  }
+
+  const raw = await readFile(configPath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid simulation config JSON at ${configPath}: ${errorMessage(err)}`,
+    );
+  }
+  const root = parsed as Record<string, unknown>;
+  if (root["judge"] === undefined) return undefined;
+  return parseJudgeConfig(root["judge"], "judge");
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -5,6 +5,7 @@ import type {
   AgentState,
   ChannelType,
   CoreMood,
+  JudgeAppConfig,
   Memory,
   PersonaConfig,
   PresenceMode,
@@ -15,6 +16,7 @@ import type {
 import {
   ChannelTypeSchema,
   CoreMoodSchema,
+  JudgeAppConfigSchema,
   PresenceModeSchema,
   RelationalStateSchema,
   SimulationSettingsSchema,
@@ -74,6 +76,8 @@ export type SimulationAppConfig = {
   deliveryGateways: DeliveryGatewayConfig[];
   channels: InitialChannelConfig[];
   agents: AgentConfig[];
+  /** Optional judge section — the same file describes agents AND judge. */
+  judge?: JudgeAppConfig;
   /** If set, a synthetic host message is injected into the default channel before pulse 0. */
   hostStartingMessage?: string;
 };
@@ -205,22 +209,27 @@ const DEFAULT_PERSONA_CALIBRATION: Omit<PersonaConfig, keyof ConfigPersona> = {
 
 export const DEFAULT_SIMULATION_CONFIG_FILENAME = "config/index.json";
 
-export function findDefaultSimulationConfigPath(
+export function findDefaultConfigPath(
+  filename: string,
   startDir = process.cwd(),
 ): string {
   let current = startDir;
   const root = parse(current).root;
 
   while (true) {
-    const candidate = join(current, DEFAULT_SIMULATION_CONFIG_FILENAME);
+    const candidate = join(current, filename);
     if (existsSync(candidate)) return candidate;
     if (current === root) break;
     current = dirname(current);
   }
 
-  throw new Error(
-    `Default simulation config not found: ${DEFAULT_SIMULATION_CONFIG_FILENAME}`,
-  );
+  throw new Error(`Default config not found: ${filename}`);
+}
+
+export function findDefaultSimulationConfigPath(
+  startDir = process.cwd(),
+): string {
+  return findDefaultConfigPath(DEFAULT_SIMULATION_CONFIG_FILENAME, startDir);
 }
 
 export async function loadSimulationConfig(
@@ -320,6 +329,14 @@ export function parseSimulationConfig(input: unknown): SimulationAppConfig {
     deliveryGateways: parseGateways(root["deliveryGateways"]),
     channels: parseChannels(root["channels"]),
     agents: parseAgents(root["agents"]),
+    judge:
+      root["judge"] === undefined
+        ? undefined
+        : parseWithSchema<JudgeAppConfig>(
+            JudgeAppConfigSchema,
+            root["judge"],
+            "judge",
+          ),
   };
 
   validateCrossReferences(config);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -50,6 +50,12 @@ export {
   DEFAULT_SIMULATION_CONFIG_FILENAME,
   inflatePersonaConfig,
 } from "./config/simulation-config.js";
+export {
+  parseJudgeConfig,
+  loadJudgeConfig,
+  loadJudgeSectionFromSimulationConfig,
+} from "./config/judge-config.js";
+export { getJudgeConfigPath } from "./cli/config-path.js";
 export type {
   SimulationAppConfig,
   AgentConfig,

--- a/packages/shared/src/__tests__/judge-config.test.ts
+++ b/packages/shared/src/__tests__/judge-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  JudgeAppConfigSchema,
+  JudgeEntryConfigSchema,
+  JudgeProviderTypeSchema,
+} from "../judge/judge-config.schema.js";
+import type { JudgeAppConfig } from "../judge/judge-config.types.js";
+
+describe("JudgeProviderTypeSchema", () => {
+  it("accepts exactly the three provider types", () => {
+    expect(JudgeProviderTypeSchema.parse("openai-compatible")).toBe("openai-compatible");
+    expect(JudgeProviderTypeSchema.parse("rule")).toBe("rule");
+    expect(JudgeProviderTypeSchema.parse("mock")).toBe("mock");
+    expect(JudgeProviderTypeSchema.safeParse("deepseek").success).toBe(false);
+    expect(JudgeProviderTypeSchema.safeParse("ollama").success).toBe(false);
+  });
+});
+
+describe("JudgeAppConfigSchema", () => {
+  it("parses a full judge section with a cross-family jury", () => {
+    const config = JudgeAppConfigSchema.parse({
+      providerType: "openai-compatible",
+      baseUrl: "https://api.deepseek.com/v1",
+      modelName: "deepseek-chat",
+      apiKeyEnv: "DEEPSEEK_API_KEY",
+      temperature: 0,
+      timeoutMs: 90000,
+      retryCount: 1,
+      responseFormatJson: true,
+      jury: [
+        {
+          providerType: "openai-compatible",
+          baseUrl: "http://localhost:11434/v1",
+          modelName: "qwen3:8b",
+          temperature: 0,
+          label: "local-qwen",
+        },
+        {
+          providerType: "openai-compatible",
+          baseUrl: "https://api.deepseek.com/v1",
+          modelName: "deepseek-chat",
+          apiKeyEnv: "DEEPSEEK_API_KEY",
+          temperature: 0,
+          label: "deepseek",
+        },
+      ],
+    });
+
+    expect(config.providerType).toBe("openai-compatible");
+    expect(config.apiKeyEnv).toBe("DEEPSEEK_API_KEY");
+    expect(config.jury).toHaveLength(2);
+    expect(config.jury![1]!.apiKeyEnv).toBe("DEEPSEEK_API_KEY");
+  });
+
+  it("accepts a minimal judge section (only providerType + modelName)", () => {
+    const config = JudgeAppConfigSchema.parse({ providerType: "rule", modelName: "rule" });
+    expect(config.baseUrl).toBeUndefined();
+    expect(config.jury).toBeUndefined();
+  });
+
+  it("accepts a jury entry without a label (runtime defaults judge-N)", () => {
+    const config = JudgeAppConfigSchema.parse({
+      providerType: "openai-compatible",
+      modelName: "qwen3:8b",
+      jury: [{ providerType: "openai-compatible", modelName: "qwen3:8b" }],
+    });
+    expect(config.jury![0]!.label).toBeUndefined();
+  });
+
+  it("rejects an unsupported providerType (deepseek is an endpoint, not a type)", () => {
+    const result = JudgeAppConfigSchema.safeParse({ providerType: "deepseek", modelName: "x" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing modelName", () => {
+    const result = JudgeAppConfigSchema.safeParse({ providerType: "openai-compatible" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects raw secrets in the section (must use apiKeyEnv by name)", () => {
+    const result = JudgeAppConfigSchema.safeParse({
+      providerType: "openai-compatible",
+      modelName: "deepseek-chat",
+      apiKey: "sk-secret",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toMatch(/secrets through env field names only/);
+    }
+  });
+
+  it("rejects raw secrets inside jury entries too", () => {
+    const result = JudgeAppConfigSchema.safeParse({
+      providerType: "openai-compatible",
+      modelName: "deepseek-chat",
+      jury: [{ providerType: "openai-compatible", modelName: "qwen3:8b", token: "sk" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("mirrors the runtime guard: duplicate jury labels throw", () => {
+    const result = JudgeAppConfigSchema.safeParse({
+      providerType: "openai-compatible",
+      modelName: "deepseek-chat",
+      jury: [
+        { providerType: "openai-compatible", modelName: "a", label: "same" },
+        { providerType: "openai-compatible", modelName: "b", label: "same" },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toMatch(/Duplicate jury judge labels: same/);
+    }
+  });
+
+  it("accepts unique jury labels", () => {
+    const result = JudgeAppConfigSchema.safeParse({
+      providerType: "openai-compatible",
+      modelName: "deepseek-chat",
+      jury: [
+        { providerType: "openai-compatible", modelName: "a", label: "one" },
+        { providerType: "openai-compatible", modelName: "b", label: "two" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects malformed field types", () => {
+    expect(JudgeAppConfigSchema.safeParse({ providerType: "rule", modelName: "", }).success).toBe(false);
+    expect(JudgeAppConfigSchema.safeParse({ providerType: "rule", modelName: "x", temperature: "0" }).success).toBe(false);
+    expect(JudgeAppConfigSchema.safeParse({ providerType: "rule", modelName: "x", timeoutMs: 1.5 }).success).toBe(false);
+    expect(JudgeAppConfigSchema.safeParse({ providerType: "rule", modelName: "x", retryCount: -1 }).success).toBe(false);
+    expect(JudgeAppConfigSchema.safeParse({ providerType: "rule", modelName: "x", responseFormatJson: "yes" }).success).toBe(false);
+  });
+
+  it("types JudgeAppConfig through the shared export", () => {
+    const config: JudgeAppConfig = {
+      providerType: "mock",
+      modelName: "mock",
+    };
+    expect(config.providerType).toBe("mock");
+    expect(JudgeEntryConfigSchema.parse({ providerType: "mock", modelName: "mock", label: "l" }).label).toBe("l");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,10 @@ export * from "./intent/intent.types.js";
 export * from "./intent/intent.schema.js";
 export * from "./intent/intent-packet.schema.js";
 
+// Judge
+export * from "./judge/judge-config.types.js";
+export * from "./judge/judge-config.schema.js";
+
 // Decision
 export * from "./decision/decision.types.js";
 

--- a/packages/shared/src/judge/judge-config.schema.ts
+++ b/packages/shared/src/judge/judge-config.schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import type { JudgeConfigBase } from "./judge-config.types.js";
+
+export const JudgeProviderTypeSchema = z.enum([
+  "openai-compatible",
+  "rule",
+  "mock",
+]);
+
+function isSecretsField(key: string): boolean {
+  return key === "apiKey" || key === "token" || key === "botToken";
+}
+
+// Shared shape; each exported schema adds its own superRefine checks AFTER
+// extend (extend only exists on ZodObject, not on a superRefined ZodEffects).
+const judgeConfigObject = z
+  .object({
+    providerType: JudgeProviderTypeSchema,
+    baseUrl: z.string().min(1).optional(),
+    modelName: z.string().min(1),
+    apiKeyEnv: z.string().min(1).optional(),
+    temperature: z.number().optional(),
+    timeoutMs: z.number().int().positive().optional(),
+    retryCount: z.number().int().nonnegative().optional(),
+    responseFormatJson: z.boolean().optional(),
+  })
+  // passthrough so a future superset field (extraBody, headers) never makes
+  // an old config unreadable; secrets are still rejected loudly instead of
+  // silently stripped.
+  .passthrough();
+
+function rejectInlineSecrets(
+  value: JudgeConfigBase & Record<string, unknown>,
+  ctx: z.RefinementCtx,
+): void {
+  // Same guard as the agent LLM section (parseLLMConfig): secrets must be
+  // referenced by env field NAME, never inlined in the config file.
+  for (const key of Object.keys(value)) {
+    if (isSecretsField(key)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `${key} must not be defined — reference secrets through env field names only (use apiKeyEnv)`,
+      });
+    }
+  }
+}
+
+export const JudgeConfigBaseSchema = judgeConfigObject.superRefine(rejectInlineSecrets);
+
+export const JudgeEntryConfigSchema = judgeConfigObject
+  .extend({ label: z.string().min(1).optional() })
+  .superRefine(rejectInlineSecrets);
+
+export const JudgeAppConfigSchema = judgeConfigObject
+  .extend({ jury: z.array(JudgeEntryConfigSchema).optional() })
+  .superRefine(rejectInlineSecrets)
+  .superRefine((config, ctx) => {
+    // Mirror of the runtime guard in eval's juryJudge (`Duplicate jury
+    // judge labels`) — the file is rejected before any judge ever runs.
+    const labels = (config.jury ?? []).map((j) => j.label ?? "");
+    const duplicates = labels.filter((label, i) => label !== "" && labels.indexOf(label) !== i);
+    if (duplicates.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate jury judge labels: ${[...new Set(duplicates)].join(", ")}`,
+      });
+    }
+  });

--- a/packages/shared/src/judge/judge-config.types.ts
+++ b/packages/shared/src/judge/judge-config.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Judge AppConfig — the judge as a first-class config section.
+ *
+ * Mirrors the agent `LLMConfig` field vocabulary (same zod-parse pattern,
+ * secrets by NAME through `apiKeyEnv`), so the same config file that
+ * describes agents and channels also describes the judge. DeepSeek is NOT
+ * a provider type — it is an openai-compatible endpoint in a file.
+ */
+
+export type JudgeProviderType = "openai-compatible" | "rule" | "mock";
+
+/** Field parity with the server `LLMConfig` (minus agent-only token caps). */
+export type JudgeConfigBase = {
+  providerType: JudgeProviderType;
+  baseUrl?: string;
+  modelName: string;
+  /** Name of the env var holding the secret — never the secret itself. */
+  apiKeyEnv?: string;
+  temperature?: number;
+  timeoutMs?: number;
+  retryCount?: number;
+  responseFormatJson?: boolean;
+};
+
+/** One jury member. `label` is optional — the runtime defaults to judge-N. */
+export type JudgeEntryConfig = JudgeConfigBase & {
+  label?: string;
+};
+
+/** The `judge` section: the default judge plus an optional cross-family jury. */
+export type JudgeAppConfig = JudgeConfigBase & {
+  jury?: JudgeEntryConfig[];
+};


### PR DESCRIPTION
## Judge as a config-file section (pivot)

The judge was the only LLM surface in the project that was not config-file
based: `judgeConfig()` in `cli/bench.ts` was pure environment, with its own
second vocabulary and a special-cased `PERFECTMAN_LLM_PROVIDER=deepseek`
branch. This PR makes the judge a first-class config section with the same
structure as the agents.

### What lands

- **Shared schema** (`packages/shared/src/judge/`): `JudgeAppConfig` with
  field parity to the agent `LLMConfig` — `providerType: "openai-compatible"
  | "rule" | "mock"`, `baseUrl`, `modelName`, `apiKeyEnv` (secret by NAME,
  agent pattern), `temperature`, `timeoutMs`, `retryCount`,
  `responseFormatJson`, plus the `jury` array. DeepSeek is no longer a
  provider type — it is an openai-compatible endpoint in a file. Duplicate
  jury labels are rejected at parse time, mirroring the runtime guard;
  inline secrets are rejected like the agent LLM section.
- **Server loader** (`config/judge-config.ts`): `loadJudgeConfig(path)`
  (loud read/JSON/schema errors) + `loadJudgeSectionFromSimulationConfig`
  (walk-up `config/index.json` `judge` section, absent → undefined) +
  `getJudgeConfigPath` in `config-path.ts` (generalized resolver, existing
  `getConfigPath` semantics unchanged). `SimulationAppConfig` gains
  `judge?`.
- **Eval loader** (`llm/judge-config.ts`): precedence
  `--judge-config <path>` > `config/index.json` `judge` section > env >
  defaults. The env tier is **byte-identical to the pre-pivot
  `judgeConfig()`** (verified across 8 env profiles, incl. the deepseek
  shortcut and temperature edge cases). `judgeConfig()` survives as a
  thin compat call.
- **Provider dispatch**: `--judge rule|llm` is now an explicit shorthand
  override of `providerType` (absent flag → file drives; no file → the
  offline rule default). `ruleJudge` is a first-class `"rule"` provider, a
  deterministic `MockJudgeProvider` covers `"mock"`, and the file's `jury`
  resolves through the same loader — `bench --judge llm` with a configured
  jury runs the median verdict.
- **Docs**: `docs/eval/README.md` gains the file-form example.

### Backward compatibility (the hard gate)

- Zero file + env only behaves exactly as before: gate bench
  **35 scenarios, signal 100.0%, probe 89.9% — BENCH GATE PASSED**
  (post-#82 numbers), both sweep evidence files **byte-identical**, and a
  CLI-level comparison of the old `judgeConfig()` vs the new loader over
  8 env configurations: **all identical**.
- `docs/test-inventory.{json,md}` regenerated (97 files / 909 its).
- Env-only LLM judge/calibrate command lines from the docs keep working
  with no file.

### Note

This is the **structure** half of the judge pivot. The **behavior** half —
promoting the shared `chatCompletion` primitive to a superset
(transport retry via `retryCount`, dual timeout, response-header
extraction, typed errors) and having `OpenAiCompatibleProvider` adopt it —
lands in a follow-up PR, since it is the risky half that requires
re-validating the provider suites. `JudgeConfig.retryCount` becomes
meaningful there.
