### PR TITLE
fix(docs): repoint the docs-lint D-39 allowlist to README.md:16

### DIFF
--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -50,7 +50,7 @@ const FRESHNESS_DAYS = 90;
 // that legitimately needs an exception updates this list (and the research log).
 const INFORMATIONAL_EXCEPTIONS = [
   "docs/adr/0008-world-goal-layer.md:50",   // prose: archiving-survival rule
-  "docs/research/goal-layer/README.md:15",  // prose: staging-copies note
+  "docs/research/goal-layer/README.md:16",  // prose: staging-copies note
   "docs/research/goal-layer/notes.md:56",   // prose: historical dead-link note
   "docs/research/goal-layer/notes.md:60",   // prose: staging-only rule (two mentions, one line)
   "docs/research/goal-layer/source-map.md:82", // link target: staging source R1


### PR DESCRIPTION
## What

Repoints the D-39 informational-mention allowlist in `scripts/docs-lint.mjs` after a line shift:

- `docs/research/goal-layer/README.md`'s `.claude/_output/research/` staging-copies prose mention sits on line 16 on `main`; a blank line moved it from 15, content unchanged.
- `INFORMATIONAL_EXCEPTIONS` still pinned `README.md:15`, so the `--check` set-drift guard fired and `pnpm test:gate` failed on `main` and on every branch cut from it. Updated the one entry to `README.md:16`.

## Validation

- `node scripts/docs-lint.mjs --check` PASS — 69 files, 0 violations, 8 informational (line-keyed), 22/22 self-test fixtures
- `node scripts/audit-tests.mjs --check` PASS — the other half of `test:gate`
