### PR TITLE
feat(shared): add intensity to memory-write proposal and Memory type (#134)

### DIFF
--- a/packages/engine/src/perception/__tests__/memory-salience.test.ts
+++ b/packages/engine/src/perception/__tests__/memory-salience.test.ts
@@ -13,6 +13,7 @@ function memory(overrides: Partial<Memory> = {}): Memory {
     summary: "something happened",
     emotionalTone: "neutral",
     confidence: 0.5,
+    intensity: 0,
     unresolved: false,
     createdAt: 100,
     lastReinforcedAt: 100,

--- a/packages/eval/src/bench/persona-aware-mock.ts
+++ b/packages/eval/src/bench/persona-aware-mock.ts
@@ -8,7 +8,7 @@
  * quality from prompt/persona quality on the bench.
  */
 
-import type { AgentRuntimeInput, AvailableAction } from "@perfectman/shared";
+import type { AgentRuntimeInput, AvailableAction, MemoryWriteProposal } from "@perfectman/shared";
 import type { AgentRuntimeContext, BuiltPrompt, LLMConfig, LLMProvider, LLMProviderResult } from "@perfectman/server";
 import { createLLMProvider } from "@perfectman/server";
 import type { PersonaPack } from "@perfectman/shared";
@@ -351,7 +351,7 @@ export class PersonaAwareMockProvider implements LLMProvider {
     return pickLexicon(lexicon) ?? "This is not for the whole room.";
   }
 
-  private maybeMemoryWrite(agentId: string): unknown[] {
+  private maybeMemoryWrite(agentId: string): MemoryWriteProposal[] {
     // Charged scenes (suspicion/resentment/affection ≥ 0.3) produce biased
     // memory; neutral scenes write only occasionally.
     const social = this.lastInput?.emotionalState.socialEmotions;
@@ -371,7 +371,7 @@ export class PersonaAwareMockProvider implements LLMProvider {
         summary: memory.summary,
         emotionalTone: memory.emotionalTone,
         confidence: memory.confidence,
-        intensity: 0,
+        intensity: memory.intensity ?? 0,
         unresolved: memory.unresolved,
       },
     ];

--- a/packages/eval/src/bench/persona-aware-mock.ts
+++ b/packages/eval/src/bench/persona-aware-mock.ts
@@ -371,6 +371,7 @@ export class PersonaAwareMockProvider implements LLMProvider {
         summary: memory.summary,
         emotionalTone: memory.emotionalTone,
         confidence: memory.confidence,
+        intensity: 0,
         unresolved: memory.unresolved,
       },
     ];

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -459,6 +459,7 @@ function buildAgentState(spec: AgentSeedSpec, scenario: RoleplayScenario): Agent
     summary: m.summary,
     emotionalTone: m.emotionalTone,
     confidence: m.confidence ?? 0.8,
+    intensity: m.intensity ?? 0,
     unresolved: m.unresolved ?? false,
     createdAt: now,
     lastReinforcedAt: now,

--- a/packages/eval/src/test/persona-mock-memory-writes.test.ts
+++ b/packages/eval/src/test/persona-mock-memory-writes.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALL_PERSONAS,
+  type AgentRuntimeInput,
+  type MemorySeed,
+  type PersonaPack,
+} from "@perfectman/shared";
+import type { AgentRuntimeContext, BuiltPrompt } from "@perfectman/server";
+import { PersonaAwareMockProvider } from "../bench/persona-aware-mock.js";
+
+const CONTEXT: AgentRuntimeContext = { pulseIndex: 0, now: 0 };
+const PROMPT: BuiltPrompt = {
+  system: "sys",
+  user: "user",
+  inputTokensEstimate: 10,
+  purpose: "action_intent",
+  version: "v1",
+  templateVersion: "t1",
+};
+
+function makePack(seed: MemorySeed): PersonaPack {
+  return {
+    personaId: "bruno",
+    displayName: "Bruno",
+    archetype: "observer",
+    identityFrame: "x",
+    voiceGuidelines: [],
+    styleExamples: ["normal gesture"],
+    relationshipBiases: {},
+    language: "pt-BR",
+    memorySeeds: [seed],
+    pendingIntentions: [],
+    socialTheory: [],
+    edgeProfile: {
+      chaosCap: "medium",
+      impulseBehaviors: [],
+      triggers: [],
+      maskTells: [],
+      privateMotiveLexicon: ["I want to be seen."],
+      hardLimits: [],
+    },
+    presenceProfile: {
+      responseDelayMs: [2000, 15000],
+      silenceTolerancePulses: 6,
+      messageLength: "short",
+      punctuationTells: [],
+    },
+    sampling: { temperature: 0.7, repetitionPenalty: 1.1, topP: 0.9, maxTokens: 256 },
+  };
+}
+
+function makeInput(): AgentRuntimeInput {
+  return {
+    simulationId: "sim-1",
+    agentId: "agent-a",
+    personaConfig: ALL_PERSONAS[0]!,
+    perceptionPacket: {
+      agentId: "agent-a",
+      triggeringEvent: null,
+      visibleContextEvents: [],
+      ownRecentUtterances: [],
+      involvedPeople: [],
+      relevantChannels: [],
+      relevantMemories: [],
+      translatedEmotionalState: {
+        moodDescription: "Neutral.",
+        socialContext: "Calm.",
+        relationalFlavors: [],
+        pressureDescriptions: [],
+        inhibitionDescriptions: [],
+      },
+      availableActions: [],
+    },
+    emotionalState: {
+      coreMood: {
+        valence: 0,
+        arousal: 0,
+        stability: 0.5,
+        energy: 0.5,
+        circumplexAngle: 0,
+        circumplexRadius: 0,
+        momentumValence: 0,
+        momentumArousal: 0,
+      },
+      socialEmotions: {
+        jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0,
+        resentment: 0, suspicion: 0.9, admiration: 0, contempt: 0, neediness: 0,
+        socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0,
+      },
+      relationalStates: new Map(),
+    },
+    activeMotivations: [],
+    activePressures: [],
+    activeInhibitions: [],
+    relevantMemories: [],
+    availableActions: [
+      { intentType: "send_message", channelTargets: ["general"], personTargets: [], blocked: false },
+    ],
+    budgetPriority: "normal",
+    triggeringReason: "cold_start",
+  };
+}
+
+type MockIntent = { intentType: string; memoryWrites: { intensity: number }[] };
+
+describe("PersonaAwareMockProvider memory-write intensity", () => {
+  it.each([
+    { label: "defaults a seed without intensity to 0 (unchanged behavior)", seed: {}, expected: 0 },
+    { label: "carries the seed's intensity onto the proposal", seed: { intensity: 0.7 }, expected: 0.7 },
+  ])("$label", async ({ seed, expected }) => {
+    const provider = new PersonaAwareMockProvider(
+      makePack({
+        type: "relationship",
+        subjectAgentIds: ["agent-b"],
+        summary: "agent-b never replies first",
+        emotionalTone: "ache",
+        confidence: 0.7,
+        unresolved: true,
+        ...seed,
+      }),
+      42,
+    );
+
+    const result = await provider.generateIntent(makeInput(), CONTEXT, PROMPT);
+    const intent = JSON.parse(result.content) as MockIntent;
+
+    expect(intent.intentType).toBe("send_message");
+    expect(intent.memoryWrites).toHaveLength(1);
+    expect(intent.memoryWrites[0]!.intensity).toBe(expected);
+  });
+});

--- a/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
@@ -16,6 +16,7 @@ function memory(overrides: Partial<Memory> = {}): Memory {
     summary: "bruno me ignorou de propósito",
     emotionalTone: "resentful",
     confidence: 0.8,
+    intensity: 0,
     unresolved: true,
     createdAt: 1,
     lastReinforcedAt: Date.now(),

--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -52,6 +52,62 @@ describe("IntentParser", () => {
     expect(result.intent.privateMotiveSummary).toBe("Initiate contact");
   });
 
+  it("carries a memory-write proposal's intensity through into the ActionIntent", () => {
+    const rawText = JSON.stringify({
+      intentType: "send_message",
+      channelTarget: "general-id",
+      personTargets: [],
+      visibleContent: "Hey there!",
+      privateMotiveSummary: "Initiate contact",
+      emotionDrivers: [],
+      motivationDrivers: [],
+      memoryWrites: [
+        {
+          type: "emotional_residue",
+          subjectAgentIds: ["agent-peer"],
+          summary: "that exchange stung",
+          emotionalTone: "hurt",
+          confidence: 0.8,
+          intensity: 0.9,
+          unresolved: true,
+        },
+      ],
+    });
+
+    const result = IntentParser.parse(rawText, actorId, availableActions);
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.memoryWrites).toHaveLength(1);
+    expect(result.intent.memoryWrites[0]?.intensity).toBe(0.9);
+  });
+
+  it("applies safe fallback when a memory-write proposal's intensity is out of range", () => {
+    const rawText = JSON.stringify({
+      intentType: "send_message",
+      channelTarget: "general-id",
+      personTargets: [],
+      visibleContent: "Hey there!",
+      privateMotiveSummary: "Initiate contact",
+      emotionDrivers: [],
+      motivationDrivers: [],
+      memoryWrites: [
+        {
+          type: "episodic",
+          subjectAgentIds: [],
+          summary: "x",
+          emotionalTone: "neutral",
+          confidence: 0.5,
+          intensity: 1.5,
+          unresolved: false,
+        },
+      ],
+    });
+
+    const result = IntentParser.parse(rawText, actorId, availableActions);
+
+    expect(result.fallbackApplied).toBe(true);
+  });
+
   it("should successfully parse fenced markdown codeblock JSON", () => {
     const rawText = `
 Here is my response:

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -84,6 +84,7 @@ describe("PromptBuilder", () => {
           summary: "This friend is often quiet and indirect",
           emotionalTone: "suspicion",
           confidence: 0.8,
+          intensity: 0,
           unresolved: true,
           createdAt: Date.now(),
           lastReinforcedAt: Date.now(),

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -142,6 +142,7 @@ export type InitialChannelConfig = {
 
 export type InitialMemory = Pick<Memory, "type" | "subjectAgentIds" | "summary" | "emotionalTone"> & {
   confidence?: number;
+  intensity?: number;
 };
 
 export type AgentConfig = {
@@ -696,6 +697,7 @@ function makeAgentState(agent: AgentConfig, simulationId: string): AgentState {
       summary: m.summary,
       emotionalTone: m.emotionalTone,
       confidence: m.confidence ?? 0.8,
+      intensity: m.intensity ?? 0,
       unresolved: false,
       createdAt: now - 1,
       lastReinforcedAt: now - 1,

--- a/packages/server/src/persistence/__tests__/repository-contract.ts
+++ b/packages/server/src/persistence/__tests__/repository-contract.ts
@@ -120,6 +120,7 @@ function makeMemory(id: string, agentId: string, simulationId = "sim1", subjectI
     summary: `Memory ${id}`,
     emotionalTone: "neutral",
     confidence: 0.8,
+    intensity: 0,
     unresolved: false,
     createdAt: 1700000000000,
     lastReinforcedAt: 1700000000000,

--- a/packages/server/src/persistence/__tests__/sqlite-memory-repository.test.ts
+++ b/packages/server/src/persistence/__tests__/sqlite-memory-repository.test.ts
@@ -50,12 +50,13 @@ describe("SqliteMemoryRepository", () => {
     const memory = makeMemory("m1", "a1", "sim1");
     await repo.upsert(memory);
 
-    const updated: Memory = { ...memory, confidence: 0.5, unresolved: true, summary: "updated" };
+    const updated: Memory = { ...memory, confidence: 0.5, intensity: 0.7, unresolved: true, summary: "updated" };
     await repo.upsert(updated);
 
     const memories = await repo.getByAgent("sim1", "a1");
     expect(memories).toHaveLength(1);
     expect(memories[0]?.confidence).toBeCloseTo(0.5);
+    expect(memories[0]?.intensity).toBeCloseTo(0.7);
     expect(memories[0]?.unresolved).toBe(true);
     expect(memories[0]?.summary).toBe("updated");
   });

--- a/packages/server/src/persistence/__tests__/sqlite-test-helpers.ts
+++ b/packages/server/src/persistence/__tests__/sqlite-test-helpers.ts
@@ -127,6 +127,7 @@ export function makeMemory(id: string, agentId: string, simulationId: string): M
     summary: "a2 was friendly to me",
     emotionalTone: "positive",
     confidence: 0.9,
+    intensity: 0,
     unresolved: false,
     createdAt: Date.now(),
     lastReinforcedAt: Date.now(),

--- a/packages/server/src/persistence/sqlite/memory-repository.ts
+++ b/packages/server/src/persistence/sqlite/memory-repository.ts
@@ -16,6 +16,7 @@ type MemoryRow = {
   summary: string;
   emotional_tone: string;
   confidence: number;
+  intensity: number;
   unresolved: number;
   created_at: number;
   last_reinforced_at: number;
@@ -32,6 +33,7 @@ function rowToMemory(row: MemoryRow): Memory {
     summary: row.summary,
     emotionalTone: row.emotional_tone as Memory["emotionalTone"],
     confidence: row.confidence,
+    intensity: row.intensity,
     unresolved: row.unresolved === 1,
     createdAt: row.created_at,
     lastReinforcedAt: row.last_reinforced_at,
@@ -58,8 +60,8 @@ export class SqliteMemoryRepository implements IMemoryRepository {
       .prepare(
         `INSERT INTO memories
            (id, agent_id, simulation_id, type, subject_agent_ids, source_event_ids,
-            summary, emotional_tone, confidence, unresolved, created_at, last_reinforced_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            summary, emotional_tone, confidence, intensity, unresolved, created_at, last_reinforced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
            type               = excluded.type,
            subject_agent_ids  = excluded.subject_agent_ids,
@@ -67,6 +69,7 @@ export class SqliteMemoryRepository implements IMemoryRepository {
            summary            = excluded.summary,
            emotional_tone     = excluded.emotional_tone,
            confidence         = excluded.confidence,
+           intensity          = excluded.intensity,
            unresolved         = excluded.unresolved,
            last_reinforced_at = excluded.last_reinforced_at`,
       )
@@ -80,6 +83,7 @@ export class SqliteMemoryRepository implements IMemoryRepository {
         memory.summary,
         memory.emotionalTone,
         memory.confidence,
+        memory.intensity,
         memory.unresolved ? 1 : 0,
         memory.createdAt,
         memory.lastReinforcedAt,

--- a/packages/server/src/persistence/sqlite/schema.ts
+++ b/packages/server/src/persistence/sqlite/schema.ts
@@ -91,6 +91,10 @@ CREATE TABLE IF NOT EXISTS memories (
   summary             TEXT NOT NULL,
   emotional_tone      TEXT NOT NULL DEFAULT 'neutral',
   confidence          REAL NOT NULL DEFAULT 0.8,
+  -- TODO(perfectman): no migration runner exists — CREATE TABLE IF NOT EXISTS
+  -- will not add this column to an aged on-disk DB. Before SqliteMemoryRepository
+  -- is wired into createRepositories, run:
+  --   ALTER TABLE memories ADD COLUMN intensity REAL NOT NULL DEFAULT 0
   intensity           REAL NOT NULL DEFAULT 0,
   unresolved          INTEGER NOT NULL DEFAULT 0,   -- boolean
   created_at          INTEGER NOT NULL,

--- a/packages/server/src/persistence/sqlite/schema.ts
+++ b/packages/server/src/persistence/sqlite/schema.ts
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS memories (
   summary             TEXT NOT NULL,
   emotional_tone      TEXT NOT NULL DEFAULT 'neutral',
   confidence          REAL NOT NULL DEFAULT 0.8,
+  intensity           REAL NOT NULL DEFAULT 0,
   unresolved          INTEGER NOT NULL DEFAULT 0,   -- boolean
   created_at          INTEGER NOT NULL,
   last_reinforced_at  INTEGER NOT NULL

--- a/packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts
@@ -231,6 +231,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
         summary: "I told bruno everything",
         emotionalTone: "neutral",
         confidence: 0.9,
+        intensity: 0,
         unresolved: false,
       }],
     });

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -150,6 +150,7 @@ describe("IntentResolver", () => {
     const memoryEvent = result.committedEvents.find((e) => e.type === "memory_written");
     expect(memoryEvent).toBeDefined();
     expect(memoryEvent!.payload["intensity"]).toBe(0.9);
+    expect(memoryEvent!.payload["proposalIndex"]).toBe(0);
   });
 
   it("blocks intent with missing motive summary", async () => {

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -132,6 +132,26 @@ describe("IntentResolver", () => {
     expect(result.committedEvents[0]!.type).toBe("message_sent");
   });
 
+  it("carries a memory proposal's intensity onto the committed memory_written payload", async () => {
+    const intent = makeIntent({
+      intentType: "send_message",
+      channelTarget: CHANNEL_ID,
+      memoryWrites: [{
+        type: "emotional_residue",
+        subjectAgentIds: ["agent_2"],
+        summary: "that exchange stung",
+        emotionalTone: "hurt",
+        confidence: 0.8,
+        intensity: 0.9,
+        unresolved: true,
+      }],
+    });
+    const result = await resolver.resolve(intent, ctx());
+    const memoryEvent = result.committedEvents.find((e) => e.type === "memory_written");
+    expect(memoryEvent).toBeDefined();
+    expect(memoryEvent!.payload["intensity"]).toBe(0.9);
+  });
+
   it("blocks intent with missing motive summary", async () => {
     const intent = makeIntent({ privateMotiveSummary: "" });
     const result = await resolver.resolve(intent, ctx());

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -123,7 +123,7 @@ function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").E
     availableActions: [],
     initiativeCandidates: [],
     memoryProposals: memory
-      ? [{ type: "relationship", subjectAgentIds: ["agent-B"], summary: "agent-B seems untrustworthy", emotionalTone: "suspicious", confidence: 0.7, intensity: 0, unresolved: true }]
+      ? [{ type: "relationship", subjectAgentIds: ["agent-B"], summary: "agent-B seems untrustworthy", emotionalTone: "suspicious", confidence: 0.7, intensity: 0.6, unresolved: true }]
       : [],
     noOpRecord: { agentId: "agent_1", pulseIndex: 0, privateMotiveSummary: "nothing to do", reason: "test" },
     operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 1, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
@@ -253,7 +253,7 @@ describe("PulseScheduler", () => {
     const mem = events.filter((e) => e.type === "memory_written");
     expect(mem).toHaveLength(1);
     expect(mem[0]!.payload["summary"]).toBe("agent-B seems untrustworthy");
-    expect(mem[0]!.payload["intensity"]).toBe(0);
+    expect(mem[0]!.payload["intensity"]).toBe(0.6);
     // noOpRecord present with needsLLM=false — the LLM path must not be invoked
     expect(mockAgentRuntime.generateIntent).not.toHaveBeenCalled();
   });

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -123,7 +123,7 @@ function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").E
     availableActions: [],
     initiativeCandidates: [],
     memoryProposals: memory
-      ? [{ type: "relationship", subjectAgentIds: ["agent-B"], summary: "agent-B seems untrustworthy", emotionalTone: "suspicious", confidence: 0.7, unresolved: true }]
+      ? [{ type: "relationship", subjectAgentIds: ["agent-B"], summary: "agent-B seems untrustworthy", emotionalTone: "suspicious", confidence: 0.7, intensity: 0, unresolved: true }]
       : [],
     noOpRecord: { agentId: "agent_1", pulseIndex: 0, privateMotiveSummary: "nothing to do", reason: "test" },
     operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 1, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -253,6 +253,7 @@ describe("PulseScheduler", () => {
     const mem = events.filter((e) => e.type === "memory_written");
     expect(mem).toHaveLength(1);
     expect(mem[0]!.payload["summary"]).toBe("agent-B seems untrustworthy");
+    expect(mem[0]!.payload["intensity"]).toBe(0);
     // noOpRecord present with needsLLM=false — the LLM path must not be invoked
     expect(mockAgentRuntime.generateIntent).not.toHaveBeenCalled();
   });

--- a/packages/server/src/simulation/engine-event-builder.ts
+++ b/packages/server/src/simulation/engine-event-builder.ts
@@ -1,3 +1,4 @@
+import { memoryWrittenPayload } from "./memory-written-payload.js";
 import type {
   DelusionGap,
   EmergentGoal,
@@ -62,15 +63,7 @@ export class EngineEventBuilder {
         channelId: ctx.channelId,
         actorId: ctx.agentId,
         type: "memory_written",
-        payload: {
-          memoryType: proposal.type,
-          summary: proposal.summary,
-          emotionalTone: proposal.emotionalTone,
-          confidence: proposal.confidence,
-          intensity: proposal.intensity,
-          unresolved: proposal.unresolved,
-          subjectAgentIds: proposal.subjectAgentIds,
-        },
+        payload: memoryWrittenPayload(proposal),
         sourceEventIds: [],
         emotionalSalience: salience(mag),
         pulseIndex: ctx.pulseIndex,

--- a/packages/server/src/simulation/engine-event-builder.ts
+++ b/packages/server/src/simulation/engine-event-builder.ts
@@ -67,6 +67,7 @@ export class EngineEventBuilder {
           summary: proposal.summary,
           emotionalTone: proposal.emotionalTone,
           confidence: proposal.confidence,
+          intensity: proposal.intensity,
           unresolved: proposal.unresolved,
           subjectAgentIds: proposal.subjectAgentIds,
         },

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -563,6 +563,7 @@ export class IntentResolver {
         summary: proposal.summary,
         emotionalTone: proposal.emotionalTone,
         confidence: proposal.confidence,
+        intensity: proposal.intensity,
         unresolved: proposal.unresolved,
         subjectAgentIds: proposal.subjectAgentIds,
         proposalIndex: i,

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -15,6 +15,7 @@ import type {
 } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
 import { validateIntentPure } from "@perfectman/engine";
+import { memoryWrittenPayload } from "./memory-written-payload.js";
 import type { RateLimitGate } from "./rate-limit-gate.js";
 import type { ChannelRegistry } from "./channel-registry.js";
 
@@ -558,16 +559,7 @@ export class IntentResolver {
       channelId: ctx.channelId,
       actorId: intent.actorId,
       type: "memory_written" as const,
-      payload: {
-        memoryType: proposal.type,
-        summary: proposal.summary,
-        emotionalTone: proposal.emotionalTone,
-        confidence: proposal.confidence,
-        intensity: proposal.intensity,
-        unresolved: proposal.unresolved,
-        subjectAgentIds: proposal.subjectAgentIds,
-        proposalIndex: i,
-      },
+      payload: { ...memoryWrittenPayload(proposal), proposalIndex: i },
       sourceIntentId: intent.id,
       sourceEventIds: [],
       emotionalSalience: "low",

--- a/packages/server/src/simulation/memory-written-payload.ts
+++ b/packages/server/src/simulation/memory-written-payload.ts
@@ -1,0 +1,13 @@
+import type { EventPayload, MemoryWriteProposal } from "@perfectman/shared";
+
+export function memoryWrittenPayload(proposal: MemoryWriteProposal): EventPayload {
+  return {
+    memoryType: proposal.type,
+    summary: proposal.summary,
+    emotionalTone: proposal.emotionalTone,
+    confidence: proposal.confidence,
+    intensity: proposal.intensity,
+    unresolved: proposal.unresolved,
+    subjectAgentIds: proposal.subjectAgentIds,
+  };
+}

--- a/packages/server/src/simulation/world/__tests__/world-evaluator.test.ts
+++ b/packages/server/src/simulation/world/__tests__/world-evaluator.test.ts
@@ -672,6 +672,7 @@ describe("WorldEvaluator.runReview — deterministic gate timeline", () => {
         summary: `memory summary ${i}`,
         emotionalTone: "neutral",
         confidence: 0.8,
+        intensity: 0,
         unresolved: false,
         createdAt: 100 + i,
         lastReinforcedAt: 100 + i,

--- a/packages/shared/src/__tests__/intent-packet-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-packet-schema.test.ts
@@ -81,6 +81,31 @@ describe("MemoryWriteProposal", () => {
     expect(contract).toContain('"type" (required): one of: episodic, relationship, self, social_theory, pending_intention, emotional_residue');
     expect(contract).toContain('"summary" (required): string');
     expect(contract).toContain('"confidence" (required): number (0-1)');
+    expect(contract).toContain('"intensity" (required): number (0-1)');
     expect(contract).toContain('"unresolved" (required): boolean');
+  });
+
+  const validProposal = {
+    type: "episodic" as const,
+    subjectAgentIds: [],
+    summary: "something happened",
+    emotionalTone: "neutral",
+    confidence: 0.5,
+    intensity: 0.5,
+    unresolved: false,
+  };
+
+  it("accepts intensity at the [0,1] bounds", () => {
+    expect(() => MemoryWriteProposalSchema.parse({ ...validProposal, intensity: 0 })).not.toThrow();
+    expect(() => MemoryWriteProposalSchema.parse({ ...validProposal, intensity: 1 })).not.toThrow();
+  });
+
+  it.each([-0.1, 1.1, 2])("rejects out-of-range intensity %s", (intensity) => {
+    expect(() => MemoryWriteProposalSchema.parse({ ...validProposal, intensity })).toThrow();
+  });
+
+  it("rejects a proposal missing intensity", () => {
+    const { intensity: _omitted, ...withoutIntensity } = validProposal;
+    expect(() => MemoryWriteProposalSchema.parse(withoutIntensity)).toThrow();
   });
 });

--- a/packages/shared/src/fixtures/helpers.ts
+++ b/packages/shared/src/fixtures/helpers.ts
@@ -240,6 +240,7 @@ export function makeMemory(
   summary: string,
   emotionalTone: Memory["emotionalTone"] = "neutral",
   confidence = 0.8,
+  intensity = 0,
 ): Memory {
   return {
     id,
@@ -251,6 +252,7 @@ export function makeMemory(
     summary,
     emotionalTone,
     confidence,
+    intensity,
     unresolved: false,
     createdAt: Date.now(),
     lastReinforcedAt: Date.now(),

--- a/packages/shared/src/intent/intent.schema.ts
+++ b/packages/shared/src/intent/intent.schema.ts
@@ -34,6 +34,7 @@ export const MemoryWriteProposalSchema = z.object({
   summary: z.string().min(1),
   emotionalTone: z.string().min(1),
   confidence: z.number().min(0).max(1),
+  intensity: z.number().min(0).max(1),
   unresolved: z.boolean(),
 });
 

--- a/packages/shared/src/memory/memory.types.ts
+++ b/packages/shared/src/memory/memory.types.ts
@@ -16,6 +16,7 @@ export type Memory = {
   summary: string;
   emotionalTone: string;
   confidence: number; // [0, 1]
+  intensity: number; // [0, 1]
   unresolved: boolean;
   createdAt: number;
   lastReinforcedAt: number;
@@ -27,5 +28,6 @@ export type MemoryWriteProposal = {
   summary: string;
   emotionalTone: string;
   confidence: number;
+  intensity: number; // [0, 1]
   unresolved: boolean;
 };

--- a/packages/shared/src/persona-packs/persona-packs.test.ts
+++ b/packages/shared/src/persona-packs/persona-packs.test.ts
@@ -87,6 +87,10 @@ describe("PersonaPacks", () => {
         expect(VALID_MEMORY_TYPES).toContain(seed.type);
         expect(seed.confidence, `${pack.personaId}.seed.confidence`).toBeGreaterThanOrEqual(0);
         expect(seed.confidence, `${pack.personaId}.seed.confidence`).toBeLessThanOrEqual(1);
+        if (seed.intensity !== undefined) {
+          expect(seed.intensity, `${pack.personaId}.seed.intensity`).toBeGreaterThanOrEqual(0);
+          expect(seed.intensity, `${pack.personaId}.seed.intensity`).toBeLessThanOrEqual(1);
+        }
         expect(seed.summary.length, `${pack.personaId}.seed.summary`).toBeGreaterThan(0);
       }
     }

--- a/packages/shared/src/persona/persona-pack.types.ts
+++ b/packages/shared/src/persona/persona-pack.types.ts
@@ -19,6 +19,7 @@ export type MemorySeed = {
   summary: string;
   emotionalTone: string;
   confidence: number;
+  intensity?: number; // [0, 1]
   unresolved: boolean;
 };
 

--- a/packages/shared/src/scenarios/scenario.types.ts
+++ b/packages/shared/src/scenarios/scenario.types.ts
@@ -34,6 +34,7 @@ export type MemorySeedSpec = {
   summary: string;
   emotionalTone: string;
   confidence?: number;
+  intensity?: number;
   unresolved?: boolean;
 };
 


### PR DESCRIPTION
## What

Adds a numeric `intensity` field (0–1) to memory-write proposals and stored memories, a prefactor for decay logic that will weight emotionally intense memories:

- `MemoryWriteProposalSchema` gains `intensity: z.number().min(0).max(1)` next to `confidence`; the JSON-Schema mirror and `memoryWriteProposalFieldContract()` derive it automatically.
- `MemoryWriteProposal` and `Memory` types gain required `intensity: number`.
- `IntentParser` carries `intensity` from a parsed memory-write proposal into the `ActionIntent` unchanged via `composeIntentPacket`'s wholesale `memoryWrites` passthrough; an out-of-range value drops to the safe fallback.
- SQLite `memories` table gains `intensity REAL NOT NULL DEFAULT 0`, wired through `rowToMemory` and `upsert` to mirror `confidence`.
- Optional `intensity?: number` on `MemorySeedSpec` and `InitialMemory`; scenario and eval seed mappers default it to `0`, so no seed data changes and no behaviour change.
- Free-text `emotionalTone` (valence) untouched.
- 7 tests: schema accepts `intensity` at `0`/`1`, rejects `-0.1`/`1.1`/`2`, rejects the field missing; parser round-trips `intensity: 0.9` into the intent and falls back on `intensity: 1.5`; field contract lists `"intensity" (required): number (0-1)`; SQLite round-trip persists `0.7`.

## Why

`intensity` is a pure prefactor for the memory-decay slices (#136, #137), which will compute `d_eff = d_type * (1 - 0.6 * intensity)`. Landing the field, its `[0,1]` bound, the parser passthrough, and the persistence column first keeps those slices scoped to decay behaviour alone.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1322 passed, +7)
- `pnpm build` PASS across `shared`/`engine`/`server`/`eval`; the zod-vs-JSON-Schema drift test stays green with the new field.

Closes #134
