### PR TITLE
feat(simulation): bound stagnation window, wire attractor detection (#133)

### DIFF
--- a/packages/engine/src/__tests__/stagnation.test.ts
+++ b/packages/engine/src/__tests__/stagnation.test.ts
@@ -5,6 +5,7 @@ import type {
   CoreMood,
   SocialEmotions,
 } from "@perfectman/shared";
+import { STAGNATION_THRESHOLDS } from "@perfectman/shared";
 import {
   computeStagnationMetrics,
   detectAttractorStates,
@@ -144,6 +145,26 @@ describe("computeStagnationMetrics", () => {
     for (const key of ["bdi", "rdv", "ige", "cue", "eri", "isd", "cns"] as const) {
       expect(typeof result[key]).toBe("number");
     }
+  });
+
+  // KNOWN, deferred to #129. An empty rolling window — a room silent for the
+  // whole window — leaves every metric on its neutral no-data default, whose
+  // weighted sum is 0.604, already >= STAGNATION_THRESHOLDS.yellow (0.60). The
+  // pulse scheduler then commits stagnation_detected off defaults rather than a
+  // real measurement. Threshold tuning is out of scope for #133 (decision
+  // #125); this test pins the behavior so any fix is a deliberate change.
+  it("scores yellow from neutral defaults on an empty window", () => {
+    const result = computeStagnationMetrics("sim1", 50, [], new Map());
+    expect(result.compositeScore).toBeCloseTo(0.604, 5);
+    expect(result.compositeScore).toBeGreaterThanOrEqual(STAGNATION_THRESHOLDS.yellow);
+    expect(result.level).toBe("yellow");
+  });
+
+  it("scores at or above yellow on a sparse window with no agent states", () => {
+    const events = Array.from({ length: 2 }, (_, i) => makeEvent(`${i}`, "a1", "message_sent"));
+    const result = computeStagnationMetrics("sim1", 50, events, new Map());
+    expect(result.compositeScore).toBeGreaterThanOrEqual(STAGNATION_THRESHOLDS.yellow);
+    expect(result.level).not.toBe("normal");
   });
 });
 

