### PR TITLE
docs(adr): map decision pointers to the ADR files instead of the pipeline decision-log

### DIFF
--- a/docs/adr/0001-event-visibility-operator-event.md
+++ b/docs/adr/0001-event-visibility-operator-event.md
@@ -1,6 +1,6 @@
 # ADR-0001: Per-Committed-Event Visibility Signal
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-1 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-1, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0002-action-intent-emission.md
+++ b/docs/adr/0002-action-intent-emission.md
@@ -1,6 +1,6 @@
 # ADR-0002: `action_intent` Operator Event
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-3 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-3, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0003-shared-agent-state-serializer.md
+++ b/docs/adr/0003-shared-agent-state-serializer.md
@@ -1,6 +1,6 @@
 # ADR-0003: Shared Agent-State Serializer
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-4 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-4, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0004-gateway-construction-metadata.md
+++ b/docs/adr/0004-gateway-construction-metadata.md
@@ -1,6 +1,6 @@
 # ADR-0004: Runtime Metadata at Gateway Construction
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-5 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-5, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0005-stream-fed-html-receiver.md
+++ b/docs/adr/0005-stream-fed-html-receiver.md
@@ -1,6 +1,6 @@
 # ADR-0005: Stream-Fed HTML Receiver in Production
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-6 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-6, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0006-html-snapshot-gateway-config.md
+++ b/docs/adr/0006-html-snapshot-gateway-config.md
@@ -1,6 +1,6 @@
 # ADR-0006: `html-snapshot` Gateway Config Variant
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-7 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-7, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0007-pulse-frame-result-approximation.md
+++ b/docs/adr/0007-pulse-frame-result-approximation.md
@@ -1,6 +1,6 @@
 # ADR-0007: `PulseFrame.result` Stream-Derived Approximation
 
-**Status**: Accepted (LOCKED, 2026-08-25) — decision D-9 in `.claude/_output/pipeline/decision-log.md`
+**Status**: Accepted (LOCKED, 2026-08-25) — decision D-9, rationale inline in this ADR
 
 ## Context
 

--- a/docs/adr/0008-world-goal-layer.md
+++ b/docs/adr/0008-world-goal-layer.md
@@ -1,6 +1,6 @@
 # ADR-0008: World Goal Layer
 
-**Status**: Accepted (LOCKED, 2026-08-25) — rationale and rejected alternatives inline below; the `.claude/_output/pipeline/decision-log.md` archive is a secondary pointer only and is never the home of this decision's rationale.
+**Status**: Accepted (LOCKED, 2026-08-25) — rationale and rejected alternatives inline in this ADR.
 
 ## Context
 

--- a/docs/adr/0009-goal-layer-runtime-wiring.md
+++ b/docs/adr/0009-goal-layer-runtime-wiring.md
@@ -1,6 +1,6 @@
 # ADR-0009: Goal-Layer Runtime Wiring
 
-**Status**: Accepted (LOCKED, 2026-08-25) — rationale and rejected alternatives inline below; the `.claude/_output/pipeline/decision-log.md` archive is a secondary pointer only and is never the home of this decision's rationale.
+**Status**: Accepted (LOCKED, 2026-08-25) — rationale and rejected alternatives inline in this ADR.
 
 ## Context
 
@@ -8,7 +8,7 @@
 
 Scope changed during planning (Step-2 revision): the acceptance path (does the sim end) depends on whether proposals are agent-legible, so the **LLM goal-synthesis seam was committed up-front** — shared contracts, config slots, server seam interfaces, call sites — while its *implementation* stays deferred. What remains deferred as one future slice (D-13): the real LLM synthesizer, `"agent"` acceptance wiring, and LLM self-verdicts. They co-require each other: agent acceptance is meaningful only for LLM-framed (agent-legible) proposals, and LLM self-verdicts share the same prompt surface.
 
-The engine layer stays pure and untouched (G4) — only index type re-exports close the server's signature gap (D-2). All decisions below are LOCKED; each row cites its decision-log ID as a secondary pointer, with the rationale itself inline here.
+The engine layer stays pure and untouched (G4) — only index type re-exports close the server's signature gap (D-2). All decisions below are LOCKED and recorded in this ADR; the rationale lives inline here.
 
 ## Decision
 

--- a/docs/adr/0010-goal-layer-llm-slice.md
+++ b/docs/adr/0010-goal-layer-llm-slice.md
@@ -1,6 +1,6 @@
 # ADR-0010: Goal-Layer LLM Slice
 
-**Status**: Accepted (LOCKED, 2026-08-26) — rationale and rejected alternatives inline below; the `.claude/_output/pipeline/decision-log.md` archive (rows D-17..D-23) is a secondary pointer only and is never the home of this decision's rationale.
+**Status**: Accepted (LOCKED, 2026-08-26) — rationale and rejected alternatives inline in this ADR (decisions D-17..D-23).
 
 ## Context
 
@@ -61,5 +61,5 @@ Design constraints carried into this slice: the engine stays pure and untouched 
 - Foundation: [ADR-0008: World Goal Layer](./0008-world-goal-layer.md) — semantics; [ADR-0009: Goal-Layer Runtime Wiring](./0009-goal-layer-runtime-wiring.md) — the seams this slice implements; 0009's "still deferred: the LLM implementations" consequence is superseded by this ADR.
 - Concept: [docs/concepts/goal-layer.md](../concepts/goal-layer.md) — the layer, lifecycle, two-verdict architecture; carries an implementation-status note.
 - Research: [docs/research/goal-layer/](../research/goal-layer/README.md) — source trail and gaps; [docs/research/log.md](../research/log.md) — run chronology.
