### PR TITLE
feat(docker): containerized app runtime + tag-triggered GHCR release (proposal)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,44 @@
+name: Docker release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/app/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ pnpm freellm:dev        # API on :3001, dashboard on :5173
 
 Add provider keys and create a unified key via the dashboard, then set `FREELLMAPI_KEY` in `.env`.
 
+**Simulation in Docker** (no local Node/pnpm toolchain needed):
+
+```bash
+mkdir -p config
+cp examples/simulations/mock.inline-personas.example.json config/index.json
+docker compose -f docker/app/app.compose.yml up --build
+```
+
+It combines with the auxiliary containers, e.g. Qwen3/Ollama alongside the runtime:
+
+```bash
+docker compose -f docker/qwen3/qwen3.compose.yml \
+               -f docker/app/app.compose.yml up -d simulation
+```
+
+Published images are built for each tagged release and pushed to GHCR (`ghcr.io/caiotheodoro/perfectman:<tag>`) — see [Releases](#releases) below.
+
+This builds a multi-stage image of the runtime itself and runs the same CLI as `pnpm --filter @perfectman/server simulation`. With the mock example it needs no API keys or model — personas converse on stdout. To use a real provider, point your mounted `config/index.json` at it and hand keys to the container with an extra read-only mount of the same `.env` the CLI reads natively:
+
+```bash
+docker compose -f docker/app/app.compose.yml run --rm \
+  -v "$PWD/.env:/app/.env:ro" simulation
+```
+
 ### Bring your own personas
 
 See [`docs/personas/README.md`](docs/personas/README.md) for the plug-and-play persona interview/compile workflow. Real, person-specific persona files live under `config/` and `docs/personas/`, both gitignored — nothing personal gets committed.
@@ -105,6 +129,18 @@ The full design lives in [`docs/README.md`](docs/README.md) — start there for 
 ## Status / open questions
 
 This is an active experiment, not a finished product. See [`docs/README.md`](docs/README.md#current-open-questions) for what's genuinely undecided — private-channel spectator visibility, how much scoring machinery should exist, which symbolic actions are worth keeping. If one of those interests you, that's a good place to start.
+
+## Releases
+
+> Proposal — this convention only exists once this lands and the first tag is cut.
+
+Every tagged release (`v*`) publishes a container image of the runtime to GitHub Container Registry via `docker-release.yml`: `ghcr.io/caiotheodoro/perfectman` gets the exact tag (`v0.1.0` → image tag `0.1.0`, plus `latest` for non-prerelease). Consumers without a Node toolchain can run the simulation directly:
+
+```bash
+docker pull ghcr.io/caiotheodoro/perfectman:latest
+```
+
+Use a tagged image instead of `latest` anywhere reproducibility matters.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ This is an active experiment, not a finished product. See [`docs/README.md`](doc
 
 ## Releases
 
-> Proposal — this convention only exists once this lands and the first tag is cut.
-
 Every tagged release (`v*`) publishes a container image of the runtime to GitHub Container Registry via `docker-release.yml`: `ghcr.io/caiotheodoro/perfectman` gets the exact tag (`v0.1.0` → image tag `0.1.0`, plus `latest` for non-prerelease). Consumers without a Node toolchain can run the simulation directly:
 
 ```bash

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,55 @@
+# Multi-stage build of the Perfectman runtime.
+#
+# Stage 1 (build) reproduces the CI gate order on the same base image:
+# pnpm install --frozen-lockfile -> pnpm -r build.
+# Stage 2 (runtime) installs only the production dependency graph of
+# @perfectman/server (plus its workspace dependencies) and copies the compiled
+# dist trees, so no source, dev dependencies, or build toolchain ship in the
+# final image. The entrypoint is the same CLI that
+# `pnpm --filter @perfectman/server simulation` runs locally; config discovery
+# (config/index.json, .env) walks up from the working directory exactly as in
+# a native checkout.
+
+FROM node:22-bookworm AS build
+
+WORKDIR /work
+
+RUN npm install -g pnpm@10
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/engine/package.json packages/engine/
+COPY packages/server/package.json packages/server/
+COPY packages/eval/package.json packages/eval/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Composite tsc projects treat a pre-existing valid tsconfig.tsbuildinfo as
+# "already built" and skip emitting dist entirely, which breaks cross-package
+# resolution. Drop any build state riding along in the context.
+RUN rm -rf packages/*/dist packages/*/*.tsbuildinfo
+
+RUN pnpm -r build
+
+FROM node:22-bookworm AS runtime
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=build /work/package.json /work/pnpm-lock.yaml /work/pnpm-workspace.yaml ./
+COPY --from=build /work/packages/shared/package.json packages/shared/
+COPY --from=build /work/packages/engine/package.json packages/engine/
+COPY --from=build /work/packages/server/package.json packages/server/
+COPY --from=build /work/packages/eval/package.json packages/eval/
+
+RUN npm install -g pnpm@10 \
+  && pnpm install --frozen-lockfile --prod --filter "@perfectman/server..."
+
+COPY --from=build /work/packages/shared/dist packages/shared/dist
+COPY --from=build /work/packages/engine/dist packages/engine/dist
+COPY --from=build /work/packages/server/dist packages/server/dist
+
+ENTRYPOINT ["node", "packages/server/dist/cli/run-simulation.js"]

--- a/docker/app/app.compose.yml
+++ b/docker/app/app.compose.yml
@@ -1,0 +1,19 @@
+name: perfectman
+
+services:
+  simulation:
+    build:
+      context: ..
+      dockerfile: app/Dockerfile
+    image: perfectman-app:local
+    container_name: perfectman-simulation
+    # Lets provider baseURLs reach services on the host (e.g. native Ollama)
+    # from inside the container on Linux too.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: "no"
+    volumes:
+      # Simulation config discovered via the existing walk-up lookup
+      # (/app/config/index.json). Real provider keys go through a mounted
+      # /app/.env (same dotenv file the CLI reads natively).
+      - ../../config:/app/config:ro

--- a/docs/README.md
+++ b/docs/README.md
@@ -245,6 +245,8 @@ pnpm qwen:dev
 
 The script starts `ollama/ollama` from the portable base compose file, pulls `qwen3:1.7b` by default into a Docker-managed volume, and exposes the OpenAI-compatible API on `http://localhost:11434/v1`. Use it with `config/index.json` copied from `examples/simulations/qwen3-local.example.json`. For the 8B model, run `pnpm qwen:dev:8b` and use a config with `modelName: "qwen3:8b"`. NVIDIA machines can opt into GPU passthrough with `-f docker/qwen3/qwen3.gpu.compose.yml` (see the root README).
 
+For running the simulation runtime itself as a container (multi-stage build from this repo, same CLI entrypoint as the pnpm workflow), see **Simulation in Docker** and **Releases** in the root README.
+
 ## Current Open Questions
 
 - How much private-channel visibility should spectators get?


### PR DESCRIPTION
## What

Three additive artifacts that let the simulation runtime run without a local Node 22 + pnpm 10 toolchain. No application code, no tests, and no new dependencies are touched.

1. **`docker/app/Dockerfile`** — multi-stage image. Stage 1 reproduces the CI order on `node:22-bookworm` (`pnpm install --frozen-lockfile` → `pnpm -r build`). Stage 2 installs only the production dependency graph of `@perfectman/server` (+ its workspace deps) and ships compiled `dist` trees. The entrypoint is the exact CLI that `pnpm --filter @perfectman/server simulation` runs natively — config discovery is untouched (walk-up finds `/app/config/index.json`, dotenv finds a mounted `/app/.env`).
2. **`docker/app/app.compose.yml`** — compose service following the existing `docker/` precedents (base file, combinable with `qwen3.compose.yml` via `-f -f`). Mounts `./config` read-only.
3. **`.github/workflows/docker-release.yml`** — on `v*` tag pushes, builds and publishes images to GHCR with `<major>.<minor>` tags from the tag name plus `latest` for non-prereleases.

Plus doc sections in both READMEs.

## What this flow enables

- **Zero-toolchain simulation**: clone → copy one example config into `config/` → `docker compose -f docker/app/app.compose.yml up --build`. Personas converse on stdout with zero API keys (mock provider). Works on machines with no Node/pnpm at all.
- **Deployable runtime**: any Docker host can run a released image (`ghcr.io/<owner>/perfectman:<tag>`), and each image is traceable to the exact commit it was built from via OCI labels — no dev checkout, no drift between "what I tested" and "what runs".
- **Foundation for frontend consumers**: the runtime already has pluggable transports (Socket.IO among them), so serving a UI becomes a *deployment decision* layered on this image rather than a new toolchain problem. This PR deliberately does not open or expose anything network-facing — it just makes the runtime something you can pull and run anywhere, which is the precondition for whatever consumes it next.
- **Images that don't rot by convention**: every `v*` tag rebuilds and republishes; reproducibility-conscious consumers pin `:<major>.<minor>` instead of `latest`.

## Proposal points (discussion wanted here)

This doubles as a proposal; reshape any of it in threads.

- **Tag-as-release convention**: this repo has never had releases or tags. The workflow proposes the minimal convention — pushing `v*` is what constitutes a release. Alternative would be GitHub Releases-driven or manual dispatch; happy either way, tag-push seemed smallest.
- **GHCR namespace**: images land under `ghcr.io/<repo-owner>/perfectman` via `${{ github.repository }}`, so they follow whoever merges first on upstream.
- **Base image**: `node:22-bookworm` full (matches CI's Node 22; avoids native-build surprises for `better-sqlite3`) vs `slim`/`alpine` for smaller images. Bookworm chosen for safety on the native dep; size optimization can come later if anyone cares.
- **Runtime graph**: stage 2 ships only `@perfectman/server`'s production deps (+ workspace deps) instead of the whole workspace install. Open to shipping more/less depending on how eval wants to relate to images later (left out of scope here).

## Validation

- Full gate green on a clean `node:22` container mirroring CI order (`install → build → lint → test:all`, including the test-hygiene audit): all pass.
- Image built from this Dockerfile and executed against `examples/simulations/mock.inline-personas.example.json` mounted at `/app/config`: live simulation stream (agent messages, mock LLM cognition calls ~50ms, engine state snapshots evolving, agents creating a private channel among themselves mid-run), clean SIGTERM shutdown (`simulation_stopped`). Zero API keys involved.
- Release workflow exercised end-to-end before proposing: test tag pushed on the author's fork → all steps green → `ghcr.io/elesiann/perfectman:0.0.0-docker-probe.1` published (and correctly *no* `latest` generated, since the probe tag carried a prerelease suffix). Probe tag deleted afterwards.
- Build-invariant note found while validating: composite tsc projects silently skip `dist` emission when a stale `tsconfig.tsbuildinfo` rides in the build context (Dockerignore patterns don't cross path separators like gitignore does). The Dockerfile clears `packages/*/dist` and `packages/*/*.tsbuildinfo` after COPY, so builds are context-independent.
