### PR TITLE
feat(delivery): per-pulse observability stream with html-snapshot receiver

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Read these in order:
 - [`concepts/`](concepts/) - product thesis, concept synthesis, and experiment framing.
 - [`notes/`](notes/) - raw source notes, transcripts, and meeting material.
 - [`implementation/`](implementation/) - post-merge implementation notes per dev stream.
+- [`adr/`](adr/) - architecture decision records (LOCKED pipeline decisions with lasting architectural consequence).
 - [`plans/`](plans/) - cross-boundary contracts and per-dev implementation plans.
 - [`personas/`](personas/) - generic persona setup docs and templates only. Real/person-specific subfolders are local-only and gitignored.
 
@@ -150,6 +151,11 @@ The novela layer, implemented as a projection over committed events:
 - Persona setup workflow: [`personas/README.md`](personas/README.md)
 - Personality/persona questionnaires: [`notes/persona-assessment-canonical.md`](notes/persona-assessment-canonical.md), [`notes/personality-assessment-research.md`](notes/personality-assessment-research.md), [`notes/friend-questionnaire.md`](notes/friend-questionnaire.md), [`notes/solo-questionnaire.md`](notes/solo-questionnaire.md)
 
+### Stream And Observability
+
+- Delivery gateway stream (event volume, receiver memory bounds, provider-agnostic shape): [`observability-stream.md`](observability-stream.md)
+- Architecture decision records: [`adr/`](adr/)
+
 ### Channel World
 
 - V1 delivery-agnostic runtime: [`architecture/application.md`](architecture/application.md)
@@ -191,7 +197,7 @@ pnpm --filter @perfectman/server simulation --config path/to/config.json
 
 Config format: see [`../examples/simulations/mock.inline-personas.example.json`](../examples/simulations/mock.inline-personas.example.json). For local friend-group personas stored outside git, see [`../examples/simulations/mock.persona-file.example.json`](../examples/simulations/mock.persona-file.example.json), [`../examples/personas/`](../examples/personas/), and [`personas/README.md`](personas/README.md).
 
-`buildConfiguredSimulation` in `packages/server/src/config/simulation-config.ts` is the composition root — it validates the config, wires repositories (in-memory or SQLite), delivery gateways (mock, stdout, or composite), `AgentConfigRegistry`, `AgentRuntime`, and `SimulationRuntime`.
+`buildConfiguredSimulation` in `packages/server/src/config/simulation-config.ts` is the composition root — it validates the config, wires repositories (in-memory or SQLite), delivery gateways (mock, stdout, html-snapshot, or composite), `AgentConfigRegistry`, `AgentRuntime`, and `SimulationRuntime`.
 
 `config/index.json` is gitignored. Copy the example, fill in your agents, and set the appropriate API key env vars if not using `providerType: "mock"`. To keep real people out of git, put compiled persona files in `config/personas/*.persona.json` and reference them from `config/index.json` using `personaFile`.
 

--- a/docs/adr/0001-event-visibility-operator-event.md
+++ b/docs/adr/0001-event-visibility-operator-event.md
@@ -1,0 +1,31 @@
+# ADR-0001: Per-Committed-Event Visibility Signal
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-1 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+US-004 requires the HTML receiver to keep the generator's per-event perspective
+filter (`visibility.visibleToAgents`). No delivered signal can reproduce it:
+`DeliveryMessage` is a reduced `{kind, agentId, content, replyToEventId?, salience}`
+with no eventId, no pulseIndex, no visibility, and spectator events are pre-filtered
+server-side. Without a new signal, a stream-fed receiver must either drop the POV
+filter or widen `IDeliveryGateway` — the first was explicitly overridden by the user,
+the second breaks the no-interface-change constraint (FR-005).
+
+## Decision
+
+Add a new additive `event_visibility` operator event, emitted by
+`PulseScheduler.appendAndProject` once per **committed** event (all event types, not
+only rendered ones) through the existing `emitOperatorEvent` channel, carrying
+`{ eventId, eventType, actorId, channelId, visibleToAgents, content?, channelName? }`
+with typed payload `EventVisibilityData` in the shared operator contract.
+
+## Consequences
+
+- Receivers can reproduce per-event perspective filtering and get the full per-pulse
+  event-type distribution from the stream alone (the basis of SC-002 parity summaries).
+- Stream volume grows by exactly one event per committed event — bounded per
+  `docs/observability-stream.md`; additive and safely ignorable by existing consumers.
+- Rejected alternatives: dropping the POV filter in the receiver (user override);
+  widening `DeliveryMessage`/`IDeliveryGateway` (FR-005 violation); re-emitting the
+  full committed-event payload (heavier than the render slice, duplicates content).

--- a/docs/adr/0002-action-intent-emission.md
+++ b/docs/adr/0002-action-intent-emission.md
@@ -1,0 +1,31 @@
+# ADR-0002: `action_intent` Operator Event
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-3 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+US-002 requires the LLM thinking payload — `intentType`, `visibleContent`,
+`privateMotiveSummary`, `emotionDrivers`, `motivationDrivers` — in the operator
+stream, and the payload must reflect the actual intent, never a fabricated or stale
+one (US-002 ACC-2). The spec clarification also keeps `pulse_metrics` lean: the
+intent payload gets a dedicated event, not a `pulse_metrics` extension. The e2e
+recorder's `agentThinking` is known to carry last-known intents from earlier pulses
+(`PersonaAwareRuntime.lastIntents` is never cleared), so it is not a usable source.
+
+## Decision
+
+The scheduler emits `action_intent` immediately after `intentResolver.resolve`
+succeeds, in the same block that forwards the resolved runtime's operator events.
+The payload reads the five FR-002 fields verbatim from `runtimeOutput.intent` —
+including truthful fallback `no_op` intents (which `action-intent-step.ts` builds
+in-band when `fallbackApplied`). Provider-failure (`runtimeOutput === null`) and
+resolver-failure (`resolved === null`) emit nothing: there is no actual intent.
+
+## Consequences
+
+- The stream's thinking is strictly per-pulse and truthful by construction; parity
+  and receivers must derive thinking from these events, never from recorder
+  `agentThinking` wholesale (stale rows).
+- `action_intent` is absent for uncalled agents in a pulse — a receiver relies on
+  absence, not on a sentinel.
+- New additive type in the shared operator contract (`ActionIntentOperatorData`).

--- a/docs/adr/0003-shared-agent-state-serializer.md
+++ b/docs/adr/0003-shared-agent-state-serializer.md
@@ -1,0 +1,26 @@
+# ADR-0003: Shared Agent-State Serializer
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-4 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+US-001 ACC-3 / SC-002 demand byte parity between the stream's
+`agent_state_snapshot` payloads and the e2e recorder's serialized `AgentState`.
+The recorder's serializer lived in `__e2e__/simulation-recorder.ts`; production
+code cannot import it. The in-memory repository stores and returns the same object
+reference the scheduler persists, so both sides can serialize the identical object.
+
+## Decision
+
+`serializeAgentState` + `SerializedAgentState` live in production at
+`packages/server/src/agent/agent-state-serializer.ts`; the `SimulationRecorder`
+swaps its local copy for an import (behavior unchanged, public types re-exported).
+Both producers — scheduler snapshot emission and recorder frames — share this one
+implementation, making parity hold by construction.
+
+## Consequences
+
+- Stream/recorder parity cannot drift: any serializer change affects both sides
+  equally, so a mismatch would surface in the parity e2e rather than silently.
+- Enforces the test→prod boundary: `__e2e__` code is never imported by production.
+- Future producers of serialized state must use this function, not inline their own.

--- a/docs/adr/0004-gateway-construction-metadata.md
+++ b/docs/adr/0004-gateway-construction-metadata.md
@@ -1,0 +1,28 @@
+# ADR-0004: Runtime Metadata at Gateway Construction
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-5 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+The stream carries ids only, but receivers need human-readable agent names,
+archetypes, and channel names (US-003 ACC-1). FR-004 fixes the injection point:
+`buildConfiguredSimulation`, which is the single gateway construction site
+(`createGateways`). The factory signature was `GatewayFactory = (cfg, debug) =>
+IDeliveryGateway`, and all callers flow through `createGateways` plus one
+`stdout-debug` fallback.
+
+## Decision
+
+`GatewayFactory` gains a third parameter — `GatewayRuntimeMetadata`
+(`simulationId`, `simulationName`, `agents: Record<id,{name,archetype}>`,
+`channels: Record<id,{name}>`) — built in `buildConfiguredSimulation` from the
+config and passed via `createGateways(config, meta)`. Only the mock, stdout, and
+html-snapshot factories consume it as an optional constructor parameter (FR-005);
+the discord factory ignores it; the `stdout-debug` fallback passes nothing.
+
+## Consequences
+
+- Metadata reaches gateways at construction time (FR-004) without reshaping any
+  event payload; the stream stays id-only for dynamic data.
+- Behavior of existing gateways is unchanged — optional params only.
+- New gateway types receive the metadata automatically via the factory map.

--- a/docs/adr/0005-stream-fed-html-receiver.md
+++ b/docs/adr/0005-stream-fed-html-receiver.md
@@ -1,0 +1,31 @@
+# ADR-0005: Stream-Fed HTML Receiver in Production
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-6 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+US-004 turns the HTML artifact into a receiver of the enriched stream so a plain
+CLI run (any provider) can produce it. The generator and the replay contract types
+lived in `__e2e__/`; a production receiver importing them would create a
+test→prod dependency, and the CLI can only load production code. FR-007 sanctions
+relocation/wrapping, while the generator's visuals and data model are out of scope.
+
+## Decision
+
+The receiver is a production `HtmlSnapshotGateway implements IDeliveryGateway` in
+`packages/server/src/delivery/html-snapshot-gateway.ts` — a thin adapter that
+collects stream events (`agent_state_snapshot`, `action_intent`, `event_visibility`)
+and channel calls, builds a `SimulationReplay`, and writes the artifact on
+`onSimulationStopped`. The generator relocates verbatim to
+`packages/server/src/html/snapshot-html-generator.ts` (content untouched), and the
+replay contract types move to `packages/server/src/html/replay-types.ts`, imported
+by recorder, receiver, and generator.
+
+## Consequences
+
+- The artifact is CLI-producible from delivered events + construction metadata
+  (US-004 ACC-1/ACC-2); the e2e recorder stays the parity reference.
+- The replay types become a real shared boundary: two producers (recorder,
+  receiver), one consumer (generator).
+- Production never imports `__e2e__`; the generator's content is unchanged, so
+  recorder-path rendering is byte-identical before and after the move.

--- a/docs/adr/0006-html-snapshot-gateway-config.md
+++ b/docs/adr/0006-html-snapshot-gateway-config.md
@@ -1,0 +1,29 @@
+# ADR-0006: `html-snapshot` Gateway Config Variant
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-7 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+The receiver needs an artifact output path; per the spec assumption, the config
+schema changes only where a receiver needs configuration, additively. The runtime
+already exposes a flush hook — `SimulationRuntime.stop` calls
+`delivery.onSimulationStopped(simulationId)` — and the CLI stop path (SIGINT/
+SIGTERM → `runtime.stop`) feeds it, which matches the spec's stop-mid-pulse edge
+case.
+
+## Decision
+
+A new additive `DeliveryGatewayConfig` variant `{ id, type: "html-snapshot",
+outputPath }`: `parseGateways` requires `outputPath` via `requiredString`, and a
+`GATEWAY_FACTORIES` entry constructs `HtmlSnapshotGateway(meta, outputPath)` —
+the factory map is the single switch site for gateway types. The artifact flushes
+on `onSimulationStopped`, partial frames included.
+
+## Consequences
+
+- Adding an `html-snapshot` gateway to any config produces the artifact on stop,
+  including after a mid-pulse stop.
+- A missing `outputPath` rejects at parse time in the established error style;
+  an unwritable path surfaces as a shutdown error (honest flush).
+- Rejected alternatives: a CLI flag (config is the established surface for gateway
+  configuration) and per-pulse incremental writes (the spec's flush semantics).

--- a/docs/adr/0007-pulse-frame-result-approximation.md
+++ b/docs/adr/0007-pulse-frame-result-approximation.md
@@ -1,0 +1,29 @@
+# ADR-0007: `PulseFrame.result` Stream-Derived Approximation
+
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-9 in `.claude/_output/pipeline/decision-log.md`
+
+## Context
+
+The `SimulationReplay` contract's `PulseFrame` carries a `PulseResult`, but the
+stream never delivers scheduler counters — and FR-003 forbids shaping the stream
+for a receiver's needs. The generator never reads `frame.result` (renderStory and
+the agent panel read `committedEvents`, `agentStates`, `agentThinking` only), and
+the parity normalizer ignores it, so the field is inert for rendering.
+
+## Decision
+
+The receiver approximates `PulseFrame.result` from stream data:
+`eventsCommitted` = count of `event_visibility` events in that pulse;
+`agentsCalled` = number of distinct `action_intent` agents in that pulse.
+Under the current 1:1 emissions (every committed event emits `event_visibility`,
+every resolved intent emits `action_intent`) the approximation equals the real
+counters; failures would legitimately diverge and are documented in the parity test.
+
+## Consequences
+
+- The stream stays the single observability truth — no counter injection.
+- The replay shape stays complete for any future consumer that does read
+  `frame.result`; the approximation is honest and documented at the emission
+  site and in the parity e2e.
+- A future change to emission cardinality (e.g. filtering visibility events) must
+  revisit the approximation and the parity assertion together.

