### PR TITLE
fix(shared): drop dead operator event types; guard producers

### DIFF
--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-26T14:57:13.972Z",
+  "generatedAt": "2026-08-26T15:03:10.415Z",
   "totals": {
     "files": 109,
-    "its": 1022
+    "its": 1025
   },
   "byPackage": {
     "engine": {
@@ -19,7 +19,7 @@
     },
     "server": {
       "files": 62,
-      "its": 538,
+      "its": 541,
       "flags": [
         "console(1)",
         "async-pause(1)",
@@ -1892,7 +1892,7 @@
       "file": "packages/server/src/simulation/__tests__/operator-event-producers.test.ts",
       "pkg": "server",
       "layer": "integration",
-      "its": 1,
+      "its": 4,
       "itsEach": 1,
       "forcedCasts": 0,
       "tsBypasses": 0,

--- a/docs/test-inventory.json
+++ b/docs/test-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-26T14:52:29.128Z",
+  "generatedAt": "2026-08-26T14:57:13.972Z",
   "totals": {
-    "files": 108,
-    "its": 1021
+    "files": 109,
+    "its": 1022
   },
   "byPackage": {
     "engine": {
@@ -18,8 +18,8 @@
       ]
     },
     "server": {
-      "files": 61,
-      "its": 537,
+      "files": 62,
+      "its": 538,
       "flags": [
         "console(1)",
         "async-pause(1)",
@@ -1872,6 +1872,28 @@
       "layer": "integration",
       "its": 18,
       "itsEach": 0,
+      "forcedCasts": 0,
+      "tsBypasses": 0,
+      "eslintDisables": 0,
+      "onlys": 0,
+      "skips": 0,
+      "consoleLogs": 0,
+      "truthy": 0,
+      "defined": 0,
+      "deadIdTruthy": 0,
+      "nonNull": 0,
+      "spies": 0,
+      "asyncPauses": 0,
+      "weakTerminals": [],
+      "flags": [],
+      "violations": []
+    },
+    {
+      "file": "packages/server/src/simulation/__tests__/operator-event-producers.test.ts",
+      "pkg": "server",
+      "layer": "integration",
+      "its": 1,
+      "itsEach": 1,
       "forcedCasts": 0,
       "tsBypasses": 0,
       "eslintDisables": 0,

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-26T14:57:13.964Z — audited 109 files, 1022 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-26T15:03:10.406Z — audited 109 files, 1025 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -10,10 +10,10 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 |---|---|---|---|
 | engine | 22 | 259 | —
 | eval | 17 | 140 | async-pause(1)
-| server | 62 | 538 | console(1), async-pause(1), async-pause(1), async-pause(2)
+| server | 62 | 541 | console(1), async-pause(1), async-pause(1), async-pause(2)
 | shared | 8 | 85 | —
 
-**Total: 109 files, 1022 it/test blocks; 5 files flagged.**
+**Total: 109 files, 1025 it/test blocks; 5 files flagged.**
 
 ## Per-file inventory
 
@@ -103,7 +103,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts | integration | 10 | 
 | packages/server/src/simulation/__tests__/intent-resolver.test.ts | integration | 8 | 
 | packages/server/src/simulation/__tests__/lifecycle-state-machine.test.ts | integration | 18 | 
-| packages/server/src/simulation/__tests__/operator-event-producers.test.ts | integration | 1 | 
+| packages/server/src/simulation/__tests__/operator-event-producers.test.ts | integration | 4 | 
 | packages/server/src/simulation/__tests__/operator-projection.test.ts | integration | 4 | 
 | packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts | integration | 12 | 
 | packages/server/src/simulation/__tests__/pulse-scheduler-resilience.test.ts | integration | 2 | async-pause(1)

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -1,6 +1,6 @@
 # Test Inventory & Hygiene Snapshot
 
-Generated: 2026-08-26T14:52:29.123Z — audited 108 files, 1021 `it`/`test` blocks (some it.each expand further at runtime).
+Generated: 2026-08-26T14:57:13.964Z — audited 109 files, 1022 `it`/`test` blocks (some it.each expand further at runtime).
 
 Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundary, once per package) / `integration` (through public surface, the honeycomb's big middle) / `e2e` (max 6 suites) / `eval-harness` (vitest tests of the eval tooling — the 123-task *benchmark* is out of scope).
 
@@ -10,10 +10,10 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 |---|---|---|---|
 | engine | 22 | 259 | —
 | eval | 17 | 140 | async-pause(1)
-| server | 61 | 537 | console(1), async-pause(1), async-pause(1), async-pause(2)
+| server | 62 | 538 | console(1), async-pause(1), async-pause(1), async-pause(2)
 | shared | 8 | 85 | —
 
-**Total: 108 files, 1021 it/test blocks; 5 files flagged.**
+**Total: 109 files, 1022 it/test blocks; 5 files flagged.**
 
 ## Per-file inventory
 
@@ -103,6 +103,7 @@ Layer classification follows `docs/testing-strategy.md`: `contract` (zod/boundar
 | packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts | integration | 10 | 
 | packages/server/src/simulation/__tests__/intent-resolver.test.ts | integration | 8 | 
 | packages/server/src/simulation/__tests__/lifecycle-state-machine.test.ts | integration | 18 | 
+| packages/server/src/simulation/__tests__/operator-event-producers.test.ts | integration | 1 | 
 | packages/server/src/simulation/__tests__/operator-projection.test.ts | integration | 4 | 
 | packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts | integration | 12 | 
 | packages/server/src/simulation/__tests__/pulse-scheduler-resilience.test.ts | integration | 2 | async-pause(1)

--- a/packages/server/src/simulation/__tests__/operator-event-producers.test.ts
+++ b/packages/server/src/simulation/__tests__/operator-event-producers.test.ts
@@ -18,8 +18,8 @@ import { OPERATOR_EVENT_TYPES } from "@perfectman/shared";
  * the type system already rejects any `type: "..."` that is not a member of
  * the union.
  *
- * This guard exists because `rate_limit_hit` was declared but never
- * emitted anywhere in packages/server/src — removed with this change. The
+ * This guard exists because `rate_limit_hit` was declared but never emitted
+ * anywhere in packages/server/src — removed with this change. The
  * observability-stream types (`agent_state_snapshot`, `action_intent`,
  * `event_visibility`) landed on main with PR #100 and each has a producer.
  */
@@ -44,6 +44,37 @@ function collectSourceFiles(dir: string): string[] {
   return files;
 }
 
+/**
+ * True if `type` is emitted as an OperatorEvent somewhere in `source`.
+ *
+ * A bare `type: "<name>"` occurrence is not proof of an operator emission:
+ * `intent_blocked`, `intent_delayed` and `llm_failure` are also committed
+ * `SimulationEvent` types, and the same `type:` literal appears in their
+ * constructions (`intent-resolver.ts` builds committed events with
+ * `type: "intent_blocked"`/`"intent_delayed"`; `pulse-scheduler.ts` builds a
+ * committed `llm_failure`). `detail` is a required field of `OperatorEvent`
+ * and never appears on `SimulationEvent`, so an occurrence with a `detail`
+ * property nearby is structurally an operator emission; one without (a
+ * committed-event construction, or a stray mention) must not count.
+ *
+ * Residual limitation: a doc comment that happens to mention both the type
+ * literal and `detail` within the window would count — none exists today.
+ */
+function hasOperatorEmission(source: string, type: string): boolean {
+  const needle = `type: "${type}"`;
+  let from = 0;
+  for (;;) {
+    const at = source.indexOf(needle, from);
+    if (at === -1) return false;
+    // `detail` is the operator-only discriminator; match both the explicit
+    // `detail:` form and the shorthand `detail,` (pulse-scheduler.ts uses
+    // shorthand in its schedulerError helper).
+    const window = source.slice(Math.max(0, at - 200), at + 300);
+    if (/detail\s*[:,]/.test(window)) return true;
+    from = at + needle.length;
+  }
+}
+
 describe("operator event producers", () => {
   const sourceFiles = collectSourceFiles(SERVER_SRC);
 
@@ -58,11 +89,63 @@ describe("operator event producers", () => {
 
   it.each(OPERATOR_EVENT_TYPES)(
     "declared operator type %s has an emission site in packages/server/src",
-    (type) => {
+    (type: (typeof OPERATOR_EVENT_TYPES)[number]) => {
       expect(
-        allSource.includes(`type: "${type}"`),
-        `${type} is declared in shared but never emitted in packages/server/src — remove it from OPERATOR_EVENT_TYPES or wire a producer`,
+        hasOperatorEmission(allSource, type),
+        `${type} is declared in shared but never emitted as an OperatorEvent in packages/server/src — remove it from OPERATOR_EVENT_TYPES or wire a producer`,
       ).toBe(true);
     },
   );
+});
+
+describe("hasOperatorEmission discriminates operator events from committed events", () => {
+  it("rejects a committed-event construction that shares the type name", () => {
+    // `llm_failure` exists in BOTH the SimulationEvent and OperatorEvent
+    // unions; a plain substring match for `type: "llm_failure"` would pass
+    // on this committed-event shape (SimulationEvent has no `detail` field)
+    // even though no OperatorEvent is emitted. This is the false-positive
+    // class the guard must reject.
+    const committedEventShape = `
+      const event: SimulationEvent = {
+        simulationId: "sim-1",
+        channelId: "general",
+        actorId: "leo",
+        type: "llm_failure",
+        payload: { reason: "provider error" },
+        sourceEventIds: [],
+        emotionalSalience: "low",
+        visibility: { visibleToAgents: [], visibleToSpectators: false, visibleToOperators: true, visibilityReason: "x" },
+      };
+    `;
+    expect(hasOperatorEmission(committedEventShape, "llm_failure")).toBe(false);
+  });
+
+  it("accepts a real operator-event construction", () => {
+    const operatorEventShape = `
+      const op: OperatorEvent = {
+        type: "llm_failure",
+        simulationId: "sim-1",
+        agentId: "leo",
+        pulseIndex: 3,
+        detail: "LLM provider execution failed",
+        createdAt: 0,
+      };
+    `;
+    expect(hasOperatorEmission(operatorEventShape, "llm_failure")).toBe(true);
+  });
+
+  it("accepts the shorthand-detail form used by schedulerError", () => {
+    const shorthand = `
+      return {
+        type: "scheduler_error",
+        simulationId: this.config.simulation.id,
+        agentId,
+        pulseIndex: this.pulseIndex,
+        detail,
+        data,
+        createdAt: Date.now(),
+      };
+    `;
+    expect(hasOperatorEmission(shorthand, "scheduler_error")).toBe(true);
+  });
 });

--- a/packages/server/src/simulation/__tests__/operator-event-producers.test.ts
+++ b/packages/server/src/simulation/__tests__/operator-event-producers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { OPERATOR_EVENT_TYPES } from "@perfectman/shared";
+
+/**
+ * Producer guard for `OperatorEventType`.
+ *
+ * The single source of truth is the `OPERATOR_EVENT_TYPES` array in
+ * packages/shared/src/operator/operator.types.ts (the type is derived from
+ * it). This test enforces the invariant that every *declared* operator type
+ * actually has an emission site in packages/server/src — a declared type
+ * nobody emits can never reach a receiver, and keeping it around invites
+ * drift between the contract and the runtime.
+ *
+ * The reverse direction (emitting an undeclared type) needs no guard here:
+ * the type system already rejects any `type: "..."` that is not a member of
+ * the union.
+ *
+ * This guard exists because `rate_limit_hit` was declared but never
+ * emitted anywhere in packages/server/src — removed with this change. The
+ * observability-stream types (`agent_state_snapshot`, `action_intent`,
+ * `event_visibility`) landed on main with PR #100 and each has a producer.
+ */
+
+// Test lives at packages/server/src/simulation/__tests__/, so the server
+// source root is three levels up from this file.
+const SERVER_SRC = fileURLToPath(new URL("../../..", import.meta.url));
+const SKIP_DIRS = new Set(["__tests__", "__e2e__"]);
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      files.push(...collectSourceFiles(full));
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts") && !entry.endsWith(".d.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe("operator event producers", () => {
+  const sourceFiles = collectSourceFiles(SERVER_SRC);
+
+  it("scans the server source tree (not an empty or wrong path)", () => {
+    // A broken path resolves to zero files and would make every producer
+    // assertion below fail for the wrong reason — or pass vacuously if the
+    // join were ever inverted. Fail loudly and name the resolved root.
+    expect(sourceFiles.length, `no source files under ${SERVER_SRC}`).toBeGreaterThan(0);
+  });
+
+  const allSource = sourceFiles.map((file) => readFileSync(file, "utf8")).join("\n");
+
+  it.each(OPERATOR_EVENT_TYPES)(
+    "declared operator type %s has an emission site in packages/server/src",
+    (type) => {
+      expect(
+        allSource.includes(`type: "${type}"`),
+        `${type} is declared in shared but never emitted in packages/server/src — remove it from OPERATOR_EVENT_TYPES or wire a producer`,
+      ).toBe(true);
+    },
+  );
+});

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -1,18 +1,32 @@
 import type { EventPayload, EventType } from "../event/event.types.js";
 import type { IntentType } from "../intent/intent.types.js";
 
-export type OperatorEventType =
-  | "llm_failure"
-  | "llm_budget_exceeded"
-  | "intent_blocked"
-  | "intent_delayed"
-  | "rate_limit_hit"
-  | "stagnation_warning"
-  | "scheduler_error"
-  | "pulse_metrics"
-  | "agent_state_snapshot"
-  | "action_intent"
-  | "event_visibility";
+/**
+ * Operator event types the server may emit. Declared once here — the single
+ * source of truth — and enforced by the producer guard in packages/server
+ * (`operator-event-producers.test.ts`): a type with no emission site in
+ * packages/server/src is dead and must be removed, not kept "for later".
+ * Deriving the type from the array keeps the runtime-iterable list and the
+ * type in one place.
+ *
+ * `rate_limit_hit` was removed — the one type declared with no producer
+ * anywhere in packages/server/src (RateLimitGate computes block state but
+ * never emits an operator event for it).
+ */
+export const OPERATOR_EVENT_TYPES = [
+  "llm_failure",
+  "llm_budget_exceeded",
+  "intent_blocked",
+  "intent_delayed",
+  "stagnation_warning",
+  "scheduler_error",
+  "pulse_metrics",
+  "agent_state_snapshot",
+  "action_intent",
+  "event_visibility",
+] as const;
+
+export type OperatorEventType = (typeof OPERATOR_EVENT_TYPES)[number];
 
 export type OperatorEvent = {
   type: OperatorEventType;


### PR DESCRIPTION
## What

`rate_limit_hit` is declared in the shared operator-event contract but never emitted anywhere in `packages/server/src` — `RateLimitGate` computes block state (`blocked`/`blockReason`) but never produces an operator event for it. A declared operator type with no producer can never reach a receiver; keeping it invites drift between the contract and the runtime. It was the only dead member of the union: every other declared type (`agent_state_snapshot`, `action_intent`, `event_visibility` included) has at least one emission site on main.

- **Removes `rate_limit_hit`** (`packages/shared/src/operator/operator.types.ts`) and turns the union into a runtime-iterable `as const` array with the type derived from it (`OPERATOR_EVENT_TYPES` = single source of truth; no zod schema added, per the testing-strategy won't-do).
- **Adds a producer guard** (`packages/server/src/simulation/__tests__/operator-event-producers.test.ts`): every declared operator type must have an emission site (`type: "<name>"`) in `packages/server/src`. The reverse direction — emitting an undeclared type — is already rejected by the type system, so the guard is one-directional. It validates all ten remaining types, including the observability-stream ones that landed on main via #100.
- Regenerates `docs/test-inventory.{md,json}`.

## Validation

- `pnpm lint` PASS (typecheck, 4/4 packages)
- `pnpm test:all` PASS — full suite green (100 files / 1064 tests incl. the new guard test); audit gate 0 violations
- The guard test passes against the 10 produced types and fails for any declared type without an emission site — the invariant this PR exists to enforce
- Gate run inside a `node:22` container (Docker, on the workspace's remote worker) with `pnpm install --frozen-lockfile`, matching the CI sequence (install → build → lint → test:all)