-- Decisions (secondary pointer): `.claude/_output/pipeline/decision-log.md` rows D-17..D-23, locked 2026-08-26 (Step 3.5), including the D-18 amendment on configured-provider routing.
+- Decisions: D-17..D-23 as recorded in this ADR (locked 2026-08-26, Step 3.5), including the D-18 amendment on configured-provider routing.
 - Code: `packages/server/src/simulation/world/{goal-layer-llm,goal-layer-prompt-builder,goal-synthesizer,world-evaluator,goal-registry,acceptance-gate}.ts`, `packages/server/src/simulation/{pulse-scheduler…}`, `packages/server/src/config/simulation-config.ts`, `packages/shared/src/goal/` (contracts + `goal-layer-config.schema.ts`), `packages/shared/src/{prompt,operator}/` (union growth), tests in the colocated `__tests__/` directories.

--- a/docs/llm-provider-sdk.md
+++ b/docs/llm-provider-sdk.md
@@ -1,6 +1,6 @@
 # LLM Provider SDK — Research and Recommendation (US-001 / FR-001)
 
-**Status**: Recommendation for the approval gate (D-1/D-2). No dependency may be added to any `package.json` until this document is reviewed and the gate records LOCKED in `.claude/_output/pipeline/decision-log.md`.
+**Status**: Recommendation for the approval gate (D-1/D-2). No dependency may be added to any `package.json` until this document is reviewed and the gate records LOCKED in the ADR record that this decision produces (`docs/adr/`).
 
 **Scope**: Issue #89 (adopt an external AI provider SDK, retire the three hand-rolled transports). This is the written comparison required by US-001/FR-001/SC-001: Vercel AI SDK vs alternatives, covering OpenAI-compatible chat completions, Ollama native `/api/chat`, structured/JSON-Schema output, no-API-key local mode, non-streaming single-shot calls, TypeScript types, maintenance status, and bundle/transitive weight — plus the two seam constraints the migration depends on (test-seam `fetch` override and raw response-header capture), the cost of not adding, and the removal cost.
 

--- a/docs/research/goal-layer/notes.md
+++ b/docs/research/goal-layer/notes.md
@@ -53,7 +53,7 @@ Atomic findings per research thread, paraphrased unless marked verbatim. Every f
 
 **The llm-wiki bar.** "The knowledge is compiled once and then *kept current*, not re-derived on every query"; raw sources are immutable and the wiki links back to them; an append-only `log.md` with `## [YYYY-MM-DD]` prefixes is parseable with `grep "^## \["` (Karpathy gist, fetched raw).
 
-**The repo's external-source trail is dead in three places.** Committed ADRs point at `.claude/_output/pipeline/decision-log.md`, which archiving moves — rationale links now resolve to nothing; bare-vendor citations ("ScienceDirect", "arxivUpenn") in `docs/notes/design-conversation-history.md` are unrecoverable; `architecture/emotion.md` cites Russell's Circumplex with no URL.
+**The repo's external-source trail is dead in two places.** Bare-vendor citations ("ScienceDirect", "arxivUpenn") in `docs/notes/design-conversation-history.md` are unrecoverable; `architecture/emotion.md` cites Russell's Circumplex with no URL. (The third dead link — ADRs pointing at the pipeline's `.claude/_output/pipeline/decision-log.md` — was repaired on 2026-08-26: decisions D-1..D-23 now resolve inside the ADRs themselves in `docs/adr/`.)
 
 **The pattern already exists in-repo.** `docs/notes/discord/` (README + source-map with URLs, fetch dates, verification status, freshness notes, gaps) is a fully realized llm-wiki raw-source loop; `eval/README.md` "Calibration-pending (honest list)" is the audit-loop precedent.
 


### PR DESCRIPTION
## What

The committed ADRs cited their locked decisions as ``.claude/_output/pipeline/decision-log.md`` — a path that is gitignored, never shipped, and resolves to nothing for any reader outside the authoring machine (`docs/research/goal-layer/notes.md` already flagged this as a dead trail).

Decisions now resolve **in-repo**:

- `docs/adr/0001-0007` — status lines read `decision D-n, rationale inline in this ADR` (all rationale was already inline; only the pointer was dead)
- `docs/adr/0008/0009/0010` — drop the `decision-log archive is a secondary pointer` clause; D-17..D-23 recorded in the ADR itself (incl. the D-18 amendment reference)
- `docs/llm-provider-sdk.md` — approval gate records LOCKED in the ADR record (`docs/adr/`)
- `docs/research/goal-layer/notes.md` — dead-trail note updated: decision pointers repaired 2026-08-26; two links remain dead (bare-vendor citations, Russell cite)

Docs-only; 12 files, 14/14 line changes. Note: `docs/research/goal-layer/{README,source-map}.md` and ADR-0008 keep intentional `.claude/_output/research/` mentions — they document the staging-vs-durable layout by design, not as resolvable citations.