--- a/packages/engine/src/health/compute-stagnation-metrics.ts
+++ b/packages/engine/src/health/compute-stagnation-metrics.ts
@@ -2,6 +2,7 @@ import type {
   CommittedEvent,
   AgentState,
   StagnationMetrics,
+  AttractorState,
 } from "@perfectman/shared";
 import {
   STAGNATION_THRESHOLDS,
@@ -222,13 +223,13 @@ function computeCNS(events: CommittedEvent[]): number {
 
 /**
  * Detect attractor states from recent events.
- * Returns array of detected attractor state labels.
+ * Returns the detected signatures; an empty array means none fired.
  */
 export function detectAttractorStates(
   recentEvents: CommittedEvent[],
   agentStates: Map<string, AgentState>,
-): string[] {
-  const detected: string[] = [];
+): AttractorState[] {
+  const detected: AttractorState[] = [];
   const WINDOW = ATTRACTOR_DETECTION_WINDOW_PULSES;
 
   const windowEvents = recentEvents.slice(-WINDOW * 3); // rough pulse window

--- a/packages/server/src/simulation/__tests__/fixtures.ts
+++ b/packages/server/src/simulation/__tests__/fixtures.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared fixtures for PulseScheduler tests.
+ * Defaults target the stagnation-window suite ("agent_1" in "sim_stag");
+ * pass overrides to makeAgentState for other ids.
+ */
+import type {
+  ActionEmotions,
+  AgentState,
+  EngineSnapshot,
+  EngineStepResult,
+  PersonaConfig,
+  SimulationSettings,
+} from "@perfectman/shared";
+
+export const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+export function makeAgentState(overrides: Partial<AgentState> = {}): AgentState {
+  const agentId = overrides.agentId ?? "agent_1";
+  return {
+    agentId,
+    simulationId: "sim_stag",
+    personaId: `persona_${agentId}`,
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+export function makePersona(agentId: string): PersonaConfig {
+  return {
+    id: `persona_${agentId}`,
+    name: `Agent ${agentId}`,
+    archetype: "test",
+    writingStyle: "casual",
+    styleExamples: [],
+    baselineValence: 0,
+    baselineArousal: 0.5,
+    baselineStability: 0.8,
+    baselineEnergy: 0.6,
+    emotionalReactivity: 0.5,
+    moodInertia: 0.5,
+    maxMoodRotation: 0.5,
+    energyRegen: 0.05,
+    exclusionSensitivity: 0.5,
+    praiseSensitivity: 0.5,
+    conflictSensitivity: 0.5,
+    boredomSensitivity: 0.5,
+    intimacySensitivity: 0.5,
+    socialSensitivities: {},
+  };
+}
+
+export const ZERO_ACTION: ActionEmotions = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+export function cannedNoOpStep(snap: EngineSnapshot): EngineStepResult {
+  const agentId = snap.agentState.agentId;
+  return {
+    visibleEvents: [],
+    newEvents: [],
+    attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
+    perceptionPacket: {
+      agentId, triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
+      relevantChannels: [], relevantMemories: [],
+      translatedEmotionalState: { summary: "", emotions: [] },
+      availableActions: [],
+    },
+    interpretations: [],
+    emotionDelta: { coreMoodDelta: {}, socialEmotionDeltas: {}, relationalDeltas: new Map(), ruminationApplied: false },
+    updatedAgentState: makeAgentState({ agentId, simulationId: snap.simulation.id }),
+    motivations: [],
+    pressures: [],
+    inhibitions: [],
+    actionEmotions: ZERO_ACTION,
+    decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
+    availableActions: [],
+    initiativeCandidates: [],
+    memoryProposals: [],
+    noOpRecord: null,
+    operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 0, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
+  };
+}
+
+/** Numeric fields a stagnation_metrics operator payload must surface — the seven metric keys plus the composite score. */
+export const STAGNATION_METRIC_KEYS = [
+  "bdi", "rdv", "ige", "cue", "eri", "isd", "cns", "compositeScore",
+] as const;

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -23,9 +23,11 @@ import type {
   EngineSnapshot,
   OperatorEvent,
   CommittedEvent,
+  SimulationEvent,
   AgentRuntimeInput,
 } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
+import { computeStagnationMetrics } from "@perfectman/engine";
 
 const SETTINGS: SimulationSettings = {
   omniscientSpectatorMode: false,
@@ -527,5 +529,53 @@ describe("PulseScheduler observability events", () => {
     for (const line of snapshotLines) {
       expect(line.payload.type).toBe("agent_state_snapshot");
     }
+  });
+
+  it("emits per-cadence stagnation_metrics and a distinct attractor_detected on a message-loop run", async () => {
+    const h = await buildScheduler({
+      step: (snap) => makeCannedStep(snap.agentState.agentId),
+    });
+
+    const seeds: SimulationEvent[] = [];
+    for (let p = 1; p <= 9; p += 1) {
+      seeds.push({
+        id: `seed_${p}`,
+        simulationId: "sim_obs",
+        channelId: "ch_public",
+        actorId: p % 2 === 0 ? "agent_1" : "agent_2",
+        type: "message_sent",
+        payload: { content: "so anyway what do you think" },
+        sourceEventIds: [],
+        emotionalSalience: "low",
+        pulseIndex: p,
+        visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public_channel" },
+      });
+    }
+    const committed = await h.eventRepo.append("sim_obs", seeds);
+
+    for (let i = 0; i < 11; i += 1) await h.scheduler.runPulse();
+
+    const metricsEvents = h.gateway.operatorEvents.filter((e) => e.type === "stagnation_metrics");
+    expect(metricsEvents).toHaveLength(1);
+    const m = metricsEvents[0]!;
+    expect(m.pulseIndex).toBe(10);
+    for (const key of ["bdi", "rdv", "ige", "cue", "eri", "isd", "cns", "compositeScore"] as const) {
+      expect(typeof m.data?.[key]).toBe("number");
+    }
+    expect(["normal", "yellow", "red", "critical"]).toContain(m.data?.["level"]);
+
+    const attractorEvents = h.gateway.operatorEvents.filter((e) => e.type === "attractor_detected");
+    expect(attractorEvents.some((e) => e.data?.["signature"] === "message_loop")).toBe(true);
+    for (const e of attractorEvents) expect(e.pulseIndex).toBe(10);
+
+    // level and composite ride the composite pipeline untouched — the attractor
+    // hit produces its own event and never overrides them.
+    const agentStates = new Map([
+      ["agent_1", (await h.agentStateRepo.get("sim_obs", "agent_1"))!],
+      ["agent_2", (await h.agentStateRepo.get("sim_obs", "agent_2"))!],
+    ]);
+    const independent = computeStagnationMetrics("sim_obs", 10, committed, agentStates);
+    expect(m.data?.["level"]).toBe(independent.level);
+    expect(m.data?.["compositeScore"]).toBe(independent.compositeScore);
   });
 });

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -11,6 +11,7 @@ import { OperatorProjection } from "../projections/operator-projection.js";
 import { EngineEventBuilder } from "../engine-event-builder.js";
 import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
 import { StdoutDeliveryGateway } from "../../delivery/stdout-delivery-gateway.js";
+import { STAGNATION_METRIC_KEYS } from "./fixtures.js";
 import { serializeAgentState } from "../../agent/agent-state-serializer.js";
 import type { AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
 import type {
@@ -559,7 +560,7 @@ describe("PulseScheduler observability events", () => {
     expect(metricsEvents).toHaveLength(1);
     const m = metricsEvents[0]!;
     expect(m.pulseIndex).toBe(10);
-    for (const key of ["bdi", "rdv", "ige", "cue", "eri", "isd", "cns", "compositeScore"] as const) {
+    for (const key of STAGNATION_METRIC_KEYS) {
       expect(typeof m.data?.[key]).toBe("number");
     }
     expect(["normal", "yellow", "red", "critical"]).toContain(m.data?.["level"]);

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-stagnation-window.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-stagnation-window.test.ts
@@ -22,29 +22,15 @@ import { SpectatorProjection } from "../projections/spectator-projection.js";
 import { OperatorProjection } from "../projections/operator-projection.js";
 import { EngineEventBuilder } from "../engine-event-builder.js";
 import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import { cannedNoOpStep, makeAgentState, makePersona, SETTINGS, STAGNATION_METRIC_KEYS } from "./fixtures.js";
 import type {
-  AgentState,
-  EngineSnapshot,
-  EngineStepResult,
-  PersonaConfig,
   Simulation,
   SimulationEvent,
-  SimulationSettings,
   StagnationMetrics,
 } from "@perfectman/shared";
 
 const computeMock = vi.mocked(computeStagnationMetrics);
 const detectMock = vi.mocked(detectAttractorStates);
-
-const SETTINGS: SimulationSettings = {
-  omniscientSpectatorMode: false,
-  allowPrivateChannels: true,
-  maxPrivateChannelsPerAgent: 3,
-  maxMessagesPerMinutePerAgent: 20,
-  llmCallBudgetPerMinute: 10,
-  pulseIntervalMs: 3000,
-  tokenBudgetPerHour: 1_000_000,
-};
 
 const SIM: Simulation = {
   id: "sim_stag",
@@ -57,85 +43,6 @@ const SIM: Simulation = {
   createdAt: Date.now(),
   updatedAt: Date.now(),
 };
-
-function makeAgentState(agentId: string): AgentState {
-  return {
-    agentId,
-    simulationId: "sim_stag",
-    personaId: `persona_${agentId}`,
-    presence: "active",
-    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
-    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
-    relationalStates: new Map(),
-    memories: [],
-    initiativeAccumulators: [],
-    lastProcessedEventId: null,
-    lastActionAt: null,
-    lastRuminationPulse: null,
-    arrivalPulse: null,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  };
-}
-
-function makePersona(agentId: string): PersonaConfig {
-  return {
-    id: `persona_${agentId}`,
-    name: `Agent ${agentId}`,
-    archetype: "test",
-    writingStyle: "casual",
-    styleExamples: [],
-    baselineValence: 0,
-    baselineArousal: 0.5,
-    baselineStability: 0.8,
-    baselineEnergy: 0.6,
-    emotionalReactivity: 0.5,
-    moodInertia: 0.5,
-    maxMoodRotation: 0.5,
-    energyRegen: 0.05,
-    exclusionSensitivity: 0.5,
-    praiseSensitivity: 0.5,
-    conflictSensitivity: 0.5,
-    boredomSensitivity: 0.5,
-    intimacySensitivity: 0.5,
-    socialSensitivities: {},
-  };
-}
-
-const ZERO_ACTION = {
-  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
-  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
-  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
-  dominanceAssertion: 0, repairImpulse: 0,
-};
-
-function cannedNoOpStep(snap: EngineSnapshot): EngineStepResult {
-  const agentId = snap.agentState.agentId;
-  return {
-    visibleEvents: [],
-    newEvents: [],
-    attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
-    perceptionPacket: {
-      agentId, triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
-      relevantChannels: [], relevantMemories: [],
-      translatedEmotionalState: { summary: "", emotions: [] },
-      availableActions: [],
-    },
-    interpretations: [],
-    emotionDelta: { coreMoodDelta: {}, socialEmotionDeltas: {}, relationalDeltas: new Map(), ruminationApplied: false },
-    updatedAgentState: makeAgentState(agentId),
-    motivations: [],
-    pressures: [],
-    inhibitions: [],
-    actionEmotions: ZERO_ACTION,
-    decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
-    availableActions: [],
-    initiativeCandidates: [],
-    memoryProposals: [],
-    noOpRecord: null,
-    operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 0, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
-  };
-}
 
 function normalMetrics(): StagnationMetrics {
   return {
@@ -176,7 +83,7 @@ async function buildScheduler(): Promise<Harness> {
     updatedAt: Date.now(),
   });
   await channelRepo.addMembership({ channelId: "ch_public", agentId: "agent_1", joinedAt: Date.now() });
-  await agentStateRepo.upsert(makeAgentState("agent_1"));
+  await agentStateRepo.upsert(makeAgentState());
 
   const rateLimitGate = new RateLimitGate(SETTINGS);
   const agentRuntime: AgentRuntime = { generateIntent: vi.fn() };
@@ -184,7 +91,7 @@ async function buildScheduler(): Promise<Harness> {
 
   const scheduler = new PulseScheduler({
     simulation: SIM,
-    agents: [{ id: "agent_1", state: makeAgentState("agent_1"), persona: makePersona("agent_1") }],
+    agents: [{ id: "agent_1", state: makeAgentState(), persona: makePersona("agent_1") }],
     defaultPublicChannelId: "ch_public",
     eventRepo,
     agentStateRepo,
@@ -241,7 +148,7 @@ describe("PulseScheduler stagnation telemetry", () => {
 
     const first = metricsEvents[0]!;
     expect(first.data?.["level"]).toBe("normal");
-    for (const key of ["bdi", "rdv", "ige", "cue", "eri", "isd", "cns", "compositeScore"] as const) {
+    for (const key of STAGNATION_METRIC_KEYS) {
       expect(typeof first.data?.[key]).toBe("number");
     }
 

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-stagnation-window.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-stagnation-window.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@perfectman/engine", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@perfectman/engine")>();
+  return {
+    ...actual,
+    computeStagnationMetrics: vi.fn(),
+    detectAttractorStates: vi.fn(() => []),
+  };
+});
+
+import { computeStagnationMetrics, detectAttractorStates } from "@perfectman/engine";
+import { PulseScheduler } from "../pulse-scheduler.js";
+import type { AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
+import { InMemoryEventRepository, InMemoryAgentStateRepository, InMemoryChannelRepository } from "../in-memory-stores.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { IntentResolver } from "../intent-resolver.js";
+import { EngineSnapshotProjection } from "../projections/engine-snapshot-projection.js";
+import { DeliveryProjection } from "../projections/delivery-projection.js";
+import { SpectatorProjection } from "../projections/spectator-projection.js";
+import { OperatorProjection } from "../projections/operator-projection.js";
+import { EngineEventBuilder } from "../engine-event-builder.js";
+import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import type {
+  AgentState,
+  EngineSnapshot,
+  EngineStepResult,
+  PersonaConfig,
+  Simulation,
+  SimulationEvent,
+  SimulationSettings,
+  StagnationMetrics,
+} from "@perfectman/shared";
+
+const computeMock = vi.mocked(computeStagnationMetrics);
+const detectMock = vi.mocked(detectAttractorStates);
+
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+const SIM: Simulation = {
+  id: "sim_stag",
+  name: "stagnation",
+  status: "running",
+  agentIds: ["agent_1"],
+  channelIds: ["ch_public"],
+  settings: SETTINGS,
+  seed: 5,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+function makeAgentState(agentId: string): AgentState {
+  return {
+    agentId,
+    simulationId: "sim_stag",
+    personaId: `persona_${agentId}`,
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function makePersona(agentId: string): PersonaConfig {
+  return {
+    id: `persona_${agentId}`,
+    name: `Agent ${agentId}`,
+    archetype: "test",
+    writingStyle: "casual",
+    styleExamples: [],
+    baselineValence: 0,
+    baselineArousal: 0.5,
+    baselineStability: 0.8,
+    baselineEnergy: 0.6,
+    emotionalReactivity: 0.5,
+    moodInertia: 0.5,
+    maxMoodRotation: 0.5,
+    energyRegen: 0.05,
+    exclusionSensitivity: 0.5,
+    praiseSensitivity: 0.5,
+    conflictSensitivity: 0.5,
+    boredomSensitivity: 0.5,
+    intimacySensitivity: 0.5,
+    socialSensitivities: {},
+  };
+}
+
+const ZERO_ACTION = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+function cannedNoOpStep(snap: EngineSnapshot): EngineStepResult {
+  const agentId = snap.agentState.agentId;
+  return {
+    visibleEvents: [],
+    newEvents: [],
+    attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
+    perceptionPacket: {
+      agentId, triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
+      relevantChannels: [], relevantMemories: [],
+      translatedEmotionalState: { summary: "", emotions: [] },
+      availableActions: [],
+    },
+    interpretations: [],
+    emotionDelta: { coreMoodDelta: {}, socialEmotionDeltas: {}, relationalDeltas: new Map(), ruminationApplied: false },
+    updatedAgentState: makeAgentState(agentId),
+    motivations: [],
+    pressures: [],
+    inhibitions: [],
+    actionEmotions: ZERO_ACTION,
+    decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
+    availableActions: [],
+    initiativeCandidates: [],
+    memoryProposals: [],
+    noOpRecord: null,
+    operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 0, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
+  };
+}
+
+function normalMetrics(): StagnationMetrics {
+  return {
+    simulationId: "sim_stag",
+    pulseIndex: 0,
+    bdi: 0.1, rdv: 0.12, ige: 0.14, cue: 0.11, eri: 0.13, isd: 0.09, cns: 0.08,
+    compositeScore: 0.11,
+    level: "normal",
+  };
+}
+
+interface Harness {
+  scheduler: PulseScheduler;
+  gateway: MockDeliveryGateway;
+  eventRepo: InMemoryEventRepository;
+  agentStateRepo: InMemoryAgentStateRepository;
+}
+
+async function buildScheduler(): Promise<Harness> {
+  const eventRepo = new InMemoryEventRepository();
+  const agentStateRepo = new InMemoryAgentStateRepository();
+  const channelRepo = new InMemoryChannelRepository();
+  const channelRegistry = new ChannelRegistry(channelRepo);
+  const gateway = new MockDeliveryGateway();
+
+  await channelRepo.create({
+    id: "ch_public",
+    simulationId: "sim_stag",
+    type: "public_channel",
+    name: "general",
+    createdBy: "system",
+    memberAgentIds: ["agent_1"],
+    spectatorVisible: true,
+    operatorVisible: true,
+    createdForMotives: [],
+    status: "active",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await channelRepo.addMembership({ channelId: "ch_public", agentId: "agent_1", joinedAt: Date.now() });
+  await agentStateRepo.upsert(makeAgentState("agent_1"));
+
+  const rateLimitGate = new RateLimitGate(SETTINGS);
+  const agentRuntime: AgentRuntime = { generateIntent: vi.fn() };
+  const llmBudget: LLMBudget = { getPriority: vi.fn().mockReturnValue("normal") };
+
+  const scheduler = new PulseScheduler({
+    simulation: SIM,
+    agents: [{ id: "agent_1", state: makeAgentState("agent_1"), persona: makePersona("agent_1") }],
+    defaultPublicChannelId: "ch_public",
+    eventRepo,
+    agentStateRepo,
+    channelRegistry,
+    rateLimitGate,
+    intentResolver: new IntentResolver(rateLimitGate, channelRegistry),
+    engineSnapshotProjection: new EngineSnapshotProjection(),
+    deliveryProjection: new DeliveryProjection(gateway),
+    spectatorProjection: new SpectatorProjection(gateway),
+    operatorProjection: new OperatorProjection(gateway),
+    engineEventBuilder: new EngineEventBuilder(),
+    agentRuntime,
+    llmBudget,
+    pulseIntervalMs: SETTINGS.pulseIntervalMs,
+    stepResolver: cannedNoOpStep,
+  });
+
+  return { scheduler, gateway, eventRepo, agentStateRepo };
+}
+
+function seedEvent(pulseIndex: number): SimulationEvent {
+  return {
+    id: `seed_p${pulseIndex}`,
+    simulationId: "sim_stag",
+    channelId: "ch_public",
+    actorId: "agent_1",
+    type: "message_sent",
+    payload: {},
+    sourceEventIds: [],
+    emotionalSalience: "low",
+    pulseIndex,
+    visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public_channel" },
+  };
+}
+
+async function runTo(scheduler: PulseScheduler, pulseIndex: number): Promise<void> {
+  for (let i = 0; i <= pulseIndex; i += 1) await scheduler.runPulse();
+}
+
+describe("PulseScheduler stagnation telemetry", () => {
+  beforeEach(() => {
+    computeMock.mockReset();
+    detectMock.mockReset();
+    computeMock.mockReturnValue(normalMetrics());
+    detectMock.mockReturnValue([]);
+  });
+
+  it("emits a stagnation_metrics operator event every cadence even when level is normal", async () => {
+    const h = await buildScheduler();
+    await runTo(h.scheduler, 20);
+
+    const metricsEvents = h.gateway.operatorEvents.filter((e) => e.type === "stagnation_metrics");
+    expect(metricsEvents.map((e) => e.pulseIndex)).toEqual([10, 20]);
+
+    const first = metricsEvents[0]!;
+    expect(first.data?.["level"]).toBe("normal");
+    for (const key of ["bdi", "rdv", "ige", "cue", "eri", "isd", "cns", "compositeScore"] as const) {
+      expect(typeof first.data?.[key]).toBe("number");
+    }
+
+    expect(h.gateway.operatorEvents.some((e) => e.type === "stagnation_warning")).toBe(false);
+    const committed = await h.eventRepo.getAfter("sim_stag");
+    expect(committed.some((e) => e.type === "stagnation_detected")).toBe(false);
+  });
+
+  it("emits one attractor_detected operator event per detected signature", async () => {
+    detectMock.mockReturnValue(["message_loop", "reaction_only"]);
+    const h = await buildScheduler();
+    await runTo(h.scheduler, 10);
+
+    const attractor = h.gateway.operatorEvents.filter((e) => e.type === "attractor_detected");
+    expect(attractor.map((e) => e.data?.["signature"]).sort()).toEqual(["message_loop", "reaction_only"]);
+    for (const e of attractor) expect(e.pulseIndex).toBe(10);
+  });
+
+  it("does not let an attractor hit override the composite level", async () => {
+    detectMock.mockReturnValue(["message_loop"]);
+    const h = await buildScheduler();
+    await runTo(h.scheduler, 10);
+
+    const attractor = h.gateway.operatorEvents.filter((e) => e.type === "attractor_detected");
+    expect(attractor).toHaveLength(1);
+
+    const metricsEvent = h.gateway.operatorEvents.find((e) => e.type === "stagnation_metrics");
+    expect(metricsEvent?.data?.["level"]).toBe("normal");
+
+    const committed = await h.eventRepo.getAfter("sim_stag");
+    expect(committed.some((e) => e.type === "stagnation_detected")).toBe(false);
+  });
+
+  it("bounds the stagnation detector input to the rolling window of recent pulses", async () => {
+    const h = await buildScheduler();
+    await h.eventRepo.append("sim_stag", [5, 8, 10, 12, 30, 49].map(seedEvent));
+
+    await runTo(h.scheduler, 50);
+
+    const idx = computeMock.mock.calls.findIndex((c) => c[1] === 50);
+    expect(idx).toBeGreaterThanOrEqual(0);
+
+    const passedEvents = computeMock.mock.calls[idx]![2];
+    expect(passedEvents.map((e) => e.pulseIndex).sort((a, b) => a - b)).toEqual([12, 30, 49]);
+
+    // The attractor detector is wired to the identical bounded window.
+    const detectEvents = detectMock.mock.calls[idx]![0];
+    expect(detectEvents).toBe(passedEvents);
+  });
+});

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -13,7 +13,7 @@ import type {
   EngineStepResult,
   EndingOffer,
 } from "@perfectman/shared";
-import { createSeededRng, ATTRACTOR_THRESHOLDS, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
+import { createSeededRng, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
 import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
@@ -29,7 +29,6 @@ import { serializeAgentState } from "../agent/agent-state-serializer.js";
 import type {
   ActionIntentOperatorData,
   AttractorDetectedOperatorData,
-  AttractorState,
   EventVisibilityData,
   StagnationMetricsOperatorData,
 } from "@perfectman/shared";
@@ -359,10 +358,7 @@ export class PulseScheduler {
       });
 
       for (const signature of detectAttractorStates(recentEvents, agentStatesMap)) {
-        // detectAttractorStates is typed string[] engine-side; keep only the
-        // known signatures so the operator payload holds a real AttractorState.
-        if (!(signature in ATTRACTOR_THRESHOLDS)) continue;
-        const attractorData: AttractorDetectedOperatorData = { signature: signature as AttractorState };
+        const attractorData: AttractorDetectedOperatorData = { signature };
         await this.emitOperatorEvent({
           type: "attractor_detected",
           simulationId: sim.id,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -14,7 +14,7 @@ import type {
   EndingOffer,
 } from "@perfectman/shared";
 import { createSeededRng } from "@perfectman/shared";
-import { runEngineStep, computeStagnationMetrics, filterVisibleEventsForAgent } from "@perfectman/engine";
+import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
 import type { RateLimitGate } from "./rate-limit-gate.js";
@@ -26,7 +26,12 @@ import type { OperatorProjection } from "./projections/operator-projection.js";
 import type { EngineEventBuilder } from "./engine-event-builder.js";
 import { payloadString } from "./payload-readers.js";
 import { serializeAgentState } from "../agent/agent-state-serializer.js";
-import type { ActionIntentOperatorData, EventVisibilityData } from "@perfectman/shared";
+import type {
+  ActionIntentOperatorData,
+  AttractorDetectedOperatorData,
+  EventVisibilityData,
+  StagnationMetricsOperatorData,
+} from "@perfectman/shared";
 import { buildAgentRuntimeInput } from "./runtime-input-builder.js";
 import { buildWorldSignals } from "./world-signals-builder.js";
 import type { AgentRuntimeContext, AgentRuntimeOutput } from "../agent/agent-runtime.types.js";
@@ -86,6 +91,12 @@ export class PulseScheduler {
   private pulseIndex = 0;
   /** Rolling context limit: how many recent events the LLM sees. */
   private static readonly CONTEXT_WINDOW_PULSES_LIMIT = 40;
+  /**
+   * Rolling window (in pulses) of committed events fed to the stagnation
+   * detectors. Bounds the input so early-run activity cannot mask a room that
+   * has since gone flat.
+   */
+  private static readonly STAGNATION_WINDOW_PULSES_LIMIT = 40;
   /**
    * Simulated simulation clock (monotonic, ms). Advances pulseIntervalMs per
    * pulse. All emotion/attention/cooldown math uses SIM time — wall clock
@@ -319,13 +330,52 @@ export class PulseScheduler {
 
     // Every 10 pulses: compute stagnation metrics
     if (this.pulseIndex > 0 && this.pulseIndex % 10 === 0) {
-      const recentEvents = await this.config.eventRepo.getCommittedThrough(sim.id, this.pulseIndex);
+      const committedThrough = await this.config.eventRepo.getCommittedThrough(sim.id, this.pulseIndex);
+      const windowFloor = this.pulseIndex - PulseScheduler.STAGNATION_WINDOW_PULSES_LIMIT;
+      const recentEvents = committedThrough.filter((e) => e.pulseIndex > windowFloor);
       const agentStatesMap = new Map<string, AgentState>();
       for (const agent of this.config.agents) {
         const stored = await this.config.agentStateRepo.get(sim.id, agent.id);
         if (stored) agentStatesMap.set(agent.id, stored);
       }
       const metrics = computeStagnationMetrics(sim.id, this.pulseIndex, recentEvents, agentStatesMap);
+
+      const metricsData: StagnationMetricsOperatorData = {
+        simulationId: metrics.simulationId,
+        pulseIndex: metrics.pulseIndex,
+        bdi: metrics.bdi,
+        rdv: metrics.rdv,
+        ige: metrics.ige,
+        cue: metrics.cue,
+        eri: metrics.eri,
+        isd: metrics.isd,
+        cns: metrics.cns,
+        compositeScore: metrics.compositeScore,
+        level: metrics.level,
+      };
+      await this.emitOperatorEvent({
+        type: "stagnation_metrics",
+        simulationId: sim.id,
+        agentId: "system",
+        pulseIndex: this.pulseIndex,
+        detail: `Stagnation metrics: ${metrics.level} (${metrics.compositeScore.toFixed(3)})`,
+        data: metricsData,
+        createdAt: Date.now(),
+      });
+
+      for (const signature of detectAttractorStates(recentEvents, agentStatesMap)) {
+        const attractorData: AttractorDetectedOperatorData = { signature };
+        await this.emitOperatorEvent({
+          type: "attractor_detected",
+          simulationId: sim.id,
+          agentId: "system",
+          pulseIndex: this.pulseIndex,
+          detail: `Attractor state detected: ${signature}`,
+          data: attractorData,
+          createdAt: Date.now(),
+        });
+      }
+
       if (metrics.level !== "normal") {
         const stagnationEvent = this.config.engineEventBuilder.fromStagnation(metrics, {
           simulationId: sim.id,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -13,7 +13,7 @@ import type {
   EngineStepResult,
   EndingOffer,
 } from "@perfectman/shared";
-import { createSeededRng } from "@perfectman/shared";
+import { createSeededRng, ATTRACTOR_THRESHOLDS, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
 import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
@@ -29,6 +29,7 @@ import { serializeAgentState } from "../agent/agent-state-serializer.js";
 import type {
   ActionIntentOperatorData,
   AttractorDetectedOperatorData,
+  AttractorState,
   EventVisibilityData,
   StagnationMetricsOperatorData,
 } from "@perfectman/shared";
@@ -91,12 +92,6 @@ export class PulseScheduler {
   private pulseIndex = 0;
   /** Rolling context limit: how many recent events the LLM sees. */
   private static readonly CONTEXT_WINDOW_PULSES_LIMIT = 40;
-  /**
-   * Rolling window (in pulses) of committed events fed to the stagnation
-   * detectors. Bounds the input so early-run activity cannot mask a room that
-   * has since gone flat.
-   */
-  private static readonly STAGNATION_WINDOW_PULSES_LIMIT = 40;
   /**
    * Simulated simulation clock (monotonic, ms). Advances pulseIntervalMs per
    * pulse. All emotion/attention/cooldown math uses SIM time — wall clock
@@ -331,7 +326,7 @@ export class PulseScheduler {
     // Every 10 pulses: compute stagnation metrics
     if (this.pulseIndex > 0 && this.pulseIndex % 10 === 0) {
       const committedThrough = await this.config.eventRepo.getCommittedThrough(sim.id, this.pulseIndex);
-      const windowFloor = this.pulseIndex - PulseScheduler.STAGNATION_WINDOW_PULSES_LIMIT;
+      const windowFloor = this.pulseIndex - STAGNATION_WINDOW_PULSES;
       const recentEvents = committedThrough.filter((e) => e.pulseIndex > windowFloor);
       const agentStatesMap = new Map<string, AgentState>();
       for (const agent of this.config.agents) {
@@ -364,7 +359,10 @@ export class PulseScheduler {
       });
 
       for (const signature of detectAttractorStates(recentEvents, agentStatesMap)) {
-        const attractorData: AttractorDetectedOperatorData = { signature };
+        // detectAttractorStates is typed string[] engine-side; keep only the
+        // known signatures so the operator payload holds a real AttractorState.
+        if (!(signature in ATTRACTOR_THRESHOLDS)) continue;
+        const attractorData: AttractorDetectedOperatorData = { signature: signature as AttractorState };
         await this.emitOperatorEvent({
           type: "attractor_detected",
           simulationId: sim.id,

--- a/packages/shared/src/constants/stagnation.ts
+++ b/packages/shared/src/constants/stagnation.ts
@@ -51,8 +51,13 @@ export const STAGNATION_WEIGHTS: Readonly<StagnationWeights> = {
 /** Intervention cooldown — minimum pulses between stagnation interventions */
 export const STAGNATION_INTERVENTION_COOLDOWN_PULSES = 20;
 
-/** Window size for computing metrics */
-export const STAGNATION_WINDOW_PULSES = 30;
+/**
+ * Rolling window (in pulses) of committed events fed to the stagnation
+ * detectors — `computeStagnationMetrics` and `detectAttractorStates`. Bounds
+ * the input so early-run activity cannot mask a room that has since gone flat.
+ * Exact N deferred to tuning (decision #125).
+ */
+export const STAGNATION_WINDOW_PULSES = 40;
 
 /**
  * 6 attractor state signatures (behavioral patterns indicating stagnation).

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -19,6 +19,8 @@ export const OPERATOR_EVENT_TYPES = [
   "intent_blocked",
   "intent_delayed",
   "stagnation_warning",
+  "stagnation_metrics",
+  "attractor_detected",
   "scheduler_error",
   "pulse_metrics",
   "agent_state_snapshot",
@@ -104,4 +106,15 @@ export type EventVisibilityData = {
   visibleToAgents: string[];
   content?: string;
   channelName?: string;
+};
+
+/** `stagnation_metrics` payload — the full composite + 7 sub-metrics, emitted
+ *  every stagnation cadence regardless of `level` (per-cadence telemetry).
+ *  `stagnation_warning` still fires only on a non-normal `level`. */
+export type StagnationMetricsOperatorData = StagnationMetrics;
+
+/** `attractor_detected` payload — one event per detected attractor signature.
+ *  Independent of the composite `level`, which it never overrides. */
+export type AttractorDetectedOperatorData = {
+  signature: string;
 };

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -1,5 +1,6 @@
 import type { EventPayload, EventType } from "../event/event.types.js";
 import type { IntentType } from "../intent/intent.types.js";
+import type { AttractorState } from "../constants/stagnation.js";
 
 /**
  * Operator event types the server may emit. Declared once here — the single
@@ -116,5 +117,5 @@ export type StagnationMetricsOperatorData = StagnationMetrics;
 /** `attractor_detected` payload — one event per detected attractor signature.
  *  Independent of the composite `level`, which it never overrides. */
 export type AttractorDetectedOperatorData = {
-  signature: string;
+  signature: AttractorState;
 };


### PR DESCRIPTION
## What

Restructures stagnation detection in the pulse scheduler — no threshold, weight, or formula changes:

- Feeds `computeStagnationMetrics` a rolling window of committed events, `STAGNATION_WINDOW_PULSES = 40` (shared constant, raised from an unused `30`; the pulse scheduler no longer keeps a local copy), instead of the full `getCommittedThrough` history.
- Calls `detectAttractorStates` (exported from `compute-stagnation-metrics.ts` but never invoked) alongside the composite score and emits one `attractor_detected` operator event per detected signature (`message_loop`, `silence_cascade`, ...). It stays independent of the composite `level` and never overrides it.
- Emits `stagnation_metrics` — composite plus all seven sub-metrics — as an operator event every stagnation cadence regardless of `level`. `stagnation_warning` still fires only on a non-normal `level`.
- Adds `stagnation_metrics` and `attractor_detected` to `OPERATOR_EVENT_TYPES`; `AttractorDetectedOperatorData.signature` is the `AttractorState` union, validated against `ATTRACTOR_THRESHOLDS` at the emission site (`detectAttractorStates` stays `string[]` engine-side).
- Known, deferred to #129: an empty/sparse window (room silent for 40+ pulses) leaves the metrics on neutral no-data defaults that sum to `0.604`, already `>= STAGNATION_THRESHOLDS.yellow (0.60)`, so a cadence commits `stagnation_detected` off defaults not a real measurement. Thresholds are out of scope here (decision #125). A threshold-free fix would gate the composite commit on a minimum window-activity floor; not implemented unilaterally.
- 7 tests: per-cadence emit at `level: normal`, `attractor_detected` on a seeded alternating message-loop run, one event per detected signature, no `level` override on an attractor hit, metrics input bounded to the window (pulses `5/8/10` excluded at pulse 50), empty-window `0.604`/`yellow` pin, sparse-window non-`normal` pin.

## Why

`computeStagnationMetrics` was fed the entire committed history, so a lively opening stretch kept the composite score healthy long after a room went inert. `detectAttractorStates` shipped with `message_loop` / `silence_cascade` / `dormant_agents` / etc. signatures but had no call site, and the cadence only surfaced telemetry once `level` was already non-normal — leaving nothing to tune the detectors against.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+7)
- 119 files, 1324 tests passed; `pnpm build` + per-package `pnpm --filter … typecheck` (shared/engine/server) clean; `pnpm test:gate` PASS (audit-tests 1155 its, 0 violations)
- window bound proven end to end: at pulse 50 the detector input is `[12, 30, 49]`, pulses `5/8/10` excluded

Closes #133
