### PR TITLE
fix(llm): stop the openai-compatible health check reporting a false green (#113)

### DIFF
--- a/.claude/skills/pr-house-style/SKILL.md
+++ b/.claude/skills/pr-house-style/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pr-house-style
+description: "Rewrite a pull-request title and body to this repo's maintainer house style before opening the PR. Use whenever you are about to run `gh pr create` for perfectman, or when asked to clean up / rewrite a PR description. Derived from matheusht's merged PRs."
+---
+
+# PR House Style
+
+Rewrite a draft PR title and body so it is indistinguishable from a `matheusht` PR in this repo. Run this immediately before `gh pr create`, on whatever draft you have (a change-report, a pipeline outcome, a rough bullet list).
+
+Output is a title line and a Markdown body. Nothing else. Do not open the PR from inside this skill unless the caller asked for that in the same breath — hand the polished text back.
+
+## Source Of Truth
+
+The style is derived from ~20 merged PRs authored by `matheusht` (PRs #59–#79 range). To refresh or extend the sample:
+
+```bash
+gh api 'repos/caiotheodoro/perfectman/pulls?state=closed&per_page=100' --paginate \
+  --jq '.[] | select(.user.login=="matheusht" and .merged_at!=null) | "### " + .title + "\n" + .body + "\n"'
+```
+
+`joao-ryft` / `yoarajota` PR **bodies** are agent-generated — do not sample them for style (his inline review *comments* are a different voice, covered by `write-as-joao`). `matheusht` bodies are hand-written and consistent; they are the model.
+
+## Title
+
+`type(scope): imperative lowercase summary` — Conventional Commits, one line, ~50–72 chars.
+
+- `type`: `feat` · `fix` · `refactor` · `docs` · `ci` · `chore`.
+- `scope`: the package or area, lowercase — `eval` · `agent` · `server` · `llm` · `engine` · `shared` · `goal-layer` · `docker` · `ci` · `simulation` · `delivery`. Pick the one a reader would grep for.
+- Summary: verb-first, lowercase, no trailing period. "adopt AI provider SDK", "survive unparseable LLM judge responses with retry + prose salvage".
+- Append ` (#NN)` **only** when the PR closes a tracked issue with that number. Otherwise no ref.
+
+## Body
+
+Exactly these sections, in this order. No others — no "How", no "Testing", no "Screenshots", no checklist, no "Notes for reviewer".
+
+```
+## What
+
+<one framing line, verb-first, ends with a colon>
+
+- <concrete change — exact symbol / file / flag / number in backticks>
+- <concrete change>
+- <...>
+- <test summary folded in: "N tests: <what each covers>, terse">
+
+## Why
+
+<1–3 sentences of specific motivating context — a real gap or incident. OMIT this
+section entirely when the framing line in What already answers "why".>
+
+## Validation
+
+- `pnpm lint` PASS - `pnpm test:all` PASS (+N)
+- <1–2 lines of concrete evidence: a head-to-head number, a live run result, a committed evidence path>
+```
+
+### `## What` rules
+
+- **Framing line**: present tense, verb-first, ends with `:`. Templates that fit almost everything:
+  - `Adds <thing> to <where>:`
+  - `Replaces <old> with <new>:`
+  - `Turns <X> into <Y>:`
+  - `Upgrades <area> from <A> to <B>:`
+  - `Makes <X> resilient to <failure>:`
+  - `Measures <tradeoff> that <gap>:`
+- **Bullets** name the substantive changes only. Every bullet carries at least one backticked identifier — a symbol, a filename, a flag, a config key, a number. No bullet is a vague verb phrase ("improve reliability", "clean up code").
+- **Contrasting pairs** get bold lead-ins: `**Old proxy**:` / `**New proxy**:`, `**Strict retry**:` / `**Prose salvage**:`.
+- **Tests** are one closing bullet, not a section: `Five unit tests: single-type floor, uniform ceiling, skew monotonicity, operator-noise exclusion, empty input.` Name each case in 2–4 words.
+- **Honest scoping** is stated plainly, in the same register, when the change has a known limit: `Committed mock baseline is honestly flat and says so`, `live-model sweeps drop straight into this harness`. Never bury a caveat and never inflate.
+
+### `## Validation` rules
+
+- First bullet is always the two commands, backticked, joined by ` - `, each followed by `PASS`. Add `(+N)` or `NNN passed (+N <label>)` when there is a test-count delta worth stating.
+- Follow with concrete proof, quantified: `edge_mutation_pressure moves 3 -> 4`, `--slice edges -> 12 variant runs, 0 failed, signals 100%`, `4-cell matrix committed under docs/eval/evidence/`. One or two bullets, no more.
+- If lint or tests were not run, or an unrelated pre-existing failure exists, say so in one plain bullet. Do not claim a green run you did not see.
+
+## Register
+
+- Declarative and dense. No "This PR…", no "I've…", no "Let me know". Drop the framing, name the thing.
+- Quantify everything quantifiable — counts, thresholds, scenario ids, file paths.
+- Em-dashes within a sentence are fine (this is not Joao's inline-comment voice). Sectioned Markdown is correct here.
+- Never mention AI, agents, pipelines, generated output, or assistant tooling — in the title, the body, or the commit.
+- Match the length of the change: a one-module fix is ~10 lines of body; a cross-cutting change is ~18. If the body runs past ~25 lines, it is over-explaining.
+
+## Checklist before handing back
+
+- [ ] Title is `type(scope): lowercase`, `(#NN)` present only if it closes that issue.
+- [ ] Body has `## What`, optional `## Why`, `## Validation` — nothing else.
+- [ ] `## What` opens with a colon-terminated framing line; every bullet has a backticked identifier.
+- [ ] Test cases are one folded bullet, each named.
+- [ ] `## Validation` leads with `` `pnpm lint` PASS - `pnpm test:all` PASS `` and follows with quantified evidence.
+- [ ] No AI/agent/pipeline mention anywhere.
+- [ ] Reads like `matheusht` wrote it.

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -368,6 +368,12 @@ export function localLLMConfig(pack: import("@perfectman/shared").PersonaPack | 
           // (stronger for hot personas) plus presence_penalty to kill loops.
           frequency_penalty: Math.min(2, (sampling.repetitionPenalty - 1) * 2.5),
           presence_penalty: 0.4,
+          // deepseek-v4-* models reason by default at effort `high`, spending
+          // the output-token budget on a thinking block before the intent
+          // JSON — every intent call then fails to parse. This is DeepSeek's
+          // OpenAI-format key to disable that phase; `reasoning_effort: "none"`
+          // returns HTTP 400 on DeepSeek.
+          thinking: { type: "disabled" },
         }
       : {
           seed: benchSeed(),

--- a/packages/eval/src/test/bench-seed.test.ts
+++ b/packages/eval/src/test/bench-seed.test.ts
@@ -36,6 +36,7 @@ describe("bench seed wiring (#45)", () => {
     const config = localLLMConfig(undefined);
     expect(config.providerType).toBe("ollama");
     expect(config.extraBody?.["seed"]).toBe(benchSeed());
+    expect(config.extraBody?.["thinking"]).toBeUndefined();
   });
 
   it("pins seed into the deepseek-path extraBody", () => {
@@ -43,5 +44,6 @@ describe("bench seed wiring (#45)", () => {
     const config = localLLMConfig(undefined);
     expect(config.providerType).toBe("openai-compatible");
     expect(config.extraBody?.["seed"]).toBe(benchSeed());
+    expect(config.extraBody?.["thinking"]).toEqual({ type: "disabled" });
   });
 });

--- a/packages/server/src/cli/__tests__/llm-health-check.test.ts
+++ b/packages/server/src/cli/__tests__/llm-health-check.test.ts
@@ -3,7 +3,25 @@ import {
   assertQwenAvailable,
   assertRequiredLLMServicesAvailable,
 } from "../llm-health-check.js";
+import { generateOpenAiCompatibleIntent } from "../../llm/sdk-transport.js";
 import type { SimulationAppConfig } from "../../config/simulation-config.js";
+import type { BuiltPrompt } from "../../agent/agent-runtime.types.js";
+
+const driftGuardPrompt: BuiltPrompt = {
+  system: "Return only JSON.",
+  user: "Return {\"ok\":true}.",
+  inputTokensEstimate: 10,
+  purpose: "action_intent",
+  version: "v-test",
+  templateVersion: "template-test",
+};
+
+function okJsonResponse(content: string): Response {
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content } }], model: "m" }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
 
 function baseConfig(): SimulationAppConfig {
   return {
@@ -74,9 +92,12 @@ describe("LLM health checks", () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
+      text: async () => JSON.stringify({ choices: [{ message: { content: "{\"ok\":true}" } }] }),
     });
 
-    await assertQwenAvailable(baseConfig().agents[0]!.llm, { fetch, timeoutMs: 1000 });
+    const cfg = baseConfig();
+    cfg.agents[0]!.llm.extraBody = { thinking: { type: "disabled" }, seed: 7 };
+    await assertQwenAvailable(cfg.agents[0]!.llm, { fetch, timeoutMs: 1000 });
 
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:11434/v1/chat/completions",
@@ -89,7 +110,8 @@ describe("LLM health checks", () => {
     expect(body.model).toBe("qwen3:1.7b");
     expect(body.max_tokens).toBe(8);
     expect(body.stream).toBe(false);
-    expect(body.think).toBe(false);
+    expect(body.thinking).toEqual({ type: "disabled" });
+    expect(body.seed).toBe(7);
   });
 
   it("fails Qwen health check when generation returns an Ollama error", async () => {
@@ -113,11 +135,108 @@ describe("LLM health checks", () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
+      text: async () => JSON.stringify({ choices: [{ message: { content: "{\"ok\":true}" } }] }),
     });
 
     await assertRequiredLLMServicesAvailable(config, { fetch, timeoutMs: 1000 });
 
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the health check when an OK response carries no parseable JSON object", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ choices: [{ message: { content: "" } }] }),
+    });
+
+    const err = await assertQwenAvailable(baseConfig().agents[0]!.llm, { fetch, timeoutMs: 1000 })
+      .then(() => undefined)
+      .catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toMatch(/reasoning/i);
+    expect(err!.message).toMatch(/disabl/i);
+    expect(err!.message).toContain("extraBody");
+    expect(err!.message).toContain('{ "thinking": { "type": "disabled" } }');
+
+    const proseFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({ choices: [{ message: { content: "Let me think about this..." } }] }),
+    });
+    await expect(
+      assertQwenAvailable(baseConfig().agents[0]!.llm, { fetch: proseFetch, timeoutMs: 1000 }),
+    ).rejects.toThrow(/reasoning/i);
+  });
+
+  it("does not bury the reasoning-overflow cause under the generic health-check hint", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({ choices: [{ message: { content: "Let me think about this..." } }] }),
+    });
+
+    const err = await assertQwenAvailable(baseConfig().agents[0]!.llm, { fetch, timeoutMs: 1000 })
+      .then(() => undefined)
+      .catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).not.toContain("Check the baseUrl, modelName, and API key");
+    expect(err!.message).not.toMatch(/^Qwen service is reachable only if/);
+  });
+
+  it("passes the health check when OK response content embeds a parseable JSON object", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({ choices: [{ message: { content: 'prefix noise {"ok":true} trailing' } }] }),
+    });
+
+    await expect(
+      assertQwenAvailable(baseConfig().agents[0]!.llm, { fetch, timeoutMs: 1000 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the preflight probe body and the runtime intent body in agreement on reasoning and sampling fields", async () => {
+    const cfg = baseConfig();
+    cfg.agents[0]!.llm.extraBody = { thinking: { type: "disabled" }, seed: 5, top_p: 0.8 };
+    const llm = cfg.agents[0]!.llm;
+
+    const runtimeFetch = vi.fn().mockResolvedValue(okJsonResponse('{"intentType":"no_op","privateMotiveSummary":"s"}'));
+    await generateOpenAiCompatibleIntent(llm, driftGuardPrompt, Date.now(), { fetch: runtimeFetch });
+
+    const probeFetch = vi.fn().mockResolvedValue(okJsonResponse('{"ok":true}'));
+    await assertQwenAvailable(llm, { fetch: probeFetch, timeoutMs: 1000 });
+
+    const runtimeBody = JSON.parse(runtimeFetch.mock.calls[0]![1]!.body as string);
+    const probeBody = JSON.parse(probeFetch.mock.calls[0]![1]!.body as string);
+
+    expect(runtimeBody.thinking).toEqual({ type: "disabled" });
+    expect(probeBody.thinking).toEqual(runtimeBody.thinking);
+    expect(probeBody.seed).toEqual(runtimeBody.seed);
+    expect(probeBody.top_p).toEqual(runtimeBody.top_p);
+  });
+
+  it("agrees that no reasoning field is present when the config has no extraBody", async () => {
+    const cfg = baseConfig();
+    delete cfg.agents[0]!.llm.extraBody;
+    const llm = cfg.agents[0]!.llm;
+
+    const runtimeFetch = vi.fn().mockResolvedValue(okJsonResponse('{"intentType":"no_op","privateMotiveSummary":"s"}'));
+    await generateOpenAiCompatibleIntent(llm, driftGuardPrompt, Date.now(), { fetch: runtimeFetch });
+
+    const probeFetch = vi.fn().mockResolvedValue(okJsonResponse('{"ok":true}'));
+    await assertQwenAvailable(llm, { fetch: probeFetch, timeoutMs: 1000 });
+
+    const runtimeBody = JSON.parse(runtimeFetch.mock.calls[0]![1]!.body as string);
+    const probeBody = JSON.parse(probeFetch.mock.calls[0]![1]!.body as string);
+
+    expect(runtimeBody.thinking).toBeUndefined();
+    expect(probeBody.thinking).toBeUndefined();
   });
 
   it("probes the native /api/chat endpoint for ollama-shaped configs", async () => {

--- a/packages/server/src/cli/llm-health-check.ts
+++ b/packages/server/src/cli/llm-health-check.ts
@@ -1,8 +1,19 @@
 import type { SimulationAppConfig } from "../config/simulation-config.js";
 import type { LLMConfig } from "../llm/llm-config.js";
 import { resolveEndpointShape } from "../llm/provider-factory.js";
+import { buildOpenAiCompatibleRequestBody } from "../llm/sdk-transport.js";
 
 type Fetch = typeof fetch;
+
+const PROBE_MAX_OUTPUT_TOKENS = 8;
+
+/**
+ * Marks a probe failure that already carries an actionable cause+fix message.
+ * The generic catch in `assertTinyGenerationAvailable` rethrows it unwrapped so
+ * the reasoning-overflow guidance is not buried behind the "check your API key"
+ * hint.
+ */
+class ReasoningOverflowError extends Error {}
 
 export type FreellmApiHealthCheckDeps = {
   env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
@@ -110,15 +121,9 @@ async function assertTinyGenerationAvailable(
           think: false,
           ...llm.extraBody,
         })
-      : JSON.stringify({
-          model: llm.modelName,
-          messages: tinyPrompt,
-          temperature: 0,
-          max_tokens: 8,
-          stream: false,
-          think: false,
-          ...llm.extraBody,
-        });
+      : JSON.stringify(
+          buildOpenAiCompatibleRequestBody(llm, tinyPrompt, PROBE_MAX_OUTPUT_TOKENS),
+        );
 
   try {
     const response = await fetchImpl(url, {
@@ -132,7 +137,31 @@ async function assertTinyGenerationAvailable(
       const detail = await response.text().catch(() => "");
       throw new Error(`generation health check returned HTTP ${response.status}: ${detail.slice(0, 240)}`);
     }
+
+    if (shape !== "ollama") {
+      const raw = await response.text().catch(() => "");
+      let content: unknown;
+      try {
+        content = (
+          JSON.parse(raw) as { choices?: Array<{ message?: { content?: unknown } }> }
+        )?.choices?.[0]?.message?.content;
+      } catch {
+        content = undefined;
+      }
+      if (typeof content !== "string" || !hasParseableJsonObject(content)) {
+        throw new ReasoningOverflowError(
+          `The tiny generation at ${normalizedBaseUrl} returned an OK response with no parseable ` +
+            `JSON object. The likely cause is that model reasoning is not disabled, so the reasoning ` +
+            `block consumed the ${PROBE_MAX_OUTPUT_TOKENS}-token budget before any JSON was emitted. ` +
+            `Add a reasoning-disable entry to the agent's llm.extraBody — for DeepSeek: ` +
+            `{ "thinking": { "type": "disabled" } }.`,
+        );
+      }
+    }
   } catch (err) {
+    if (err instanceof ReasoningOverflowError) {
+      throw err;
+    }
     const detail = err instanceof Error ? err.message : String(err);
     const prefix =
       `Qwen service is reachable only if it can complete a tiny generation at ${normalizedBaseUrl}. `;
@@ -143,5 +172,20 @@ async function assertTinyGenerationAvailable(
     throw new Error(`${prefix}${hint}Details: ${detail}`);
   } finally {
     clearTimeout(timeoutId);
+  }
+}
+
+function hasParseableJsonObject(s: string): boolean {
+  const trimmed = s.trim();
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed.slice(start, end + 1));
+    return typeof parsed === "object" && parsed !== null;
+  } catch {
+    return false;
   }
 }

--- a/packages/server/src/llm/__tests__/sdk-transport.test.ts
+++ b/packages/server/src/llm/__tests__/sdk-transport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  buildOpenAiCompatibleRequestBody,
   generateOpenAiCompatibleIntent,
   generateOllamaIntent,
 } from "../sdk-transport.js";
@@ -181,7 +182,7 @@ describe("sdk-transport OpenAI-compatible path", () => {
     const fetchSpy = vi.fn().mockResolvedValue(openAiOkResponse({ choices: [{ message: { content: "{}" } }], model: "m" }));
 
     await generateOpenAiCompatibleIntent(
-      openAiConfig({ extraBody: { custom_flag: true, seed: 7 } }),
+      openAiConfig({ extraBody: { custom_flag: true, seed: 7, thinking: { type: "disabled" } } }),
       prompt,
       startTime(),
       { fetch: fetchSpy },
@@ -190,6 +191,7 @@ describe("sdk-transport OpenAI-compatible path", () => {
     const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
     expect(body.custom_flag).toBe(true);
     expect(body.seed).toBe(7);
+    expect(body.thinking).toEqual({ type: "disabled" });
   });
 
   it("sends no response_format when responseFormatJson is not enabled", async () => {
@@ -343,6 +345,76 @@ describe("sdk-transport OpenAI-compatible path", () => {
     await expect(
       generateOpenAiCompatibleIntent(openAiConfig(), prompt, startTime(), { fetch: fetchSpy }),
     ).rejects.toThrow(LLMError);
+  });
+});
+
+describe("buildOpenAiCompatibleRequestBody", () => {
+  const probeMessages = [
+    { role: "system", content: "sys" },
+    { role: "user", content: "user" },
+  ];
+
+  it("spreads reasoning-disable and sampling extraBody entries onto the body root", () => {
+    const body = buildOpenAiCompatibleRequestBody(
+      openAiConfig({ extraBody: { thinking: { type: "disabled" }, seed: 7, top_p: 0.9 } }),
+      probeMessages,
+      8,
+    );
+
+    expect(body).toEqual({
+      model: "gemini/gemini-2.5-flash",
+      messages: probeMessages,
+      stream: false,
+      max_tokens: 8,
+      temperature: 0.7,
+      thinking: { type: "disabled" },
+      seed: 7,
+      top_p: 0.9,
+    });
+  });
+
+  it("adds no reasoning-control field when the config has no extraBody", () => {
+    const body = buildOpenAiCompatibleRequestBody(openAiConfig(), probeMessages, 8);
+
+    expect(body).toEqual({
+      model: "gemini/gemini-2.5-flash",
+      messages: probeMessages,
+      stream: false,
+      max_tokens: 8,
+      temperature: 0.7,
+    });
+    expect(body).not.toHaveProperty("thinking");
+    expect(body).not.toHaveProperty("think");
+    expect(body).not.toHaveProperty("response_format");
+  });
+
+  it("keeps the reasoning-disable entry at the body root through a proxy-style baseUrl", () => {
+    const body = buildOpenAiCompatibleRequestBody(
+      openAiConfig({
+        baseUrl: "https://api.freellmapi.com/v1",
+        extraBody: { thinking: { type: "disabled" } },
+      }),
+      probeMessages,
+      8,
+    );
+
+    expect(body.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("lets an extraBody max_tokens override the passed cap via spread order", () => {
+    const body = buildOpenAiCompatibleRequestBody(
+      openAiConfig({ extraBody: { max_tokens: 4096 } }),
+      probeMessages,
+      8,
+    );
+
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it("passes an empty messages array through unchanged", () => {
+    const body = buildOpenAiCompatibleRequestBody(openAiConfig(), [], 8);
+
+    expect(body.messages).toEqual([]);
   });
 });
 

--- a/packages/server/src/llm/llm-config.ts
+++ b/packages/server/src/llm/llm-config.ts
@@ -15,5 +15,13 @@ export type LLMConfig = {
    * OpenAI-compatible provider); set false to force syntax-only json_object.
    */
   responseFormatJsonSchema?: boolean;
+  /**
+   * Extra provider-specific keys spread onto the OpenAI-compatible request
+   * body root (and translated into Ollama's nested `options` on the native
+   * path). Reasoning-capable hosted models that think by default must be
+   * given an explicit reasoning-disable entry here, or the reasoning block
+   * consumes the output-token budget before the intent JSON and every call
+   * fails to parse. DeepSeek's key is `{ thinking: { type: "disabled" } }`.
+   */
   extraBody?: Record<string, unknown>;
 };

--- a/packages/server/src/llm/sdk-transport.ts
+++ b/packages/server/src/llm/sdk-transport.ts
@@ -179,6 +179,32 @@ function captureResponseHeaders(headers: Record<string, string> | undefined): Re
   return captured;
 }
 
+/**
+ * The OpenAI-compatible `POST .../chat/completions` request body, assembled
+ * from an LLMConfig in one place so the startup health probe and the runtime
+ * intent call cannot drift on their reasoning- and sampling-control fields.
+ * `extraBody` is spread onto the root the same way the SDK does at runtime
+ * (`providerOptions["openai-compatible"]`), so an operator's reasoning-disable
+ * entry (DeepSeek's `{ thinking: { type: "disabled" } }`) reaches the wire
+ * unchanged. Injects no reasoning field of its own. Callers override only
+ * `maxOutputTokens` — the probe caps it low; every other field comes from the
+ * real config.
+ */
+export function buildOpenAiCompatibleRequestBody(
+  config: LLMConfig,
+  messages: Array<{ role: string; content: string }>,
+  maxOutputTokens: number,
+): Record<string, unknown> {
+  return {
+    model: config.modelName,
+    messages,
+    stream: false,
+    max_tokens: maxOutputTokens,
+    temperature: config.temperature,
+    ...config.extraBody,
+  };
+}
+
 export async function generateOpenAiCompatibleIntent(
   config: LLMConfig,
   prompt: BuiltPrompt,


### PR DESCRIPTION
## What

Stops a reasoning-by-default hosted model (DeepSeek `deepseek-v4-flash` and kin) silently no-op'ing every pulse behind a green preflight:

- **Shared body builder**: `buildOpenAiCompatibleRequestBody(config, messages, maxOutputTokens)` in `sdk-transport.ts` — a free function mirroring `resolveEndpointShape`, imported by the health-check probe so the preflight and runtime request shapes cannot drift on reasoning / sampling fields. It injects no reasoning field; reasoning control is operator `extraBody`, exactly like `seed` / `top_p`.
- **Probe uses the real config**: the `openai-compatible` probe now builds its body from the agent's real `LLMConfig` and overrides only `max_tokens` (`PROBE_MAX_OUTPUT_TOKENS = 8`). The hardcoded `think: false` / `stream: false` / `temperature: 0` literals are gone — `temperature` comes from `config.temperature`.
- **Reasoning-overflow classification**: an OK HTTP status whose content has no parseable JSON object throws `ReasoningOverflowError`, rethrown unwrapped past the generic `"Check the baseUrl, modelName, and API key"` prefix, naming reasoning-not-disabled as the likely cause and `{ "thinking": { "type": "disabled" } }` under `extraBody` as the DeepSeek fix. The `ollama` `/api/chat` path, HTTP-error handling, timeout and one-probe-per-endpoint dedup are untouched.
- **Operator + eval**: `LLMConfig.extraBody` JSDoc names the requirement and shows the DeepSeek key; the eval scenario-runner's `isDeepseek` `extraBody` branch gains `thinking: { type: "disabled" }` (non-deepseek branch keeps `think: false`, no `thinking` key). `config/index.json` gets the same entry in both agents' `llm.extraBody` — that file is git-ignored, so it is not in this diff. No new `providerType`, no reasoning-mode enum, no `parseExtraBody` change.
- **Honest scoping**: the DeepSeek key `{ "thinking": { "type": "disabled" } }` is from the current DeepSeek OpenAI-format docs (corroborated by LiteLLM #27439/#27453) but was not re-hit against the live API here — the new classification is the backstop if it is wrong. `reasoning_effort: "none"` is not used: DeepSeek returns HTTP 400 for it.
- `+13 tests`: builder shape (root-spread, no-`extraBody`, proxy `baseUrl`, `max_tokens` override, empty messages), probe body carries the real `extraBody`, reasoning-overflow message carries cause + fix, no generic prefix, embedded-JSON content still passes, preflight/runtime body drift-guard on `thinking` / `seed` / `top_p`, extended "spreads extraBody onto the request body root".

## Why

A green preflight guaranteed nothing about real intent calls: the tiny-generation probe hand-built its request body independently of the runtime transport, hardcoding a reasoning-off flag and an 8-token cap, so it always came back with small clean JSON regardless of how the model would behave on a real intent call. Every pulse then failed to parse and the agent mind fell back to a no-op, with no signal to the operator.

## Validation

- `pnpm --filter @perfectman/server test` PASS — 719/719 (+13); `sdk-transport` 37/37 including the untouched json_schema -> json_object fallback tests, `llm-health-check` 9/9
- `pnpm --filter @perfectman/eval exec vitest run src/test/bench-seed.test.ts` PASS — 7/7
- Drift-guard red-green shown: passing the probe a config without `thinking` while the runtime call keeps it fails the `thinking` comparison; reverted, passes.
- CI `PR gate`: all 1315 unit tests pass. `test:gate` is red on a pre-existing docs-lint allowlist drift in `docs/research/goal-layer/README.md` that is also red on `main` (line 15 -> 16 shift, content unchanged) — fixed separately in #115; rebase once that lands. Locally `pnpm -r typecheck` OOMs in this environment; per-package `tsc --noEmit` is clean on the touched files (one pre-existing unrelated `world-evaluator.ts:142` error, byte-identical before/after).

---

Also on this branch: `.claude/skills/pr-house-style/` — a skill that codifies the maintainer PR-body conventions (this description was written to it). Separate commit; drop it if it does not belong here.