--- a/docs/observability-stream.md
+++ b/docs/observability-stream.md
@@ -1,0 +1,73 @@
+# Observability Stream: Event Volume & Receiver Memory Bounds (SC-005)
+
+The delivery-gateway operator stream is the single observability contract of the
+simulation (FR-003). This document records the per-agent-per-pulse event volume the
+enriched stream adds (issue #91), the memory bound of stream-fed receivers that
+accumulate frames (like `HtmlSnapshotGateway`), and the provider-agnostic shape of
+the stream (FR-006).
+
+## Per-Agent-Per-Pulse Event Volume
+
+For every pulse, the scheduler emits, per agent, through the existing
+best-effort `emitOperatorEvent` channel:
+
+| Event | When | Count per agent per pulse |
+| ----- | ---- | ------------------------- |
+| `agent_state_snapshot` | every agent, every pulse (all three persist paths — no-LLM fall-through, provider-null, resolver-null) | exactly 1 |
+| `action_intent` | only agents whose intent entered resolution (post-resolve; includes truthful fallback `no_op` intents) | 0 or 1 |
+| `event_visibility` | once per **committed** event (all event types), so 1 for a `no_op_recorded`, 1-2 for a `message_sent`/`reply_sent`, 2 for a `channel_created` + `agent_invited` pair | 0..n, where n = events committed by that agent in the pulse |
+| `pulse_metrics` | pre-existing; 1 per LLM call (usage/latency/tokens) | 0 or 1 (LLM-called agents only) |
+| `scheduler_error`, `llm_failure`, `intent_blocked`, `intent_delayed`, `stagnation_warning` | pre-existing; only on the corresponding conditions | 0..n (rare) |
+
+Operator events never enter LLM context — the payload is delivered to gateways
+only, so the added volume has no token cost. All new payloads are additive:
+existing consumers (stdout lines, mock capture, projections, recorder frames)
+are unaffected.
+
+### 4-Persona × 15-Pulse Bound
+
+The e2e 4-persona scenario (Ana, Bruno, Carla, Diego; 15 pulses) stays within:
+
+- **~60 `agent_state_snapshot`** events (4 agents × 15 pulses, exactly 1 per agent per pulse)
+- **≤ ~60 `action_intent`** events (LLM-called agents only; uncalled agents emit none)
+- **~60–120 `event_visibility`** events (committed events per pulse: 1–3 per acting agent;
+  engine `no_op_recorded` plus message/reply/channel events)
+- plus the pre-existing `pulse_metrics` per LLM call (≤ ~60)
+
+Payloads stay bounded per the spec's current-state-only framing: snapshots carry
+the full serialized `AgentState` (including `memories` — bounded by the engine's
+memory lifecycle — and no history/deltas); `action_intent` carries the five
+FR-002 fields verbatim; `event_visibility` carries id/type/actor/channel/
+`visibleToAgents` plus content/channelName where present.
+
+## Receiver Memory Bound
+
+Stream-fed receivers that accumulate per-pulse frames (the `HtmlSnapshotGateway`
+pattern, like the e2e recorder before it) hold, at most:
+
+```
+memory ≈ pulseCount × (per-frame events + serialized agent states + thinking + operator events)
+```
+
+A frame (`PulseFrame`) contains: `committedEvents` (rebuilt rows from
+`event_visibility`), `agentStates` (one serialized state per agent),
+`agentThinking` (one row per called agent), `operatorEvents` (the pulse's
+operator events), and the D-9 approximation of `PulseResult`. In the
+4-persona × 15-pulse scenario this is ~15 frames ≈ tens of KB per frame
+(dominated by the serialized states), i.e. well under 1 MB per run.
+
+The receiver's memory grows linearly with pulse count, not with wall-clock
+time: a long run accumulates frames for every pulse from start to stop.
+Receivers must flush on the `simulation_stopped` signal (partial frames
+included — `HtmlSnapshotGateway` renders whatever has been delivered on
+`onSimulationStopped`). No history or cross-pulse aggregation is retained.
+
+## Provider-Agnostic Shape (FR-006)
+
+The stream shape is identical for every `providerType` — `mock`, `ollama`,
+`openai-compatible` — because all payloads are built in the scheduler from
+shared types (`packages/shared/src/operator/operator.types.ts`), with zero
+changes to the SDK transport or the LLM provider layer. A receiver consuming
+`agent_state_snapshot` / `action_intent` / `event_visibility` + construction
+metadata produces the same artifact for a hosted-provider run as for a mock
+run (SC-003); only the thinking content itself reflects the real model.

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-24T19:47:52.822Z",
+  "generatedAt": "2026-08-25T01:44:27.795Z",
   "totals": {
-    "files": 99,
-    "its": 950
+    "files": 102,
+    "its": 981
   },
   "byPackage": {
     "engine": {
@@ -18,8 +18,8 @@
       ]
     },
     "server": {
-      "files": 52,
-      "its": 457,
+      "files": 55,
+      "its": 488,
       "flags": [
         "console(1)",
         "async-pause(1)",
@@ -894,6 +894,28 @@
       "violations": []
     },
     {
+      "file": "packages/server/src/__e2e__/html-receiver-parity.e2e.test.ts",
+      "pkg": "server",
+      "layer": "e2e",
+      "its": 7,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
       "file": "packages/server/src/__e2e__/html-snapshot.e2e.test.ts",
       "pkg": "server",
       "layer": "e2e",
@@ -1185,7 +1207,7 @@
       "file": "packages/server/src/config/__tests__/simulation-config.test.ts",
       "pkg": "server",
       "layer": "integration",
-      "its": 14,
+      "its": 19,
       "itsEach": 0,
       "forcedCasts": 0,
       "tsBypasses": 0,
@@ -1197,6 +1219,28 @@
       "defined": 0,
       "deadIdTruthy": 0,
       "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts",
+      "pkg": "server",
+      "layer": "integration",
+      "its": 7,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 2,
       "spies": 0,
       "asyncPauses": 0,
       "weakTerminals": [],
@@ -1860,6 +1904,28 @@
       "deadIdTruthy": 0,
       "nonNull": 0,
       "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts",
+      "pkg": "server",
+      "layer": "integration",
+      "its": 12,
+      "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 6,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 5,
       "asyncPauses": 0,
       "weakTerminals": [],
       "flags": [],

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-24T19:47:52.818Z — audited 99 files, 950 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-25T01:44:27.787Z — audited 102 files, 981 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -10,10 +10,10 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 |---|---|---|---|
 | engine | 22 | 259 | —
 | eval | 17 | 140 | async-pause(1)
-| server | 52 | 457 | console(1), async-pause(1), async-pause(1)
+| server | 55 | 488 | console(1), async-pause(1), async-pause(1)
 | shared | 8 | 94 | —
 
-**Total: 99 files, 950 it/test blocks; 4 files flagged.**
+**Total: 102 files, 981 it/test blocks; 4 files flagged.**
 
 ## Per-file inventory
 
@@ -58,6 +58,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/eval/src/test/probes.test.ts | eval-harness | 23 | 
 | packages/eval/src/test/signal-breakdown.test.ts | eval-harness | 4 | 
 | packages/eval/src/test/sweep-temperature.test.ts | eval-harness | 6 | 
+| packages/server/src/__e2e__/html-receiver-parity.e2e.test.ts | e2e | 7 | 
 | packages/server/src/__e2e__/html-snapshot.e2e.test.ts | e2e | 1 | console(1)
 | packages/server/src/__e2e__/pipeline-invariants.e2e.test.ts | e2e | 10 | 
 | packages/server/src/__e2e__/roleplay-behaviors.e2e.test.ts | e2e | 17 | 
@@ -71,7 +72,8 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/agent/surface/__tests__/action-intent-step.test.ts | integration | 9 | 
 | packages/server/src/cli/__tests__/llm-health-check.test.ts | integration | 4 | 
 | packages/server/src/config/__tests__/judge-config.test.ts | integration | 16 | 
-| packages/server/src/config/__tests__/simulation-config.test.ts | integration | 14 | 
+| packages/server/src/config/__tests__/simulation-config.test.ts | integration | 19 | 
+| packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts | integration | 7 | 
 | packages/server/src/discord/__tests__/bot-registry.test.ts | integration | 9 | 
 | packages/server/src/discord/__tests__/channel-map.test.ts | integration | 6 | 
 | packages/server/src/discord/__tests__/discord-config.test.ts | integration | 13 | 
@@ -102,6 +104,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/simulation/__tests__/intent-resolver.test.ts | integration | 8 | 
 | packages/server/src/simulation/__tests__/lifecycle-state-machine.test.ts | integration | 18 | 
 | packages/server/src/simulation/__tests__/operator-projection.test.ts | integration | 4 | 
+| packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts | integration | 12 | 
 | packages/server/src/simulation/__tests__/pulse-scheduler-resilience.test.ts | integration | 2 | async-pause(1)
 | packages/server/src/simulation/__tests__/pulse-scheduler.test.ts | integration | 7 | 
 | packages/server/src/simulation/__tests__/runtime-input-builder.test.ts | integration | 5 | 

--- a/packages/server/src/__e2e__/html-receiver-parity.e2e.test.ts
+++ b/packages/server/src/__e2e__/html-receiver-parity.e2e.test.ts
@@ -1,0 +1,270 @@
+/**
+ * HTML Receiver Parity E2E (SC-002 / D-8)
+ *
+ * One seeded mock run (PersonaAwareRuntime wrapper, both sides) driving a
+ * recorder-style capture AND the production HtmlSnapshotGateway receiver in
+ * the same composite delivery: the receiver must derive the same replay the
+ * recorder-style capture does, normalized per D-8:
+ *   (a) per-pulse event-type→actor summaries (event_visibility vs committedEvents)
+ *   (b) serialized agent states byte-equal (shared serializer, D-4)
+ *   (c) thinking derived from `action_intent` events only — never compared
+ *       against the recorder's stale last-known `agentThinking` wholesale
+ *   (d) channels restricted to the static scenario ids
+ *
+ * The capture loop mirrors SimulationRecorder.runOnePulse exactly (the
+ * recorder's handle is private, so the parity harness replicates its
+ * formulas; the recorder itself stays the reference of html-snapshot.e2e).
+ * The comparison is deterministic: seeded mock, no real LLM.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildConfiguredSimulation,
+  type ConfiguredSimulationHandle,
+  type SimulationAppConfig,
+} from "../config/simulation-config.js";
+import { MockDeliveryGateway } from "../delivery/mock-delivery-gateway.js";
+import { HtmlSnapshotGateway } from "../delivery/html-snapshot-gateway.js";
+import { PersonaAwareRuntime } from "./persona-aware-runtime.js";
+import { FOUR_PERSONA_CONFIG } from "./4-persona-scenario.js";
+import { serializeAgentState, type SerializedAgentState } from "../agent/agent-state-serializer.js";
+import { generateHtml } from "../html/snapshot-html-generator.js";
+import type { AgentThinking, PulseFrame, SimulationReplay } from "../html/replay-types.js";
+import type { ActionIntent, OperatorEvent } from "@perfectman/shared";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = resolve(__dirname, "../../../../tmp/perfectman-receiver-parity.html");
+const PULSE_COUNT = parseInt(process.env["PULSE_COUNT"] ?? "15", 10);
+
+const PARITY_CONFIG: SimulationAppConfig = {
+  ...FOUR_PERSONA_CONFIG,
+  deliveryGateways: [
+    { id: "mock", type: "mock" },
+    { id: "html", type: "html-snapshot", outputPath: OUTPUT_PATH },
+  ],
+};
+
+const STATIC_CHANNEL_IDS = new Set(FOUR_PERSONA_CONFIG.channels.map((c) => c.id));
+
+// ── Recorder-style helpers (mirror SimulationRecorder's formulas) ─────────────
+
+function intentToThinking(agentId: string, intent: ActionIntent): AgentThinking {
+  return {
+    agentId,
+    intentType: intent.intentType,
+    visibleContent: intent.visibleContent,
+    privateMotiveSummary: intent.privateMotiveSummary,
+    emotionDrivers: intent.emotionDrivers ?? [],
+    motivationDrivers: intent.motivationDrivers ?? [],
+  };
+}
+
+function thinkingFromIntentEvent(event: OperatorEvent): AgentThinking | null {
+  if (!event.agentId) return null;
+  const data = event.data ?? {};
+  const visibleContent = data["visibleContent"];
+  return {
+    agentId: event.agentId,
+    intentType: typeof data["intentType"] === "string" ? data["intentType"] : "",
+    visibleContent: typeof visibleContent === "string" ? visibleContent : undefined,
+    privateMotiveSummary:
+      typeof data["privateMotiveSummary"] === "string" ? data["privateMotiveSummary"] : "",
+    emotionDrivers: Array.isArray(data["emotionDrivers"])
+      ? data["emotionDrivers"].filter((d): d is string => typeof d === "string")
+      : [],
+    motivationDrivers: Array.isArray(data["motivationDrivers"])
+      ? data["motivationDrivers"].filter((d): d is string => typeof d === "string")
+      : [],
+  };
+}
+
+function eventSummary(frame: PulseFrame): Record<string, string[]> {
+  const byActor: Record<string, string[]> = {};
+  for (const e of frame.committedEvents) {
+    (byActor[e.actorId] ??= []).push(e.type);
+  }
+  for (const types of Object.values(byActor)) types.sort();
+  return byActor;
+}
+
+function recorderStyleReplay(
+  config: SimulationAppConfig,
+  simulationId: string,
+  pulses: PulseFrame[],
+): SimulationReplay {
+  const agentNames: Record<string, string> = {};
+  const agentArchetypes: Record<string, string> = {};
+  for (const agent of config.agents) {
+    agentNames[agent.id] = agent.persona.name;
+    agentArchetypes[agent.id] = agent.persona.archetype;
+  }
+  return {
+    simulationId,
+    simulationName: config.simulation.name,
+    agentIds: config.agents.map((a) => a.id),
+    agentNames,
+    agentArchetypes,
+    channels: config.channels.map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      memberAgentIds: c.memberAgentIds,
+    })),
+    pulses,
+  };
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+describe("html receiver parity (SC-002)", () => {
+  let handle: ConfiguredSimulationHandle;
+  let gateway: MockDeliveryGateway;
+  let receiver: HtmlSnapshotGateway;
+  let recorderReplay: SimulationReplay;
+  let receiverReplay: SimulationReplay;
+
+  beforeAll(async () => {
+    let personaRuntime: PersonaAwareRuntime | undefined;
+    handle = await buildConfiguredSimulation(PARITY_CONFIG, {
+      agentRuntimeFactory: (registry) => {
+        personaRuntime = new PersonaAwareRuntime(registry);
+        return personaRuntime;
+      },
+    });
+    const gw = handle.gateways["mock"];
+    if (!(gw instanceof MockDeliveryGateway)) throw new Error("parity config must create a mock gateway");
+    gateway = gw;
+    const html = handle.gateways["html"];
+    if (!(html instanceof HtmlSnapshotGateway)) throw new Error("parity config must create an html-snapshot gateway");
+    receiver = html;
+    gateway.reset();
+
+    const pulses: PulseFrame[] = [];
+    let lastEventId: string | undefined = undefined;
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      const preOpCount = gateway.operatorEvents.length;
+      const result = await handle.runtime.runPulse(handle.simulationId);
+
+      const newEvents = await handle.repositories.eventRepo.getAfter(handle.simulationId, lastEventId);
+      if (newEvents.length > 0) lastEventId = newEvents[newEvents.length - 1]!.id;
+
+      const agentStates: Record<string, SerializedAgentState> = {};
+      for (const agent of PARITY_CONFIG.agents) {
+        const state = await handle.repositories.agentStateRepo.get(handle.simulationId, agent.id);
+        if (state) agentStates[agent.id] = serializeAgentState(state);
+      }
+
+      const agentThinking: Record<string, AgentThinking> = {};
+      for (const [agentId, intent] of personaRuntime!.lastIntents.entries()) {
+        agentThinking[agentId] = intentToThinking(agentId, intent);
+      }
+
+      pulses.push({
+        pulseIndex: result.pulseIndex,
+        result,
+        committedEvents: newEvents,
+        agentStates,
+        agentThinking,
+        operatorEvents: gateway.operatorEvents.slice(preOpCount),
+      });
+    }
+
+    recorderReplay = recorderStyleReplay(PARITY_CONFIG, handle.simulationId, pulses);
+    await handle.runtime.stop(handle.simulationId); // flushes the receiver artifact
+    receiverReplay = receiver.toReplay();
+  }, 120_000);
+
+  afterAll(async () => {
+    await handle?.close();
+  });
+
+  it("runs the same scenario for the recorder-style capture and the receiver", () => {
+    expect(receiverReplay.pulses).toHaveLength(PULSE_COUNT);
+    expect(recorderReplay.pulses).toHaveLength(PULSE_COUNT);
+    expect(receiverReplay.simulationName).toBe(recorderReplay.simulationName);
+    expect(receiverReplay.agentIds).toEqual(recorderReplay.agentIds);
+    expect(receiverReplay.agentNames).toEqual(recorderReplay.agentNames);
+    expect(receiverReplay.agentArchetypes).toEqual(recorderReplay.agentArchetypes);
+    // The receiver sees the full stream: same operator events, same order.
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      expect(receiverReplay.pulses[i]!.operatorEvents).toEqual(recorderReplay.pulses[i]!.operatorEvents);
+    }
+  });
+
+  it("matches per-pulse event-type→actor summaries (event_visibility vs committedEvents)", () => {
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      expect(eventSummary(receiverReplay.pulses[i]!)).toEqual(eventSummary(recorderReplay.pulses[i]!));
+    }
+  });
+
+  it("produces byte-equal serialized agent states per pulse", () => {
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      expect(receiverReplay.pulses[i]!.agentStates).toEqual(recorderReplay.pulses[i]!.agentStates);
+    }
+  });
+
+  it("derives thinking from the action_intent events, never from stale recorder thinking", () => {
+    let staleFrames = 0;
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      const recorderFrame = recorderReplay.pulses[i]!;
+      const receiverFrame = receiverReplay.pulses[i]!;
+
+      const intentMap: Record<string, AgentThinking> = {};
+      for (const opEv of recorderFrame.operatorEvents) {
+        if (opEv.type !== "action_intent") continue;
+        const thinking = thinkingFromIntentEvent(opEv);
+        if (thinking) intentMap[thinking.agentId] = thinking;
+      }
+
+      // Receiver thinking == intent-event derivation for this pulse only.
+      expect(receiverFrame.agentThinking).toEqual(intentMap);
+      // The recorder's stale last-known map is a superset on frames where an
+      // agent was called earlier but not this pulse — exactly the rows the
+      // stream-fed receiver must NOT carry.
+      if (Object.keys(recorderFrame.agentThinking).length > Object.keys(intentMap).length) {
+        staleFrames += 1;
+      }
+    }
+    expect(staleFrames).toBeGreaterThan(0);
+  });
+
+  it("restricts receiver channels to the static scenario ids (dynamic normalized)", () => {
+    const receiverStatic = receiverReplay.channels
+      .filter((c) => STATIC_CHANNEL_IDS.has(c.id))
+      .sort((a, b) => a.id.localeCompare(b.id));
+    const recorderChannels = [...recorderReplay.channels].sort((a, b) => a.id.localeCompare(b.id));
+    expect(receiverStatic.map((c) => ({ id: c.id, name: c.name, type: c.type }))).toEqual(
+      recorderChannels.map((c) => ({ id: c.id, name: c.name, type: c.type })),
+    );
+    // Any extra channels are dynamic ones created mid-run: their ids are not
+    // in the static set and their names fall back to the id (no metadata).
+    const dynamicChannels = receiverReplay.channels.filter((c) => !STATIC_CHANNEL_IDS.has(c.id));
+    for (const channel of dynamicChannels) {
+      expect(channel.name).toBe(channel.id);
+    }
+  });
+
+  it("approximates PulseFrame.result from the stream (D-9)", () => {
+    for (let i = 0; i < PULSE_COUNT; i++) {
+      const receiverFrame = receiverReplay.pulses[i]!;
+      const recorderFrame = recorderReplay.pulses[i]!;
+      // eventsCommitted: one event_visibility per committed event — equals the scheduler counter.
+      expect(receiverFrame.result.eventsCommitted).toBe(recorderFrame.result.eventsCommitted);
+      expect(receiverFrame.result.eventsCommitted).toBe(receiverFrame.committedEvents.length);
+      // agentsCalled: distinct action_intent agents — healthy run resolves every call.
+      expect(receiverFrame.result.agentsCalled).toBe(recorderFrame.result.agentsCalled);
+      expect(receiverFrame.result.pulseIndex).toBe(recorderFrame.result.pulseIndex);
+    }
+  });
+
+  it("writes the artifact and renders the four persona names on both paths", async () => {
+    expect(existsSync(OUTPUT_PATH)).toBe(true);
+    const receiverHtml = generateHtml(receiverReplay);
+    for (const name of ["Ana", "Bruno", "Carla", "Diego"]) {
+      expect(receiverHtml).toContain(name);
+      expect(generateHtml(recorderReplay)).toContain(name);
+    }
+  });
+});

--- a/packages/server/src/__e2e__/html-snapshot.e2e.test.ts
+++ b/packages/server/src/__e2e__/html-snapshot.e2e.test.ts
@@ -17,8 +17,8 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SimulationRecorder } from "./simulation-recorder.js";
 import { FOUR_PERSONA_CONFIG } from "./4-persona-scenario.js";
-import { generateHtml } from "./snapshot-html-generator.js";
-import type { SimulationReplay } from "./simulation-recorder.js";
+import { generateHtml } from "../html/snapshot-html-generator.js";
+import type { SimulationReplay } from "../html/replay-types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Test evidence only — written to a gitignored tmp dir so the tree stays clean.

--- a/packages/server/src/__e2e__/simulation-recorder.ts
+++ b/packages/server/src/__e2e__/simulation-recorder.ts
@@ -8,14 +8,17 @@
  *  - Captures the last ActionIntent per agent (for "thinking" panels)
  */
 import type {
-  CommittedEvent,
-  AgentState,
-  OperatorEvent,
-  RelationalState,
   ActionIntent,
   SimulationEvent,
 } from "@perfectman/shared";
-import type { PulseResult } from "../simulation/pulse-scheduler.js";
+import { serializeAgentState, type SerializedAgentState } from "../agent/agent-state-serializer.js";
+export type { SerializedAgentState };
+import type {
+  AgentThinking,
+  PulseFrame,
+  SimulationReplay,
+} from "../html/replay-types.js";
+export type { AgentThinking, PulseFrame, SimulationReplay };
 import type {
   SimulationAppConfig,
   ConfiguredSimulationHandle,
@@ -23,46 +26,6 @@ import type {
 import { buildConfiguredSimulation } from "../config/simulation-config.js";
 import { MockDeliveryGateway } from "../delivery/mock-delivery-gateway.js";
 import { PersonaAwareRuntime } from "./persona-aware-runtime.js";
-
-// ── Serializable types (Maps replaced with plain objects) ─────────────────────
-
-export type SerializedAgentState = Omit<AgentState, "relationalStates"> & {
-  relationalStates: Record<string, RelationalState>;
-};
-
-export type AgentThinking = {
-  agentId: string;
-  intentType: string;
-  visibleContent: string | undefined;
-  privateMotiveSummary: string;
-  emotionDrivers: string[];
-  motivationDrivers: string[];
-};
-
-export type PulseFrame = {
-  pulseIndex: number;
-  result: PulseResult;
-  committedEvents: CommittedEvent[];
-  agentStates: Record<string, SerializedAgentState>;
-  /** Thinking data from the LLM intent — only set if agent had an LLM call this pulse */
-  agentThinking: Record<string, AgentThinking>;
-  operatorEvents: OperatorEvent[];
-};
-
-export type SimulationReplay = {
-  simulationId: string;
-  simulationName: string;
-  agentIds: string[];
-  agentNames: Record<string, string>;
-  agentArchetypes: Record<string, string>;
-  channels: Array<{
-    id: string;
-    name: string;
-    type: string;
-    memberAgentIds: string[];
-  }>;
-  pulses: PulseFrame[];
-};
 
 // ── Recorder ─────────────────────────────────────────────────────────────────
 
@@ -212,13 +175,6 @@ export class SimulationRecorder {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function serializeAgentState(state: AgentState): SerializedAgentState {
-  return {
-    ...state,
-    relationalStates: Object.fromEntries(state.relationalStates.entries()),
-  };
-}
 
 function intentToThinking(agentId: string, intent: ActionIntent): AgentThinking {
   return {

--- a/packages/server/src/agent/agent-state-serializer.ts
+++ b/packages/server/src/agent/agent-state-serializer.ts
@@ -1,0 +1,16 @@
+import type { AgentState, RelationalState } from "@perfectman/shared";
+
+/** Serializable agent state — `relationalStates` Map replaced with a plain object. */
+export type SerializedAgentState = Omit<AgentState, "relationalStates"> & {
+  relationalStates: Record<string, RelationalState>;
+};
+
+/** The single implementation shared by the scheduler's snapshot emission and the
+ *  e2e recorder's frames — stream/recorder parity depends on both producers
+ *  serializing through this. Change in place; never duplicate per producer. */
+export function serializeAgentState(state: AgentState): SerializedAgentState {
+  return {
+    ...state,
+    relationalStates: Object.fromEntries(state.relationalStates.entries()),
+  };
+}

--- a/packages/server/src/config/__tests__/simulation-config.test.ts
+++ b/packages/server/src/config/__tests__/simulation-config.test.ts
@@ -9,6 +9,7 @@ import {
   parseSimulationConfig,
   type SimulationAppConfig,
 } from "../simulation-config.js";
+import { MockDeliveryGateway } from "../../delivery/index.js";
 
 const persona = {
   id: "ana",
@@ -243,6 +244,80 @@ describe("simulation config", () => {
     } finally {
       await handle.close();
     }
+  });
+
+  it("injects runtime metadata into mock gateway construction (US-003 ACC-1)", async () => {
+    const handle = await buildConfiguredSimulation(baseConfig());
+    try {
+      const meta = (handle.gateways["mock"] as MockDeliveryGateway).runtimeMetadata;
+      expect(meta).toEqual({
+        simulationId: "sim_config_test",
+        simulationName: "Config Test",
+        agents: { ana: { name: "Ana", archetype: "observer" } },
+        channels: { general: { name: "general" } },
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("maps a 4-persona scenario's names and archetypes into metadata (US-003 ACC-2)", async () => {
+    const config = baseConfig();
+    const fourPersona = parseSimulationConfig({
+      ...config,
+      agents: [
+        config.agents[0],
+        { id: "bruno", persona: { ...persona, id: "bruno", name: "Bruno" }, promptProfile: { ...promptProfile, personaId: "bruno", displayName: "Bruno" }, llm },
+        { id: "carla", persona: { ...persona, id: "carla", name: "Carla", archetype: "provocateur" }, promptProfile: { ...promptProfile, personaId: "carla", displayName: "Carla" }, llm },
+        { id: "diego", persona: { ...persona, id: "diego", name: "Diego", archetype: "strategist" }, promptProfile: { ...promptProfile, personaId: "diego", displayName: "Diego" }, llm },
+      ],
+    });
+    const handle = await buildConfiguredSimulation(fourPersona);
+    try {
+      const meta = (handle.gateways["mock"] as MockDeliveryGateway).runtimeMetadata;
+      expect(meta?.agents).toEqual({
+        ana: { name: "Ana", archetype: "observer" },
+        bruno: { name: "Bruno", archetype: "observer" },
+        carla: { name: "Carla", archetype: "provocateur" },
+        diego: { name: "Diego", archetype: "strategist" },
+      });
+      expect(meta?.channels).toEqual({ general: { name: "general" } });
+      expect(meta?.simulationId).toBe("sim_config_test");
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("parses an html-snapshot gateway with a required outputPath (US-004 ACC-1)", () => {
+    const config = baseConfig();
+    const parsed = parseSimulationConfig({
+      ...config,
+      deliveryGateways: [
+        { id: "mock", type: "mock" },
+        { id: "html", type: "html-snapshot", outputPath: "tmp/out.html" },
+      ],
+    });
+    expect(parsed.deliveryGateways).toContainEqual({
+      id: "html",
+      type: "html-snapshot",
+      outputPath: "tmp/out.html",
+    });
+  });
+
+  it("rejects an html-snapshot gateway without an outputPath", () => {
+    const config = baseConfig();
+    expect(() => parseSimulationConfig({
+      ...config,
+      deliveryGateways: [{ id: "html", type: "html-snapshot" }],
+    })).toThrow("deliveryGateways[0].outputPath must be a non-empty string");
+  });
+
+  it("still rejects unknown gateway types", () => {
+    const config = baseConfig();
+    expect(() => parseSimulationConfig({
+      ...config,
+      deliveryGateways: [{ id: "x", type: "smoke-signals" }],
+    })).toThrow("Unsupported deliveryGateways[0].type: smoke-signals");
   });
 
   it("loads an agent persona and prompt profile from a local personaFile", async () => {

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -60,6 +60,7 @@ import type {
 } from "../simulation/pulse-scheduler.js";
 import {
   CompositeDeliveryGateway,
+  HtmlSnapshotGateway,
   MockDeliveryGateway,
   StdoutDeliveryGateway,
 } from "../delivery/index.js";
@@ -95,6 +96,7 @@ export type DebugConfig = {
 export type DeliveryGatewayConfig =
   | { id: string; type: "mock" }
   | { id: string; type: "stdout"; debug?: boolean }
+  | { id: string; type: "html-snapshot"; outputPath: string }
   | {
       id: string;
       type: "discord";
@@ -103,6 +105,14 @@ export type DeliveryGatewayConfig =
       managerBotTokenEnv?: string;
       setupMode?: "readonly_existing" | "manage_channels";
     };
+
+/** Construction-time runtime metadata (US-003 / FR-004): the stream carries ids only. */
+export type GatewayRuntimeMetadata = {
+  simulationId: string;
+  simulationName: string;
+  agents: Record<string, { name: string; archetype: string }>;
+  channels: Record<string, { name: string }>;
+};
 
 export type InitialChannelConfig = {
   id: string;
@@ -349,7 +359,10 @@ export async function buildConfiguredSimulation(
 ): Promise<ConfiguredSimulationHandle> {
   const simulationId = config.simulation.id ?? createId();
   const persistence = createRepositories(config.persistence);
-  const gateways = await createGateways(config);
+  const gateways = await createGateways(
+    config,
+    buildGatewayRuntimeMetadata(config, simulationId),
+  );
   const delivery = new CompositeDeliveryGateway(Object.values(gateways));
   const configuredAgents = config.agents.map<ConfiguredAgent>((agent) => ({
     id: agent.id,
@@ -431,16 +444,23 @@ function createRepositories(config: PersistenceConfig): {
 type GatewayFactory = (
   cfg: DeliveryGatewayConfig,
   debug: DebugConfig | undefined,
+  meta: GatewayRuntimeMetadata,
 ) => IDeliveryGateway | Promise<IDeliveryGateway>;
 
 const GATEWAY_FACTORIES: Record<DeliveryGatewayConfig["type"], GatewayFactory> =
   {
-    mock: () => new MockDeliveryGateway(),
-    stdout: (cfg, debug) =>
+    mock: (_cfg, _debug, meta) => new MockDeliveryGateway(meta),
+    "html-snapshot": (cfg, _debug, meta) =>
+      new HtmlSnapshotGateway(
+        meta,
+        (cfg as Extract<DeliveryGatewayConfig, { type: "html-snapshot" }>).outputPath,
+      ),
+    stdout: (cfg, debug, meta) =>
       new StdoutDeliveryGateway(
         (cfg as Extract<DeliveryGatewayConfig, { type: "stdout" }>).debug ??
           debug?.operatorEvents ??
           false,
+        meta,
       ),
     discord: async (cfg) => {
       const discordCfg = cfg as Extract<DeliveryGatewayConfig, { type: "discord" }>;
@@ -507,12 +527,40 @@ const GATEWAY_FACTORIES: Record<DeliveryGatewayConfig["type"], GatewayFactory> =
     },
   };
 
+function buildGatewayRuntimeMetadata(
+  config: SimulationAppConfig,
+  simulationId: string,
+): GatewayRuntimeMetadata {
+  const agents: GatewayRuntimeMetadata["agents"] = {};
+  for (const agent of config.agents) {
+    agents[agent.id] = {
+      name: agent.persona.name,
+      archetype: agent.persona.archetype,
+    };
+  }
+  const channels: GatewayRuntimeMetadata["channels"] = {};
+  for (const channel of config.channels) {
+    channels[channel.id] = { name: channel.name };
+  }
+  return {
+    simulationId,
+    simulationName: config.simulation.name,
+    agents,
+    channels,
+  };
+}
+
 async function createGateways(
   config: SimulationAppConfig,
+  meta: GatewayRuntimeMetadata,
 ): Promise<Record<string, IDeliveryGateway>> {
   const result: Record<string, IDeliveryGateway> = {};
   for (const gateway of config.deliveryGateways) {
-    result[gateway.id] = await GATEWAY_FACTORIES[gateway.type](gateway, config.debug);
+    result[gateway.id] = await GATEWAY_FACTORIES[gateway.type](
+      gateway,
+      config.debug,
+      meta,
+    );
   }
   if (
     config.debug?.stdoutDelivery &&
@@ -611,6 +659,16 @@ function parseGateways(input: unknown): DeliveryGatewayConfig[] {
       `deliveryGateways[${index}].type`,
     );
     if (type === "mock") return { id, type };
+    if (type === "html-snapshot") {
+      return {
+        id,
+        type,
+        outputPath: requiredString(
+          gateway["outputPath"],
+          `deliveryGateways[${index}].outputPath`,
+        ),
+      };
+    }
     if (type === "stdout") {
       return {
         id,

--- a/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
+++ b/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HtmlSnapshotGateway } from "../html-snapshot-gateway.js";
+import { generateHtml } from "../../html/snapshot-html-generator.js";
+import type { GatewayRuntimeMetadata } from "../../config/simulation-config.js";
+import type { SerializedAgentState } from "../../agent/agent-state-serializer.js";
+import type { OperatorEvent } from "@perfectman/shared";
+
+const META: GatewayRuntimeMetadata = {
+  simulationId: "sim_rcv",
+  simulationName: "Receiver Test",
+  agents: {
+    ana: { name: "Ana", archetype: "observer" },
+    bruno: { name: "Bruno", archetype: "observer" },
+  },
+  channels: {
+    general: { name: "general" },
+    "ana-carla": { name: "ana ↔ carla" },
+  },
+};
+
+const SOCIAL_ZERO = {
+  jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0,
+  affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0,
+  neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0,
+  desireForIntimacy: 0,
+};
+
+function state(agentId: string): SerializedAgentState {
+  return {
+    agentId,
+    simulationId: "sim_rcv",
+    personaId: `persona_${agentId}`,
+    presence: "active",
+    coreMood: { valence: 0.1, arousal: 0.4, stability: 0.7, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.4, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { ...SOCIAL_ZERO, pride: 0.2 },
+    relationalStates: {},
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function snapshot(agentId: string, pulseIndex: number): OperatorEvent {
+  return {
+    type: "agent_state_snapshot",
+    simulationId: "sim_rcv",
+    agentId,
+    pulseIndex,
+    detail: "Agent state snapshot",
+    data: { state: state(agentId) },
+    createdAt: 1,
+  };
+}
+
+function intent(agentId: string, pulseIndex: number): OperatorEvent {
+  return {
+    type: "action_intent",
+    simulationId: "sim_rcv",
+    agentId,
+    pulseIndex,
+    detail: "Action intent",
+    data: {
+      intentType: "send_message",
+      visibleContent: "oi gente",
+      privateMotiveSummary: "Preciso marcar presença sem chamar atenção.",
+      emotionDrivers: ["curiosity"],
+      motivationDrivers: ["connection"],
+    },
+    createdAt: 1,
+  };
+}
+
+function visibility(eventId: string, pulseIndex: number, type: string, extra: Record<string, unknown> = {}): OperatorEvent {
+  const actorId = typeof extra["actorId"] === "string" ? extra["actorId"] : "ana";
+  const channelId = typeof extra["channelId"] === "string" ? extra["channelId"] : "general";
+  const visibleToAgents = Array.isArray(extra["visibleToAgents"])
+    ? extra["visibleToAgents"].filter((x): x is string => typeof x === "string")
+    : [];
+  const content = typeof extra["content"] === "string" ? extra["content"] : undefined;
+  const channelName = typeof extra["channelName"] === "string" ? extra["channelName"] : undefined;
+  return {
+    type: "event_visibility",
+    simulationId: "sim_rcv",
+    agentId: actorId,
+    pulseIndex,
+    detail: `Event visibility: ${type}`,
+    data: {
+      eventId,
+      eventType: type,
+      actorId,
+      channelId,
+      visibleToAgents,
+      content,
+      channelName,
+    },
+    createdAt: 1,
+  };
+}
+
+describe("HtmlSnapshotGateway (stream-fed receiver)", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  /** Fresh gateway pre-created with the two metadata channels. */
+  function buildGateway(): { gw: HtmlSnapshotGateway; outputPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "perfectman-html-gw-"));
+    dirs.push(dir);
+    const outputPath = join(dir, "out", "snapshot.html");
+    const gw = new HtmlSnapshotGateway(META, outputPath);
+    void gw.createChannel("general", "public_channel", ["ana", "bruno"]);
+    void gw.createChannel("ana-carla", "private_channel", ["ana", "bruno"]);
+    return { gw, outputPath };
+  }
+
+  it("builds a replay from the delivered stream and flushes the artifact on stop", async () => {
+    const { gw, outputPath } = buildGateway();
+    // Delivery messages are redundant for this receiver — content rides in event_visibility.
+    void gw.sendAgentMessage("general", { kind: "message", agentId: "ana", content: "oi", salience: "low" });
+
+    await gw.sendOperatorEvent(snapshot("ana", 0));
+    await gw.sendOperatorEvent(snapshot("bruno", 0));
+    await gw.sendOperatorEvent(intent("ana", 0));
+    await gw.sendOperatorEvent(visibility("ev_m1", 0, "message_sent", { content: "oi gente" }));
+    await gw.sendOperatorEvent(visibility("ev_noop", 0, "no_op_recorded", { actorId: "bruno", visibleToAgents: [] }));
+    await gw.onSimulationStopped("sim_rcv");
+
+    const replay = gw.toReplay();
+    expect(replay.simulationId).toBe("sim_rcv");
+    expect(replay.simulationName).toBe("Receiver Test");
+    expect(replay.agentIds).toEqual(["ana", "bruno"]);
+    expect(replay.agentNames).toEqual({ ana: "Ana", bruno: "Bruno" });
+    expect(replay.agentArchetypes).toEqual({ ana: "observer", bruno: "observer" });
+
+    expect(replay.channels).toEqual([
+      { id: "general", name: "general", type: "public_channel", memberAgentIds: ["ana", "bruno"] },
+      { id: "ana-carla", name: "ana ↔ carla", type: "private_channel", memberAgentIds: ["ana", "bruno"] },
+    ]);
+    expect(replay.pulses).toHaveLength(1);
+
+    const frame = replay.pulses[0]!;
+    expect(frame.pulseIndex).toBe(0);
+    expect(Object.keys(frame.agentStates).sort()).toEqual(["ana", "bruno"]);
+    expect(frame.agentStates["ana"]).toEqual(state("ana"));
+    expect(frame.committedEvents.map((e) => e.type)).toEqual(["message_sent", "no_op_recorded"]);
+    const messageRow = frame.committedEvents[0]!;
+    expect(messageRow.id).toBe("ev_m1");
+    expect(messageRow.actorId).toBe("ana");
+    expect(messageRow.channelId).toBe("general");
+    expect(messageRow.payload["content"]).toBe("oi gente");
+    expect(messageRow.visibility.visibleToAgents).toEqual([]);
+    const noOpRow = frame.committedEvents[1]!;
+    expect(noOpRow.actorId).toBe("bruno");
+    expect(noOpRow.visibility.visibleToAgents).toEqual([]);
+
+    expect(frame.agentThinking["ana"]).toEqual({
+      agentId: "ana",
+      intentType: "send_message",
+      visibleContent: "oi gente",
+      privateMotiveSummary: "Preciso marcar presença sem chamar atenção.",
+      emotionDrivers: ["curiosity"],
+      motivationDrivers: ["connection"],
+    });
+    expect(frame.result.eventsCommitted).toBe(2);
+    expect(frame.result.agentsCalled).toBe(1);
+
+    // Artifact flushed on stop: file exists, rendered names + thinking present.
+    const html = readFileSync(outputPath, "utf-8");
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("Ana");
+    expect(html).toContain("Bruno");
+    expect(html).toContain("Preciso marcar presença sem chamar atenção.");
+  });
+
+  it("keeps the partial frame when stopped mid-pulse", async () => {
+    const { gw } = buildGateway();
+    await gw.sendOperatorEvent(snapshot("ana", 0));
+    await gw.sendOperatorEvent(snapshot("bruno", 0));
+    await gw.sendOperatorEvent(visibility("ev_1", 0, "message_sent", { content: "first" }));
+    // Pulse 1 interrupted: only one snapshot and one intent delivered.
+    await gw.sendOperatorEvent(snapshot("ana", 1));
+    await gw.sendOperatorEvent(intent("ana", 1));
+    await gw.onSimulationStopped("sim_rcv");
+
+    const replay = gw.toReplay();
+    expect(replay.pulses).toHaveLength(2);
+    expect(replay.pulses[0]!.committedEvents).toHaveLength(1);
+    expect(replay.pulses[1]!.committedEvents).toHaveLength(0);
+    expect(replay.pulses[1]!.agentStates).toEqual({ ana: state("ana") });
+    expect(replay.pulses[1]!.agentThinking).toHaveProperty("ana");
+  });
+
+  it("creates an empty replay when stopped before any pulse", async () => {
+    const { gw } = buildGateway();
+    await gw.onSimulationStopped("sim_rcv");
+
+    const replay = gw.toReplay();
+    expect(replay.pulses).toEqual([]);
+    expect(replay.channels).toHaveLength(2);
+    expect(replay.agentIds).toEqual(["ana", "bruno"]);
+  });
+
+  it("keeps a frame with only snapshots empty of committed events", async () => {
+    const { gw } = buildGateway();
+    await gw.sendOperatorEvent(snapshot("ana", 2));
+    await gw.sendOperatorEvent(snapshot("bruno", 2));
+    await gw.onSimulationStopped("sim_rcv");
+
+    const frame = gw.toReplay().pulses[0]!;
+    expect(frame.pulseIndex).toBe(2);
+    expect(frame.committedEvents).toEqual([]);
+    expect(frame.result.eventsCommitted).toBe(0);
+    expect(frame.result.agentsCalled).toBe(0);
+  });
+
+  it("falls back to the channel id when metadata has no name for a dynamic channel", async () => {
+    const { gw } = buildGateway();
+    await gw.createChannel("dyn-7f3a", "private_channel", ["ana"]);
+    const replay = gw.toReplay();
+    const dynamic = replay.channels.find((c) => c.id === "dyn-7f3a");
+    expect(dynamic?.name).toBe("dyn-7f3a");
+    expect(dynamic?.type).toBe("private_channel");
+  });
+
+  it("tracks addMember and removeMember on the channel topology", async () => {
+    const { gw } = buildGateway();
+    await gw.addMember("ana-carla", "bruno");
+    await gw.createChannel("dyn-9", "private_channel", ["carla"]);
+    await gw.addMember("dyn-9", "ana");
+    await gw.removeMember("dyn-9", "carla");
+    const replay = gw.toReplay();
+    const privateChannel = replay.channels.find((c) => c.id === "ana-carla")!;
+    expect(privateChannel.memberAgentIds).toEqual(["ana", "bruno"]);
+    const dynamic = replay.channels.find((c) => c.id === "dyn-9")!;
+    expect(dynamic.memberAgentIds).toEqual(["ana"]);
+  });
+
+  it("renders a standalone artifact via generateHtml with names and thinking", async () => {
+    const { gw, outputPath } = buildGateway();
+    await gw.sendOperatorEvent(snapshot("ana", 0));
+    await gw.sendOperatorEvent(snapshot("bruno", 0));
+    await gw.sendOperatorEvent(intent("ana", 0));
+    await gw.sendOperatorEvent(visibility("ev_1", 0, "message_sent", { content: "oi" }));
+    await gw.onSimulationStopped("sim_rcv");
+
+    const replay = gw.toReplay();
+    const html = generateHtml(replay);
+    expect(html).toContain("REPLAY_DATA");
+    expect(html).toContain("Ana");
+    expect(html).toContain("Bruno");
+    expect(html).toContain("Preciso marcar presença sem chamar atenção.");
+    expect(html).toContain("oi");
+
+    const flushed = readFileSync(outputPath, "utf-8");
+    expect(flushed).toBe(html);
+  });
+});

--- a/packages/server/src/delivery/html-snapshot-gateway.ts
+++ b/packages/server/src/delivery/html-snapshot-gateway.ts
@@ -1,0 +1,195 @@
+/**
+ * HtmlSnapshotGateway — stream-fed receiver that renders the HTML snapshot
+ * artifact (US-004 / FR-003).
+ *
+ * Everything the generator needs is derived from delivered events plus
+ * construction-time metadata: agent states come from `agent_state_snapshot`
+ * operator events, thinking from `action_intent`, committed-event rows from
+ * `event_visibility`, channel topology from `createChannel`/`addMember`/
+ * `removeMember` calls, and names/archetypes from the runtime metadata. The
+ * receiver never touches repositories or runtime state; the artifact flushes
+ * on `onSimulationStopped` (spec edge case: receivers flush partial output).
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type {
+  ChannelType,
+  CommittedEvent,
+  EventPayloadValue,
+  OperatorEvent,
+  SpectatorEvent,
+} from "@perfectman/shared";
+import type { GatewayRuntimeMetadata } from "../config/simulation-config.js";
+import type { DeliveryMessage, IDeliveryGateway } from "../simulation/scheduler-contracts.js";
+import { payloadString, payloadStringArray } from "../simulation/payload-readers.js";
+import type { SerializedAgentState } from "../agent/agent-state-serializer.js";
+import type { AgentThinking, PulseFrame, SimulationReplay } from "../html/replay-types.js";
+import { generateHtml } from "../html/snapshot-html-generator.js";
+
+function serializedState(value: EventPayloadValue | undefined): SerializedAgentState | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  // The scheduler emits the output of the shared serializer directly (D-4);
+  // EventPayload is loose, so the deep object needs a structural double cast.
+  return value as unknown as SerializedAgentState;
+}
+
+type ChannelView = {
+  type: ChannelType;
+  memberAgentIds: Set<string>;
+};
+
+export class HtmlSnapshotGateway implements IDeliveryGateway {
+  private readonly frames = new Map<number, PulseFrame>();
+  private readonly channels = new Map<string, ChannelView>();
+
+  constructor(
+    private readonly meta: GatewayRuntimeMetadata,
+    private readonly outputPath: string,
+  ) {}
+
+  sendAgentMessage(_channelId: string, _message: DeliveryMessage): Promise<void> {
+    // Message content and recipients travel in `event_visibility` events;
+    // the generator renders committed events, not delivery messages.
+    return Promise.resolve();
+  }
+
+  createChannel(channelId: string, type: ChannelType, memberAgentIds: string[]): Promise<void> {
+    const existing = this.channels.get(channelId);
+    if (existing) {
+      for (const agentId of memberAgentIds) existing.memberAgentIds.add(agentId);
+    } else {
+      this.channels.set(channelId, { type, memberAgentIds: new Set(memberAgentIds) });
+    }
+    return Promise.resolve();
+  }
+
+  addMember(channelId: string, agentId: string): Promise<void> {
+    this.channels.get(channelId)?.memberAgentIds.add(agentId);
+    return Promise.resolve();
+  }
+
+  removeMember(channelId: string, agentId: string): Promise<void> {
+    this.channels.get(channelId)?.memberAgentIds.delete(agentId);
+    return Promise.resolve();
+  }
+
+  sendSpectatorEvent(_event: SpectatorEvent): Promise<void> {
+    return Promise.resolve();
+  }
+
+  sendOperatorEvent(event: OperatorEvent): Promise<void> {
+    const frame = this.frameFor(event.pulseIndex);
+    frame.operatorEvents.push(event);
+    switch (event.type) {
+      case "agent_state_snapshot": {
+        const state = serializedState(event.data?.["state"]);
+        if (state && event.agentId) frame.agentStates[event.agentId] = state;
+        break;
+      }
+      case "action_intent": {
+        const thinking = this.thinkingFromEvent(event);
+        if (event.agentId) {
+          if (!(event.agentId in frame.agentThinking)) frame.result.agentsCalled += 1;
+          frame.agentThinking[event.agentId] = thinking;
+        }
+        break;
+      }
+      case "event_visibility": {
+        frame.committedEvents.push(this.eventRowFromVisibility(event));
+        frame.result.eventsCommitted += 1;
+        break;
+      }
+      default:
+        break;
+    }
+    return Promise.resolve();
+  }
+
+  /** Flushes the artifact on simulation stop (partial frames included). */
+  async onSimulationStopped(_simulationId: string): Promise<void> {
+    const html = generateHtml(this.toReplay());
+    await mkdir(dirname(this.outputPath), { recursive: true });
+    await writeFile(this.outputPath, html, "utf-8");
+  }
+
+  /** The replay assembled purely from delivered events + metadata. */
+  toReplay(): SimulationReplay {
+    const agentNames: Record<string, string> = {};
+    const agentArchetypes: Record<string, string> = {};
+    for (const [id, agent] of Object.entries(this.meta.agents)) {
+      agentNames[id] = agent.name;
+      agentArchetypes[id] = agent.archetype;
+    }
+    return {
+      simulationId: this.meta.simulationId,
+      simulationName: this.meta.simulationName,
+      agentIds: Object.keys(this.meta.agents),
+      agentNames,
+      agentArchetypes,
+      channels: [...this.channels.entries()].map(([id, channel]) => ({
+        id,
+        name: this.meta.channels[id]?.name ?? id,
+        type: channel.type,
+        memberAgentIds: [...channel.memberAgentIds],
+      })),
+      pulses: [...this.frames.values()].sort((a, b) => a.pulseIndex - b.pulseIndex),
+    };
+  }
+
+  private frameFor(pulseIndex: number): PulseFrame {
+    let frame = this.frames.get(pulseIndex);
+    if (!frame) {
+      frame = {
+        pulseIndex,
+        // D-9: PulseResult is not delivered; honest stream-derived approximation.
+        result: { pulseIndex, eventsCommitted: 0, agentsCalled: 0 },
+        committedEvents: [],
+        agentStates: {},
+        agentThinking: {},
+        operatorEvents: [],
+      };
+      this.frames.set(pulseIndex, frame);
+    }
+    return frame;
+  }
+
+  private thinkingFromEvent(event: OperatorEvent): AgentThinking {
+    const data = event.data ?? {};
+    const visibleContent = data["visibleContent"];
+    return {
+      agentId: event.agentId ?? "",
+      intentType: payloadString(data, "intentType"),
+      visibleContent: typeof visibleContent === "string" ? visibleContent : undefined,
+      privateMotiveSummary: payloadString(data, "privateMotiveSummary"),
+      emotionDrivers: payloadStringArray(data, "emotionDrivers"),
+      motivationDrivers: payloadStringArray(data, "motivationDrivers"),
+    };
+  }
+
+  private eventRowFromVisibility(event: OperatorEvent): CommittedEvent {
+    const data = event.data ?? {};
+    const content = payloadString(data, "content");
+    const channelName = payloadString(data, "channelName");
+    return {
+      id: payloadString(data, "eventId"),
+      simulationId: event.simulationId,
+      channelId: payloadString(data, "channelId"),
+      actorId: payloadString(data, "actorId", event.agentId ?? ""),
+      type: payloadString(data, "eventType") as CommittedEvent["type"],
+      payload: {
+        ...(content ? { content } : {}),
+        ...(channelName ? { channelName } : {}),
+      },
+      sourceEventIds: [],
+      emotionalSalience: "low",
+      visibility: {
+        visibleToAgents: payloadStringArray(data, "visibleToAgents"),
+        visibleToSpectators: true,
+        visibleToOperators: true,
+        visibilityReason: "public",
+      },
+      createdAt: event.createdAt,
+      pulseIndex: event.pulseIndex,
+    };
+  }
+}

--- a/packages/server/src/delivery/index.ts
+++ b/packages/server/src/delivery/index.ts
@@ -1,4 +1,5 @@
 export { MockDeliveryGateway } from "./mock-delivery-gateway.js";
 export { StdoutDeliveryGateway } from "./stdout-delivery-gateway.js";
 export { CompositeDeliveryGateway } from "./composite-delivery-gateway.js";
+export { HtmlSnapshotGateway } from "./html-snapshot-gateway.js";
 export { DiscordDeliveryGateway } from "../discord/index.js";

--- a/packages/server/src/delivery/mock-delivery-gateway.ts
+++ b/packages/server/src/delivery/mock-delivery-gateway.ts
@@ -3,9 +3,12 @@ import type {
   OperatorEvent,
   SpectatorEvent,
 } from "@perfectman/shared";
+import type { GatewayRuntimeMetadata } from "../config/simulation-config.js";
 import type { DeliveryMessage, IDeliveryGateway } from "../simulation/scheduler-contracts.js";
 
 export class MockDeliveryGateway implements IDeliveryGateway {
+  constructor(public readonly runtimeMetadata?: GatewayRuntimeMetadata) {}
+
   readonly agentMessages: Array<{ channelId: string; message: DeliveryMessage }> = [];
   readonly createdChannels: Array<{ channelId: string; type: ChannelType; memberAgentIds: string[] }> = [];
   readonly addedMembers: Array<{ channelId: string; agentId: string }> = [];

--- a/packages/server/src/delivery/stdout-delivery-gateway.ts
+++ b/packages/server/src/delivery/stdout-delivery-gateway.ts
@@ -3,10 +3,14 @@ import type {
   OperatorEvent,
   SpectatorEvent,
 } from "@perfectman/shared";
+import type { GatewayRuntimeMetadata } from "../config/simulation-config.js";
 import type { DeliveryMessage, IDeliveryGateway } from "../simulation/scheduler-contracts.js";
 
 export class StdoutDeliveryGateway implements IDeliveryGateway {
-  constructor(private readonly debug = false) {}
+  constructor(
+    private readonly debug = false,
+    private readonly runtimeMetadata?: GatewayRuntimeMetadata,
+  ) {}
 
   sendAgentMessage(channelId: string, message: DeliveryMessage): Promise<void> {
     this.write("agent_message", { channelId, message });

--- a/packages/server/src/html/replay-types.ts
+++ b/packages/server/src/html/replay-types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared replay contract for the HTML snapshot artifact: produced by the
+ * e2e SimulationRecorder (parity reference) and the production
+ * HtmlSnapshotGateway receiver (stream-fed), consumed by the generator.
+ * Maps are replaced with plain objects for JSON serializability.
+ */
+import type { CommittedEvent, OperatorEvent } from "@perfectman/shared";
+import type { SerializedAgentState } from "../agent/agent-state-serializer.js";
+import type { PulseResult } from "../simulation/pulse-scheduler.js";
+
+export type AgentThinking = {
+  agentId: string;
+  intentType: string;
+  visibleContent: string | undefined;
+  privateMotiveSummary: string;
+  emotionDrivers: string[];
+  motivationDrivers: string[];
+};
+
+export type PulseFrame = {
+  pulseIndex: number;
+  result: PulseResult;
+  committedEvents: CommittedEvent[];
+  agentStates: Record<string, SerializedAgentState>;
+  /** Thinking data from the LLM intent — only set if agent had an LLM call this pulse */
+  agentThinking: Record<string, AgentThinking>;
+  operatorEvents: OperatorEvent[];
+};
+
+export type SimulationReplay = {
+  simulationId: string;
+  simulationName: string;
+  agentIds: string[];
+  agentNames: Record<string, string>;
+  agentArchetypes: Record<string, string>;
+  channels: Array<{
+    id: string;
+    name: string;
+    type: string;
+    memberAgentIds: string[];
+  }>;
+  pulses: PulseFrame[];
+};

--- a/packages/server/src/html/snapshot-html-generator.ts
+++ b/packages/server/src/html/snapshot-html-generator.ts
@@ -5,7 +5,7 @@
  * Each pulse section shows messages → inline thinking → dreaming asides for silent agents.
  * No external dependencies — system fonts only.
  */
-import type { SimulationReplay } from "./simulation-recorder.js";
+import type { SimulationReplay } from "./replay-types.js";
 
 export function generateHtml(replay: SimulationReplay): string {
   const dataJson = JSON.stringify(replay, null, 0);

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PulseScheduler } from "../pulse-scheduler.js";
+import { InMemoryEventRepository, InMemoryAgentStateRepository, InMemoryChannelRepository } from "../in-memory-stores.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { IntentResolver } from "../intent-resolver.js";
+import { EngineSnapshotProjection } from "../projections/engine-snapshot-projection.js";
+import { DeliveryProjection } from "../projections/delivery-projection.js";
+import { SpectatorProjection } from "../projections/spectator-projection.js";
+import { OperatorProjection } from "../projections/operator-projection.js";
+import { EngineEventBuilder } from "../engine-event-builder.js";
+import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import { StdoutDeliveryGateway } from "../../delivery/stdout-delivery-gateway.js";
+import { serializeAgentState } from "../../agent/agent-state-serializer.js";
+import type { AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
+import type {
+  Simulation,
+  SimulationSettings,
+  AgentState,
+  PersonaConfig,
+  ActionIntent,
+  EngineStepResult,
+  EngineSnapshot,
+  OperatorEvent,
+  CommittedEvent,
+  AgentRuntimeInput,
+} from "@perfectman/shared";
+import { createId } from "@perfectman/shared";
+
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+const SIM: Simulation = {
+  id: "sim_obs",
+  name: "observability",
+  status: "running",
+  agentIds: ["agent_1", "agent_2"],
+  channelIds: ["ch_public"],
+  settings: SETTINGS,
+  seed: 7,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+function makeAgentState(agentId: string): AgentState {
+  return {
+    agentId,
+    simulationId: "sim_obs",
+    personaId: `persona_${agentId}`,
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map([["agent_2", { warmth: 0.2, intimacy: 0.1, powerDifference: 0, trust: 0.5, rivalry: 0, history: [] }]]),
+    memories: [{ id: "mem_1", type: "observation", summary: "agent_2 seems guarded", emotionalTone: "curious", confidence: 0.6, createdAt: 1, sourceEventId: "ev_0", subjects: ["agent_2"] }],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function makePersona(agentId: string): PersonaConfig {
+  return {
+    id: `persona_${agentId}`,
+    name: `Agent ${agentId}`,
+    archetype: "test",
+    writingStyle: "casual",
+    styleExamples: [],
+    baselineValence: 0,
+    baselineArousal: 0.5,
+    baselineStability: 0.8,
+    baselineEnergy: 0.6,
+    emotionalReactivity: 0.5,
+    moodInertia: 0.5,
+    maxMoodRotation: 0.5,
+    energyRegen: 0.05,
+    exclusionSensitivity: 0.5,
+    praiseSensitivity: 0.5,
+    conflictSensitivity: 0.5,
+    boredomSensitivity: 0.5,
+    intimacySensitivity: 0.5,
+    socialSensitivities: {},
+  };
+}
+
+const ZERO_ACTION = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+function makeCannedStep(agentId: string): EngineStepResult {
+  return {
+    visibleEvents: [],
+    newEvents: [],
+    attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
+    perceptionPacket: {
+      agentId, triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
+      relevantChannels: [], relevantMemories: [],
+      translatedEmotionalState: { summary: "", emotions: [] },
+      availableActions: [],
+    },
+    interpretations: [],
+    emotionDelta: { coreMoodDelta: {}, socialEmotionDeltas: {}, relationalDeltas: new Map(), ruminationApplied: false },
+    updatedAgentState: makeAgentState(agentId),
+    motivations: [],
+    pressures: [],
+    inhibitions: [],
+    actionEmotions: ZERO_ACTION,
+    decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
+    availableActions: [],
+    initiativeCandidates: [],
+    memoryProposals: [],
+    noOpRecord: null,
+    operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 0, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
+  };
+}
+
+function makeNoOpIntent(agentId: string): ActionIntent {
+  return {
+    id: createId(),
+    actorId: agentId,
+    intentType: "no_op",
+    personTargets: [],
+    privateMotiveSummary: "nothing worth doing",
+    emotionDrivers: [],
+    motivationDrivers: [],
+    memoryWrites: [],
+  };
+}
+
+function makeSendMessageIntent(agentId: string, content: string): ActionIntent {
+  return {
+    id: createId(),
+    actorId: agentId,
+    intentType: "send_message",
+    personTargets: [],
+    visibleContent: content,
+    privateMotiveSummary: "I have something to say",
+    emotionDrivers: ["curiosity"],
+    motivationDrivers: ["connection"],
+    memoryWrites: [],
+  };
+}
+
+function makeCreateChannelIntent(agentId: string): ActionIntent {
+  return {
+    id: createId(),
+    actorId: agentId,
+    intentType: "create_channel",
+    personTargets: ["agent_2"],
+    channelName: "secret-lair",
+    channelType: "private_channel",
+    privateMotiveSummary: "I need a private space",
+    emotionDrivers: ["caution"],
+    motivationDrivers: ["privacy"],
+    invitedAgentIds: ["agent_2"],
+    memoryWrites: [],
+  };
+}
+
+const SEND_MESSAGE_SLOT = { intentType: "send_message" as const, channelTargets: [], personTargets: [], blocked: false };
+const CREATE_CHANNEL_SLOT = { intentType: "create_channel" as const, channelTargets: [], personTargets: [], blocked: false };
+
+/** Canned step driving agent_1 through the LLM path; agent_2 stays no-LLM. */
+function llmStep(extra: Partial<EngineStepResult> = {}): (snap: EngineSnapshot) => EngineStepResult {
+  return (snap) => {
+    const base = makeCannedStep(snap.agentState.agentId);
+    if (snap.agentState.agentId !== "agent_1") return base;
+    return {
+      ...base,
+      decision: { outcome: "act", needsLLM: true, initiativeProceed: false },
+      ...extra,
+    };
+  };
+}
+
+function runtimeWith(output: (agentId: string) => ActionIntent, fallbackApplied = false): AgentRuntime {
+  return {
+    generateIntent: vi.fn().mockImplementation((input: AgentRuntimeInput) =>
+      Promise.resolve({
+        intent: output(input.agentId),
+        llmUsage: null,
+        latencyMs: 10,
+        fallbackApplied,
+        operatorEvents: [],
+      }),
+    ),
+  };
+}
+
+interface SchedulerHarness {
+  scheduler: PulseScheduler;
+  gateway: MockDeliveryGateway;
+  eventRepo: InMemoryEventRepository;
+  agentStateRepo: InMemoryAgentStateRepository;
+}
+
+describe("PulseScheduler observability events", () => {
+  let stdoutSpy: { mockRestore(): void } | null = null;
+
+  async function buildScheduler(options: {
+    step?: (snap: EngineSnapshot) => EngineStepResult;
+    runtime?: AgentRuntime;
+    gateway?: MockDeliveryGateway | StdoutDeliveryGateway;
+    intentResolver?: IntentResolver;
+  } = {}): Promise<SchedulerHarness> {
+    const eventRepo = new InMemoryEventRepository();
+    const agentStateRepo = new InMemoryAgentStateRepository();
+    const channelRepo = new InMemoryChannelRepository();
+    const channelRegistry = new ChannelRegistry(channelRepo);
+    const gateway = options.gateway ?? new MockDeliveryGateway();
+
+    await channelRepo.create({
+      id: "ch_public",
+      simulationId: "sim_obs",
+      type: "public_channel",
+      name: "general",
+      createdBy: "system",
+      memberAgentIds: ["agent_1", "agent_2"],
+      spectatorVisible: true,
+      operatorVisible: true,
+      createdForMotives: [],
+      status: "active",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await channelRepo.addMembership({ channelId: "ch_public", agentId: "agent_1", joinedAt: Date.now() });
+    await channelRepo.addMembership({ channelId: "ch_public", agentId: "agent_2", joinedAt: Date.now() });
+    await agentStateRepo.upsert(makeAgentState("agent_1"));
+    await agentStateRepo.upsert(makeAgentState("agent_2"));
+
+    const rateLimitGate = new RateLimitGate(SETTINGS);
+    const agentRuntime: AgentRuntime = options.runtime ?? runtimeWith(() => makeNoOpIntent("agent_1"));
+    const llmBudget: LLMBudget = { getPriority: vi.fn().mockReturnValue("normal") };
+
+    const scheduler = new PulseScheduler({
+      simulation: SIM,
+      agents: ["agent_1", "agent_2"].map((id) => ({ id, state: makeAgentState(id), persona: makePersona(id) })),
+      defaultPublicChannelId: "ch_public",
+      eventRepo,
+      agentStateRepo,
+      channelRegistry,
+      rateLimitGate,
+      intentResolver: options.intentResolver ?? new IntentResolver(rateLimitGate, channelRegistry),
+      engineSnapshotProjection: new EngineSnapshotProjection(),
+      deliveryProjection: new DeliveryProjection(gateway),
+      spectatorProjection: new SpectatorProjection(gateway),
+      operatorProjection: new OperatorProjection(gateway),
+      engineEventBuilder: new EngineEventBuilder(),
+      agentRuntime,
+      llmBudget,
+      pulseIntervalMs: SETTINGS.pulseIntervalMs,
+      ...(options.step ? { stepResolver: options.step } : {}),
+    });
+
+    return {
+      scheduler,
+      // A non-mock gateway (stdout NDJSON test) asserts via captured writes,
+      // never through this harness field — keep the type stable for callers.
+      gateway: gateway instanceof MockDeliveryGateway ? gateway : new MockDeliveryGateway(),
+      eventRepo,
+      agentStateRepo,
+    };
+  }
+
+  afterEach(() => {
+    if (stdoutSpy) {
+      stdoutSpy.mockRestore();
+      stdoutSpy = null;
+    }
+  });
+
+  function snapshots(events: OperatorEvent[]): OperatorEvent[] {
+    return events.filter((e) => e.type === "agent_state_snapshot");
+  }
+
+  function intents(events: OperatorEvent[]): OperatorEvent[] {
+    return events.filter((e) => e.type === "action_intent");
+  }
+
+  function visibility(events: OperatorEvent[]): OperatorEvent[] {
+    return events.filter((e) => e.type === "event_visibility");
+  }
+
+  it("emits exactly one state snapshot per agent per pulse with serialized state parity", async () => {
+    const state1 = makeAgentState("agent_1");
+    const state2 = makeAgentState("agent_2");
+    const h = await buildScheduler({
+      step: (snap) => ({
+        ...makeCannedStep(snap.agentState.agentId),
+        updatedAgentState: snap.agentState.agentId === "agent_1" ? state1 : state2,
+      }),
+    });
+    await h.scheduler.runPulse();
+    await h.scheduler.runPulse();
+
+    const snaps = snapshots(h.gateway.operatorEvents);
+    expect(snaps).toHaveLength(4); // 2 agents × 2 pulses
+    expect(snaps.filter((s) => s.pulseIndex === 0)).toHaveLength(2);
+    expect(snaps.filter((s) => s.pulseIndex === 1)).toHaveLength(2);
+    expect(snaps.filter((s) => s.agentId === "agent_1")).toHaveLength(2);
+    expect(snaps.filter((s) => s.agentId === "agent_2")).toHaveLength(2);
+
+    expect(snaps[0]!.data?.["state"]).toEqual(serializeAgentState(state1));
+    expect(snaps[1]!.data?.["state"]).toEqual(serializeAgentState(state2));
+    expect(snaps[0]!.data?.["state"]).toEqual(
+      serializeAgentState(await h.agentStateRepo.get("sim_obs", "agent_1")),
+    );
+    expect(snaps[0]!.simulationId).toBe("sim_obs");
+    expect(snaps[0]!.pulseIndex).toBe(0);
+  });
+
+  it("still emits exactly one snapshot per agent on the LLM path", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith(() => makeSendMessageIntent("agent_1", "hello from the LLM path")),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    expect(snapshots(h.gateway.operatorEvents)).toHaveLength(2);
+    const intentEvents = intents(h.gateway.operatorEvents);
+    expect(intentEvents).toHaveLength(1);
+    expect(intentEvents[0]!.agentId).toBe("agent_1");
+  });
+
+  it("emits a snapshot but no action_intent when the provider rejects", async () => {
+    const h = await buildScheduler({
+      runtime: { generateIntent: vi.fn().mockRejectedValue(new Error("provider timeout")) },
+      step: llmStep(),
+    });
+    await h.scheduler.runPulse();
+
+    expect(snapshots(h.gateway.operatorEvents)).toHaveLength(2);
+    expect(intents(h.gateway.operatorEvents)).toHaveLength(0);
+    expect(h.gateway.operatorEvents.some((e) => e.type === "llm_failure")).toBe(true);
+  });
+
+  it("emits a snapshot but no action_intent when the intent resolver fails", async () => {
+    const rateLimitGate = new RateLimitGate(SETTINGS);
+    const channelRegistryForResolver = new ChannelRegistry(new InMemoryChannelRepository());
+    const broken = new IntentResolver(rateLimitGate, channelRegistryForResolver);
+    vi.spyOn(broken, "resolve").mockRejectedValueOnce(new Error("resolver exploded"));
+
+    const h = await buildScheduler({
+      runtime: runtimeWith(() => makeSendMessageIntent("agent_1", "doomed")),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+      intentResolver: broken,
+    });
+    await h.scheduler.runPulse();
+
+    expect(snapshots(h.gateway.operatorEvents)).toHaveLength(2);
+    expect(intents(h.gateway.operatorEvents)).toHaveLength(0);
+    expect(h.gateway.operatorEvents.some((e) => e.type === "scheduler_error" && e.detail === "Intent resolver failed")).toBe(true);
+  });
+
+  it("carries the five intent fields verbatim in action_intent", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith((agentId) => ({
+        ...makeSendMessageIntent(agentId, "the visible content"),
+        visibleContent: "the visible content",
+        emotionDrivers: ["curiosity", "warmth"],
+        motivationDrivers: ["connection", "status"],
+      })),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    const intentEvents = intents(h.gateway.operatorEvents);
+    expect(intentEvents).toHaveLength(1);
+    const ev = intentEvents[0]!;
+    expect(ev.agentId).toBe("agent_1");
+    expect(ev.pulseIndex).toBe(0);
+    expect(ev.data?.["intentType"]).toBe("send_message");
+    expect(ev.data?.["visibleContent"]).toBe("the visible content");
+    expect(ev.data?.["privateMotiveSummary"]).toBe("I have something to say");
+    expect(ev.data?.["emotionDrivers"]).toEqual(["curiosity", "warmth"]);
+    expect(ev.data?.["motivationDrivers"]).toEqual(["connection", "status"]);
+  });
+
+  it("emits a truthful no_op action_intent when a fallback intent was produced", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith((agentId) => makeNoOpIntent(agentId), true),
+      step: llmStep(),
+    });
+    await h.scheduler.runPulse();
+
+    const intentEvents = intents(h.gateway.operatorEvents);
+    expect(intentEvents).toHaveLength(1);
+    expect(intentEvents[0]!.data?.["intentType"]).toBe("no_op");
+    expect(intentEvents[0]!.data?.["privateMotiveSummary"]).toBe("nothing worth doing");
+    expect(intentEvents[0]!.data?.["emotionDrivers"]).toEqual([]);
+    expect(intentEvents[0]!.data?.["visibleContent"]).toBeUndefined();
+  });
+
+  it("emits no action_intent for an uncalled agent in the same pulse", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith(() => makeSendMessageIntent("agent_1", "only I speak")),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    const intentEvents = intents(h.gateway.operatorEvents);
+    expect(intentEvents).toHaveLength(1);
+    expect(intentEvents[0]!.agentId).toBe("agent_1");
+    expect(snapshots(h.gateway.operatorEvents)).toHaveLength(2);
+  });
+
+  it("defaults missing emotionDrivers and motivationDrivers to empty arrays", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith((agentId) => {
+        const bare = makeSendMessageIntent(agentId, "bare");
+        return {
+          id: bare.id,
+          actorId: bare.actorId,
+          intentType: "send_message" as const,
+          personTargets: bare.personTargets,
+          visibleContent: bare.visibleContent,
+          privateMotiveSummary: bare.privateMotiveSummary,
+          memoryWrites: bare.memoryWrites,
+        } as ActionIntent;
+      }),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    const intentEvents = intents(h.gateway.operatorEvents);
+    expect(intentEvents[0]!.data?.["emotionDrivers"]).toEqual([]);
+    expect(intentEvents[0]!.data?.["motivationDrivers"]).toEqual([]);
+  });
+
+  it("emits one event_visibility per committed engine event (no_op_recorded)", async () => {
+    const h = await buildScheduler({
+      step: (snap) => ({
+        ...makeCannedStep(snap.agentState.agentId),
+        noOpRecord: { agentId: snap.agentState.agentId, pulseIndex: 0, privateMotiveSummary: "quiet", reason: "nothing due" },
+      }),
+    });
+    await h.scheduler.runPulse();
+
+    const visEvents = visibility(h.gateway.operatorEvents);
+    expect(visEvents).toHaveLength(2); // one per agent's no_op_recorded
+    const first = visEvents[0]!;
+    expect(first.data?.["eventType"]).toBe("no_op_recorded");
+    expect(first.data?.["actorId"]).toBe(first.agentId);
+    expect(first.data?.["visibleToAgents"]).toEqual([]);
+    expect(first.data?.["content"]).toBeUndefined();
+    expect(first.data?.["channelName"]).toBeUndefined();
+    expect(first.pulseIndex).toBe(0);
+  });
+
+  it("carries content in event_visibility for committed message_sent events", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith(() => makeSendMessageIntent("agent_1", "the committed content")),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    const committed = await h.eventRepo.getAfter("sim_obs");
+    const messageEvent = committed.find((e): e is CommittedEvent => e.type === "message_sent");
+    expect(messageEvent).toBeDefined();
+
+    const visEvents = visibility(h.gateway.operatorEvents);
+    const msgVis = visEvents.find((e) => e.data?.["eventType"] === "message_sent");
+    expect(msgVis).toBeDefined();
+    expect(msgVis!.data?.["eventId"]).toBe(messageEvent!.id);
+    expect(msgVis!.data?.["content"]).toBe("the committed content");
+    expect(msgVis!.data?.["channelId"]).toBe("ch_public");
+    expect(msgVis!.data?.["visibleToAgents"]).toEqual(messageEvent!.visibility.visibleToAgents);
+  });
+
+  it("carries channelName and members for committed channel_created events", async () => {
+    const h = await buildScheduler({
+      runtime: runtimeWith((agentId) => makeCreateChannelIntent(agentId)),
+      step: llmStep({ availableActions: [CREATE_CHANNEL_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+
+    const committed = await h.eventRepo.getAfter("sim_obs");
+    const created = committed.find((e): e is CommittedEvent => e.type === "channel_created");
+    expect(created).toBeDefined();
+    const invited = committed.find((e): e is CommittedEvent => e.type === "agent_invited");
+    expect(invited).toBeDefined();
+
+    const visEvents = visibility(h.gateway.operatorEvents);
+    expect(visEvents).toHaveLength(2); // channel_created + agent_invited
+    const createdVis = visEvents.find((e) => e.data?.["eventType"] === "channel_created");
+    expect(createdVis).toBeDefined();
+    expect(createdVis!.data?.["eventId"]).toBe(created!.id);
+    expect(createdVis!.data?.["channelName"]).toBe("secret-lair");
+    expect(createdVis!.data?.["visibleToAgents"]).toEqual(created!.visibility.visibleToAgents);
+    const invitedVis = visEvents.find((e) => e.data?.["eventType"] === "agent_invited");
+    expect(invitedVis).toBeDefined();
+    expect(invitedVis!.data?.["channelName"]).toBeUndefined();
+    expect(invitedVis!.data?.["visibleToAgents"]).toEqual(invited!.visibility.visibleToAgents);
+  });
+
+  it("writes one agent_state_snapshot NDJSON line per agent per pulse on a debug stdout gateway", async () => {
+    const writes: string[] = [];
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    const h = await buildScheduler({
+      gateway: new StdoutDeliveryGateway(true),
+      step: (snap) => makeCannedStep(snap.agentState.agentId),
+    });
+    await h.scheduler.runPulse();
+    await h.scheduler.runPulse();
+
+    const snapshotLines = writes
+      .map((line) => JSON.parse(line) as { type: string; payload: { type?: string } })
+      .filter((parsed) => parsed.type === "operator_event" && parsed.payload.type === "agent_state_snapshot");
+    expect(snapshotLines).toHaveLength(4); // 2 pulses × 2 agents, one snapshot per agent per pulse
+    for (const line of snapshotLines) {
+      expect(line.payload.type).toBe("agent_state_snapshot");
+    }
+  });
+});

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -23,6 +23,9 @@ import type { DeliveryProjection } from "./projections/delivery-projection.js";
 import type { SpectatorProjection } from "./projections/spectator-projection.js";
 import type { OperatorProjection } from "./projections/operator-projection.js";
 import type { EngineEventBuilder } from "./engine-event-builder.js";
+import { payloadString } from "./payload-readers.js";
+import { serializeAgentState } from "../agent/agent-state-serializer.js";
+import type { ActionIntentOperatorData, EventVisibilityData } from "@perfectman/shared";
 import { buildAgentRuntimeInput } from "./runtime-input-builder.js";
 import { buildWorldSignals } from "./world-signals-builder.js";
 import type { AgentRuntimeContext, AgentRuntimeOutput } from "../agent/agent-runtime.types.js";
@@ -254,7 +257,7 @@ export class PulseScheduler {
         });
 
         if (!runtimeOutput) {
-          await this.safeUpsertAgentState(stepResult.updatedAgentState);
+          await this.persistAndSnapshot(stepResult.updatedAgentState);
           continue;
         }
 
@@ -274,9 +277,27 @@ export class PulseScheduler {
         });
 
         if (!resolved) {
-          await this.safeUpsertAgentState(stepResult.updatedAgentState);
+          await this.persistAndSnapshot(stepResult.updatedAgentState);
           continue;
         }
+
+        const intent = runtimeOutput.intent;
+        const intentData: ActionIntentOperatorData = {
+          intentType: intent.intentType,
+          ...(intent.visibleContent !== undefined ? { visibleContent: intent.visibleContent } : {}),
+          privateMotiveSummary: intent.privateMotiveSummary,
+          emotionDrivers: intent.emotionDrivers ?? [],
+          motivationDrivers: intent.motivationDrivers ?? [],
+        };
+        await this.emitOperatorEvent({
+          type: "action_intent",
+          simulationId: sim.id,
+          agentId: agent.id,
+          pulseIndex: this.pulseIndex,
+          detail: `Action intent: ${intent.intentType}`,
+          data: intentData,
+          createdAt: Date.now(),
+        });
 
         if (resolved.committedEvents.length > 0) {
           eventsCommitted += await this.appendAndProject(resolved.committedEvents, channels, membership);
@@ -287,7 +308,7 @@ export class PulseScheduler {
         }
       }
 
-      await this.safeUpsertAgentState(stepResult.updatedAgentState);
+      await this.persistAndSnapshot(stepResult.updatedAgentState);
     }
 
     // Every 10 pulses: compute stagnation metrics
@@ -338,9 +359,33 @@ export class PulseScheduler {
       this.lastCommittedEventId = ev.id;
       this.updateCurrentChannelAnchors(ev);
       await this.projectCommittedEvent(ev, channels, membership);
+      await this.emitEventVisibility(ev);
     }
 
     return committed.length;
+  }
+
+  private async emitEventVisibility(event: CommittedEvent): Promise<void> {
+    const content = payloadString(event.payload, "content");
+    const channelName = payloadString(event.payload, "channelName");
+    const data: EventVisibilityData = {
+      eventId: event.id,
+      eventType: event.type,
+      actorId: event.actorId,
+      channelId: event.channelId,
+      visibleToAgents: event.visibility.visibleToAgents,
+      ...(content ? { content } : {}),
+      ...(channelName ? { channelName } : {}),
+    };
+    await this.emitOperatorEvent({
+      type: "event_visibility",
+      simulationId: event.simulationId,
+      agentId: event.actorId,
+      pulseIndex: event.pulseIndex,
+      detail: `Event visibility: ${event.type}`,
+      data,
+      createdAt: Date.now(),
+    });
   }
 
   private async projectCommittedEvent(
@@ -366,12 +411,21 @@ export class PulseScheduler {
     }
   }
 
-  private async safeUpsertAgentState(agentState: AgentState): Promise<void> {
+  private async persistAndSnapshot(agentState: AgentState): Promise<void> {
     try {
       await this.config.agentStateRepo.upsert(agentState);
     } catch (err) {
       await this.emitOperatorEvent(this.schedulerError("Failed to persist agent state", err, agentState.agentId));
     }
+    await this.emitOperatorEvent({
+      type: "agent_state_snapshot",
+      simulationId: this.config.simulation.id,
+      agentId: agentState.agentId,
+      pulseIndex: this.pulseIndex,
+      detail: "Agent state snapshot",
+      data: { state: serializeAgentState(agentState) },
+      createdAt: Date.now(),
+    });
   }
 
   private async emitOperatorEvent(event: OperatorEvent): Promise<void> {

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -1,4 +1,5 @@
-import type { EventPayload } from "../event/event.types.js";
+import type { EventPayload, EventType } from "../event/event.types.js";
+import type { IntentType } from "../intent/intent.types.js";
 
 export type OperatorEventType =
   | "llm_failure"
@@ -9,7 +10,9 @@ export type OperatorEventType =
   | "stagnation_warning"
   | "scheduler_error"
   | "pulse_metrics"
-  | "agent_state_snapshot";
+  | "agent_state_snapshot"
+  | "action_intent"
+  | "event_visibility";
 
 export type OperatorEvent = {
   type: OperatorEventType;
@@ -59,4 +62,26 @@ export type OperatorMetrics = {
   llmCallsMade: number;
   budgetUsedPercent: number;
   stagnation?: StagnationMetrics;
+};
+
+/** `action_intent` payload — the LLM thinking payload for one agent in one
+ *  pulse, emitted post-resolution (truthful, including fallback `no_op`). */
+export type ActionIntentOperatorData = {
+  intentType: IntentType;
+  visibleContent?: string;
+  privateMotiveSummary: string;
+  emotionDrivers: string[];
+  motivationDrivers: string[];
+};
+
+/** `event_visibility` payload — per-committed-event visibility/recipient
+ *  data, the perspective-filter signal for receivers. */
+export type EventVisibilityData = {
+  eventId: string;
+  eventType: EventType;
+  actorId: string;
+  channelId: string;
+  visibleToAgents: string[];
+  content?: string;
+  channelName?: string;
 };


### PR DESCRIPTION
## What

Per-pulse observability for the delivery gateway stream — three additive operator events, construction-time runtime metadata, and a stream-fed HTML artifact receiver. **Stacked on #90** (this branch's `simulation-config.ts` carries the provider-SDK commit; retarget to `main` after #90 merges).

- **Per-pulse events** (`packages/shared/src/operator/operator.types.ts`, `packages/server/src/simulation/pulse-scheduler.ts`):
  - `agent_state_snapshot` — once per agent per pulse, full serialized state. Parity with the e2e recorder is by construction: one shared `serializeAgentState` (`packages/server/src/agent/agent-state-serializer.ts`), both producers import it.
  - `action_intent` — additive, emitted post-resolve with the five intent fields verbatim from the intent that entered resolution. `no_op` fallbacks are truthful; provider/resolver failures emit nothing rather than fabricate.
  - `event_visibility` — once per committed event, carrying `visibleToAgents` + content/channel name, so stream consumers can reproduce the per-agent perspective filter the artifact has today.
- **Runtime metadata** (`simulation-config.ts`, mock/stdout gateways): `GatewayFactory` gains a metadata parameter — agent names/archetypes and channel names built in `buildConfiguredSimulation`. Optional constructor params keep stdout/mock behavior identical (FR-005).
- **`HtmlSnapshotGateway`** (`packages/server/src/delivery/html-snapshot-gateway.ts`): new additive `html-snapshot` delivery config variant (`outputPath`). It rebuilds the artifact purely from delivered events + metadata and flushes on `simulation_stopped` (stop-mid-pulse keeps partial frames). The generator relocates verbatim from `__e2e__/` to `src/html/` sharing replay types with the recorder.
- **No interface change.** `IDeliveryGateway`, provider/SDK/transport, and persistence untouched — same stream shape for mock | ollama | openai-compatible (FR-006).
- Docs: `docs/observability-stream.md` (SC-005 volume + receiver memory bounds), 7 ADRs in `docs/adr/` (D-1, D-3–D-7, D-9).

## Validation

- `pnpm test:all` PASS — 102 files / 1087 tests; audit gate 981 its, 0 violations
- `pnpm -r typecheck` PASS; server vitest 551/551
- Parity e2e (`html-receiver-parity.e2e.test.ts`) PASS twice (seed 42): normalized event summaries, byte-equal agent states, intent-derived thinking with the stale-recorder-thinking exclusion asserted live
- Real CLI smoke: SIGINT → artifact written; NDJSON exactly 30 snapshots (2 agents × 15 pulses, one per agent per pulse), 10 intents (2 truthful `no_op`), 14 visibility, 1 stopped

Closes #91.