### PR TITLE
fix(server): resolve reply/reaction targets via event handles (#135)

### DIFF
--- a/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
+++ b/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { buildPerceptionPacket } from "../build-perception-packet.js";
+import type {
+  AgentState,
+  AttentionResult,
+  CommittedEvent,
+  TranslatedEmotionalState,
+} from "@perfectman/shared";
+
+function agent(): AgentState {
+  return {
+    agentId: "agent-me",
+    simulationId: "sim-1",
+    personaId: "p1",
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function event(id: string, actor: string, type: CommittedEvent["type"] = "message_sent"): CommittedEvent {
+  return {
+    id,
+    simulationId: "sim-1",
+    channelId: "ch-1",
+    actorId: actor,
+    type,
+    payload: { content: `msg ${id}` },
+    createdAt: 1,
+    pulseIndex: 1,
+    sourceEventIds: [],
+    emotionalSalience: "low",
+    visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
+  };
+}
+
+const translated: TranslatedEmotionalState = {
+  moodDescription: "",
+  socialContext: "",
+  relationalFlavors: [],
+  pressureDescriptions: [],
+  inhibitionDescriptions: [],
+};
+
+const attention: AttentionResult = {
+  noticed: true,
+  dueScore: 1,
+  reasons: [],
+  needsLLM: true,
+  triggeringReason: "direct_mention",
+};
+
+describe("buildPerceptionPacket eventHandles", () => {
+  it("assigns e1 to the triggering event, then e2.. to visible-context events in order", () => {
+    const trigger = event("evt_trigger", "agent-peer");
+    const ctx1 = event("evt_ctx_1", "agent-x");
+    const ctx2 = event("evt_ctx_2", "agent-y");
+
+    const packet = buildPerceptionPacket(
+      agent(),
+      [ctx1, ctx2, trigger],
+      trigger,
+      [],
+      attention,
+      translated,
+      [],
+    );
+
+    expect(packet.eventHandles).toEqual({
+      e1: "evt_trigger",
+      e2: "evt_ctx_1",
+      e3: "evt_ctx_2",
+    });
+    // the triggering event is not double-counted as a context event
+    expect(packet.visibleContextEvents.map((e) => e.id)).toEqual(["evt_ctx_1", "evt_ctx_2"]);
+  });
+
+  it("starts handles at e1 for the context events when there is no triggering event", () => {
+    const ctx1 = event("evt_a", "agent-x");
+    const ctx2 = event("evt_b", "agent-y");
+
+    const packet = buildPerceptionPacket(agent(), [ctx1, ctx2], null, [], attention, translated, []);
+
+    expect(packet.eventHandles).toEqual({ e1: "evt_a", e2: "evt_b" });
+  });
+
+  it("returns an empty handle map when nothing is in view", () => {
+    const packet = buildPerceptionPacket(agent(), [], null, [], attention, translated, []);
+    expect(packet.eventHandles).toEqual({});
+  });
+});

--- a/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
+++ b/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
@@ -1,47 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { buildPerceptionPacket } from "../build-perception-packet.js";
+import { makeAgent, makeEvent } from "../../__tests__/fixtures.js";
 import type {
-  AgentState,
   AttentionResult,
-  CommittedEvent,
   TranslatedEmotionalState,
 } from "@perfectman/shared";
-
-function agent(): AgentState {
-  return {
-    agentId: "agent-me",
-    simulationId: "sim-1",
-    personaId: "p1",
-    presence: "active",
-    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
-    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
-    relationalStates: new Map(),
-    memories: [],
-    initiativeAccumulators: [],
-    lastProcessedEventId: null,
-    lastActionAt: null,
-    lastRuminationPulse: null,
-    arrivalPulse: null,
-    createdAt: 0,
-    updatedAt: 0,
-  };
-}
-
-function event(id: string, actor: string, type: CommittedEvent["type"] = "message_sent"): CommittedEvent {
-  return {
-    id,
-    simulationId: "sim-1",
-    channelId: "ch-1",
-    actorId: actor,
-    type,
-    payload: { content: `msg ${id}` },
-    createdAt: 1,
-    pulseIndex: 1,
-    sourceEventIds: [],
-    emotionalSalience: "low",
-    visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
-  };
-}
 
 const translated: TranslatedEmotionalState = {
   moodDescription: "",
@@ -61,12 +24,12 @@ const attention: AttentionResult = {
 
 describe("buildPerceptionPacket eventHandles", () => {
   it("assigns e1 to the triggering event, then e2.. to visible-context events in order", () => {
-    const trigger = event("evt_trigger", "agent-peer");
-    const ctx1 = event("evt_ctx_1", "agent-x");
-    const ctx2 = event("evt_ctx_2", "agent-y");
+    const trigger = makeEvent("message_sent", { id: "evt_trigger", actorId: "agent-peer" });
+    const ctx1 = makeEvent("message_sent", { id: "evt_ctx_1", actorId: "agent-x" });
+    const ctx2 = makeEvent("message_sent", { id: "evt_ctx_2", actorId: "agent-y" });
 
     const packet = buildPerceptionPacket(
-      agent(),
+      makeAgent({ agentId: "agent-me" }),
       [ctx1, ctx2, trigger],
       trigger,
       [],
@@ -85,16 +48,16 @@ describe("buildPerceptionPacket eventHandles", () => {
   });
 
   it("starts handles at e1 for the context events when there is no triggering event", () => {
-    const ctx1 = event("evt_a", "agent-x");
-    const ctx2 = event("evt_b", "agent-y");
+    const ctx1 = makeEvent("message_sent", { id: "evt_a", actorId: "agent-x" });
+    const ctx2 = makeEvent("message_sent", { id: "evt_b", actorId: "agent-y" });
 
-    const packet = buildPerceptionPacket(agent(), [ctx1, ctx2], null, [], attention, translated, []);
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [ctx1, ctx2], null, [], attention, translated, []);
 
     expect(packet.eventHandles).toEqual({ e1: "evt_a", e2: "evt_b" });
   });
 
   it("returns an empty handle map when nothing is in view", () => {
-    const packet = buildPerceptionPacket(agent(), [], null, [], attention, translated, []);
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [], null, [], attention, translated, []);
     expect(packet.eventHandles).toEqual({});
   });
 });

--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -49,6 +49,19 @@ export function buildPerceptionPacket(
     .slice(-CONTEXT_WINDOW)
     .filter(e => e.id !== triggeringEvent?.id);
 
+  // Short ordinal handles ("e1", "e2", …) for the triggering event and each
+  // visible-context event, in the same order the prompt renders them. The
+  // model references these instead of raw event ids for replyToEventId /
+  // targetEventId; IntentParser resolves them back via this map. One handle
+  // per distinct event id.
+  const eventHandles: Record<string, string> = {};
+  const seenEventIds = new Set<string>();
+  for (const e of triggeringEvent ? [triggeringEvent, ...contextEvents] : contextEvents) {
+    if (seenEventIds.has(e.id)) continue;
+    seenEventIds.add(e.id);
+    eventHandles[`e${seenEventIds.size}`] = e.id;
+  }
+
   // Channels visible to this agent
   const relevantChannels = channels
     .filter(c => c.memberAgentIds.includes(agent.agentId))
@@ -107,5 +120,6 @@ export function buildPerceptionPacket(
     relevantMemories,
     translatedEmotionalState: translatedEmotionalState,
     availableActions,
+    eventHandles,
   };
 }

--- a/packages/server/src/__tests__/fixtures.ts
+++ b/packages/server/src/__tests__/fixtures.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared fixtures for the intent-pipeline test files (action-intent step,
+ * intent parser). Q5 of docs/testing-strategy.md: a fixture belongs here once
+ * a second test file needs it — server tests otherwise keep per-file makers,
+ * so do not grow this speculatively.
+ */
+import type { CommittedEvent } from "@perfectman/shared";
+
+export function makeEvent(overrides: Partial<CommittedEvent> = {}): CommittedEvent {
+  return {
+    id: "evt_1",
+    simulationId: "sim-1",
+    channelId: "general",
+    actorId: "agent-peer",
+    type: "message_sent",
+    payload: { content: "a visible message" },
+    createdAt: 1,
+    pulseIndex: 1,
+    sourceEventIds: [],
+    emotionalSalience: "low",
+    visibility: {
+      visibleToAgents: [],
+      visibleToSpectators: true,
+      visibleToOperators: true,
+      visibilityReason: "public",
+    },
+    ...overrides,
+  };
+}
+
+/** A reply_to_message model packet as the provider would emit it. */
+export function replyIntentJson(
+  replyToEventId: string,
+  overrides: { channelTarget?: string; visibleContent?: string } = {},
+): string {
+  return JSON.stringify({
+    intentType: "reply_to_message",
+    channelTarget: "general",
+    personTargets: ["agent-peer"],
+    visibleContent: "yes I did",
+    replyToEventId,
+    privateMotiveSummary: "engage",
+    emotionDrivers: [],
+    motivationDrivers: [],
+    ...overrides,
+  });
+}
+
+/** A react model packet as the provider would emit it. */
+export function reactIntentJson(
+  targetEventId: string,
+  overrides: { channelTarget?: string } = {},
+): string {
+  return JSON.stringify({
+    intentType: "react",
+    channelTarget: "general",
+    emoji: "🔥",
+    targetEventId,
+    privateMotiveSummary: "signal approval",
+    emotionDrivers: [],
+    motivationDrivers: [],
+    ...overrides,
+  });
+}

--- a/packages/server/src/agent/__tests__/agent-runtime.test.ts
+++ b/packages/server/src/agent/__tests__/agent-runtime.test.ts
@@ -52,7 +52,7 @@ describe("AgentRuntime Orchestration", () => {
     perceptionPacket: {
       agentId: "example-friend",
       triggeringEvent: null,
-      visibleContextEvents: [], ownRecentUtterances: [],
+      visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],

--- a/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/background-reflection-prompt-builder.test.ts
@@ -56,6 +56,7 @@ function input(memories: Memory[] = []): AgentRuntimeInput {
       agentId: "goulart",
       triggeringEvent: null,
       visibleContextEvents: [],
+      eventHandles: {},
       ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],

--- a/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
@@ -1,38 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { IntentParser, type TargetResolutionContext } from "../intent-parser.js";
-import type { AvailableAction, CommittedEvent } from "@perfectman/shared";
+import type { AvailableAction } from "@perfectman/shared";
+import { makeEvent, replyIntentJson, reactIntentJson } from "../../__tests__/fixtures.js";
 
 const actorId = "agent-me";
 
 const availableActions: AvailableAction[] = [
-  { intentType: "send_message", channelTargets: ["general-id"], personTargets: [], blocked: false },
-  { intentType: "reply_to_message", channelTargets: ["general-id"], personTargets: ["agent-peer"], blocked: false },
-  { intentType: "react", channelTargets: ["general-id"], personTargets: [], blocked: false },
+  { intentType: "send_message", channelTargets: ["general"], personTargets: [], blocked: false },
+  { intentType: "reply_to_message", channelTargets: ["general"], personTargets: ["agent-peer"], blocked: false },
+  { intentType: "react", channelTargets: ["general"], personTargets: [], blocked: false },
 ];
 
-function event(id: string, actor: string, type: CommittedEvent["type"] = "message_sent"): CommittedEvent {
-  return {
-    id,
-    simulationId: "sim-1",
-    channelId: "general-id",
-    actorId: actor,
-    type,
-    payload: { content: `content of ${id}` },
-    createdAt: 1,
-    pulseIndex: 1,
-    sourceEventIds: [],
-    emotionalSalience: "low",
-    visibility: {
-      visibleToAgents: [],
-      visibleToSpectators: true,
-      visibleToOperators: true,
-      visibilityReason: "public",
-    },
-  };
-}
-
-const triggering = event("evt_trigger", "agent-peer");
-const ctxEvent = event("evt_ctx", "agent-other");
+const triggering = makeEvent({ id: "evt_trigger", actorId: "agent-peer" });
+const ctxEvent = makeEvent({ id: "evt_ctx", actorId: "agent-other" });
 
 function targetContext(overrides: Partial<TargetResolutionContext> = {}): TargetResolutionContext {
   return {
@@ -43,34 +23,9 @@ function targetContext(overrides: Partial<TargetResolutionContext> = {}): Target
   };
 }
 
-function replyJson(replyToEventId: string): string {
-  return JSON.stringify({
-    intentType: "reply_to_message",
-    channelTarget: "general-id",
-    personTargets: ["agent-peer"],
-    visibleContent: "responding to you",
-    replyToEventId,
-    privateMotiveSummary: "engage the thread",
-    emotionDrivers: [],
-    motivationDrivers: [],
-  });
-}
-
-function reactJson(targetEventId: string): string {
-  return JSON.stringify({
-    intentType: "react",
-    channelTarget: "general-id",
-    emoji: "🔥",
-    targetEventId,
-    privateMotiveSummary: "signal approval",
-    emotionDrivers: [],
-    motivationDrivers: [],
-  });
-}
-
 describe("IntentParser reply/react target resolution", () => {
   it("resolves a valid handle to the real event id and stamps replyToActorId", () => {
-    const result = IntentParser.parse(replyJson("e1"), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(replyIntentJson("e1"), actorId, availableActions, "no_op", targetContext());
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.unresolvedTarget).toBeUndefined();
@@ -79,7 +34,7 @@ describe("IntentParser reply/react target resolution", () => {
   });
 
   it("tolerates a bracket-wrapped handle ('[e2]')", () => {
-    const result = IntentParser.parse(replyJson("[e2]"), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(replyIntentJson("[e2]"), actorId, availableActions, "no_op", targetContext());
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.intent.replyToEventId).toBe("evt_ctx");
@@ -87,14 +42,14 @@ describe("IntentParser reply/react target resolution", () => {
   });
 
   it("accepts a real event id the model copied verbatim when it is in view", () => {
-    const result = IntentParser.parse(replyJson("evt_ctx"), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(replyIntentJson("evt_ctx"), actorId, availableActions, "no_op", targetContext());
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.intent.replyToEventId).toBe("evt_ctx");
   });
 
   it("resolves a react targetEventId handle without setting replyToActorId", () => {
-    const result = IntentParser.parse(reactJson("e1"), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(reactIntentJson("e1"), actorId, availableActions, "no_op", targetContext());
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.intent.targetEventId).toBe("evt_trigger");
@@ -102,7 +57,7 @@ describe("IntentParser reply/react target resolution", () => {
   });
 
   it("flags an invented slug as a retriable unresolved target (no fallback intent yet)", () => {
-    const result = IntentParser.parse(replyJson("marianas-last-message"), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(replyIntentJson("marianas-last-message"), actorId, availableActions, "no_op", targetContext());
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.intent.intentType).toBe("reply_to_message");
@@ -114,14 +69,14 @@ describe("IntentParser reply/react target resolution", () => {
   });
 
   it("flags an empty replyToEventId as unresolved", () => {
-    const result = IntentParser.parse(replyJson(""), actorId, availableActions, "no_op", targetContext());
+    const result = IntentParser.parse(replyIntentJson(""), actorId, availableActions, "no_op", targetContext());
 
     expect(result.unresolvedTarget?.field).toBe("replyToEventId");
     expect(result.unresolvedTarget?.badHandle).toBe("");
   });
 
   it("leaves the raw target string untouched when no targetContext is supplied (legacy passthrough)", () => {
-    const result = IntentParser.parse(replyJson("e1"), actorId, availableActions);
+    const result = IntentParser.parse(replyIntentJson("e1"), actorId, availableActions);
 
     expect(result.fallbackApplied).toBe(false);
     expect(result.intent.replyToEventId).toBe("e1");
@@ -130,7 +85,7 @@ describe("IntentParser reply/react target resolution", () => {
 
   describe("floorTargets (retry-exhausted floor)", () => {
     it("infers the triggering event as the reply target and stamps its actor", () => {
-      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", targetContext());
+      const parsed = IntentParser.parse(replyIntentJson("bogus"), actorId, availableActions, "no_op", targetContext());
       const floored = IntentParser.floorTargets(parsed.intent, targetContext());
 
       expect(floored.outcome).toBe("floored");
@@ -144,7 +99,7 @@ describe("IntentParser reply/react target resolution", () => {
 
     it("falls to the most recent visible message when there is no triggering event", () => {
       const ctx = targetContext({ triggeringEventId: undefined, events: [ctxEvent], eventHandles: { e1: "evt_ctx" } });
-      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const parsed = IntentParser.parse(replyIntentJson("bogus"), actorId, availableActions, "no_op", ctx);
       const floored = IntentParser.floorTargets(parsed.intent, ctx);
 
       expect(floored.intent.replyToEventId).toBe("evt_ctx");
@@ -153,19 +108,19 @@ describe("IntentParser reply/react target resolution", () => {
 
     it("downgrades a reply to send_message when there is no event to target", () => {
       const ctx = targetContext({ triggeringEventId: undefined, events: [], eventHandles: {} });
-      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const parsed = IntentParser.parse(replyIntentJson("bogus"), actorId, availableActions, "no_op", ctx);
       const floored = IntentParser.floorTargets(parsed.intent, ctx);
 
       expect(floored.outcome).toBe("downgraded");
       expect(floored.intent.intentType).toBe("send_message");
       expect(floored.intent.replyToEventId).toBeUndefined();
       expect(floored.intent.replyToActorId).toBeUndefined();
-      expect(floored.intent.visibleContent).toBe("responding to you");
+      expect(floored.intent.visibleContent).toBe("yes I did");
     });
 
     it("drops a reaction when there is no triggering event and no visible message", () => {
       const ctx = targetContext({ triggeringEventId: undefined, events: [], eventHandles: {} });
-      const parsed = IntentParser.parse(reactJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const parsed = IntentParser.parse(reactIntentJson("bogus"), actorId, availableActions, "no_op", ctx);
       const floored = IntentParser.floorTargets(parsed.intent, ctx);
 
       expect(floored.outcome).toBe("dropped");
@@ -173,7 +128,7 @@ describe("IntentParser reply/react target resolution", () => {
     });
 
     it("does not mutate the intent passed in", () => {
-      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", targetContext());
+      const parsed = IntentParser.parse(replyIntentJson("bogus"), actorId, availableActions, "no_op", targetContext());
       const before = parsed.intent.replyToEventId;
       IntentParser.floorTargets(parsed.intent, targetContext());
       expect(parsed.intent.replyToEventId).toBe(before);

--- a/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { IntentParser, type TargetResolutionContext } from "../intent-parser.js";
+import type { AvailableAction, CommittedEvent } from "@perfectman/shared";
+
+const actorId = "agent-me";
+
+const availableActions: AvailableAction[] = [
+  { intentType: "send_message", channelTargets: ["general-id"], personTargets: [], blocked: false },
+  { intentType: "reply_to_message", channelTargets: ["general-id"], personTargets: ["agent-peer"], blocked: false },
+  { intentType: "react", channelTargets: ["general-id"], personTargets: [], blocked: false },
+];
+
+function event(id: string, actor: string, type: CommittedEvent["type"] = "message_sent"): CommittedEvent {
+  return {
+    id,
+    simulationId: "sim-1",
+    channelId: "general-id",
+    actorId: actor,
+    type,
+    payload: { content: `content of ${id}` },
+    createdAt: 1,
+    pulseIndex: 1,
+    sourceEventIds: [],
+    emotionalSalience: "low",
+    visibility: {
+      visibleToAgents: [],
+      visibleToSpectators: true,
+      visibleToOperators: true,
+      visibilityReason: "public",
+    },
+  };
+}
+
+const triggering = event("evt_trigger", "agent-peer");
+const ctxEvent = event("evt_ctx", "agent-other");
+
+function targetContext(overrides: Partial<TargetResolutionContext> = {}): TargetResolutionContext {
+  return {
+    eventHandles: { e1: "evt_trigger", e2: "evt_ctx" },
+    events: [triggering, ctxEvent],
+    triggeringEventId: "evt_trigger",
+    ...overrides,
+  };
+}
+
+function replyJson(replyToEventId: string): string {
+  return JSON.stringify({
+    intentType: "reply_to_message",
+    channelTarget: "general-id",
+    personTargets: ["agent-peer"],
+    visibleContent: "responding to you",
+    replyToEventId,
+    privateMotiveSummary: "engage the thread",
+    emotionDrivers: [],
+    motivationDrivers: [],
+  });
+}
+
+function reactJson(targetEventId: string): string {
+  return JSON.stringify({
+    intentType: "react",
+    channelTarget: "general-id",
+    emoji: "🔥",
+    targetEventId,
+    privateMotiveSummary: "signal approval",
+    emotionDrivers: [],
+    motivationDrivers: [],
+  });
+}
+
+describe("IntentParser reply/react target resolution", () => {
+  it("resolves a valid handle to the real event id and stamps replyToActorId", () => {
+    const result = IntentParser.parse(replyJson("e1"), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.unresolvedTarget).toBeUndefined();
+    expect(result.intent.replyToEventId).toBe("evt_trigger");
+    expect(result.intent.replyToActorId).toBe("agent-peer");
+  });
+
+  it("tolerates a bracket-wrapped handle ('[e2]')", () => {
+    const result = IntentParser.parse(replyJson("[e2]"), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.replyToEventId).toBe("evt_ctx");
+    expect(result.intent.replyToActorId).toBe("agent-other");
+  });
+
+  it("accepts a real event id the model copied verbatim when it is in view", () => {
+    const result = IntentParser.parse(replyJson("evt_ctx"), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.replyToEventId).toBe("evt_ctx");
+  });
+
+  it("resolves a react targetEventId handle without setting replyToActorId", () => {
+    const result = IntentParser.parse(reactJson("e1"), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.targetEventId).toBe("evt_trigger");
+    expect(result.intent.replyToActorId).toBeUndefined();
+  });
+
+  it("flags an invented slug as a retriable unresolved target (no fallback intent yet)", () => {
+    const result = IntentParser.parse(replyJson("marianas-last-message"), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.intentType).toBe("reply_to_message");
+    expect(result.unresolvedTarget).toEqual({
+      field: "replyToEventId",
+      badHandle: "marianas-last-message",
+      validHandles: ["e1", "e2"],
+    });
+  });
+
+  it("flags an empty replyToEventId as unresolved", () => {
+    const result = IntentParser.parse(replyJson(""), actorId, availableActions, "no_op", targetContext());
+
+    expect(result.unresolvedTarget?.field).toBe("replyToEventId");
+    expect(result.unresolvedTarget?.badHandle).toBe("");
+  });
+
+  it("leaves the raw target string untouched when no targetContext is supplied (legacy passthrough)", () => {
+    const result = IntentParser.parse(replyJson("e1"), actorId, availableActions);
+
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.replyToEventId).toBe("e1");
+    expect(result.unresolvedTarget).toBeUndefined();
+  });
+
+  describe("floorTargets (retry-exhausted floor)", () => {
+    it("infers the triggering event as the reply target and stamps its actor", () => {
+      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", targetContext());
+      const floored = IntentParser.floorTargets(parsed.intent, targetContext());
+
+      expect(floored.droppedReaction).toBeFalsy();
+      expect(floored.intent.intentType).toBe("reply_to_message");
+      expect(floored.intent.replyToEventId).toBe("evt_trigger");
+      expect(floored.intent.replyToActorId).toBe("agent-peer");
+    });
+
+    it("falls to the most recent visible message when there is no triggering event", () => {
+      const ctx = targetContext({ triggeringEventId: undefined, events: [ctxEvent], eventHandles: { e1: "evt_ctx" } });
+      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const floored = IntentParser.floorTargets(parsed.intent, ctx);
+
+      expect(floored.intent.replyToEventId).toBe("evt_ctx");
+      expect(floored.intent.replyToActorId).toBe("agent-other");
+    });
+
+    it("downgrades a reply to send_message when there is no event to target", () => {
+      const ctx = targetContext({ triggeringEventId: undefined, events: [], eventHandles: {} });
+      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const floored = IntentParser.floorTargets(parsed.intent, ctx);
+
+      expect(floored.intent.intentType).toBe("send_message");
+      expect(floored.intent.replyToEventId).toBeUndefined();
+      expect(floored.intent.replyToActorId).toBeUndefined();
+      expect(floored.intent.visibleContent).toBe("responding to you");
+    });
+
+    it("drops a reaction when there is no triggering event and no visible message", () => {
+      const ctx = targetContext({ triggeringEventId: undefined, events: [], eventHandles: {} });
+      const parsed = IntentParser.parse(reactJson("bogus"), actorId, availableActions, "no_op", ctx);
+      const floored = IntentParser.floorTargets(parsed.intent, ctx);
+
+      expect(floored.droppedReaction).toBe(true);
+    });
+
+    it("does not mutate the intent passed in", () => {
+      const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", targetContext());
+      const before = parsed.intent.replyToEventId;
+      IntentParser.floorTargets(parsed.intent, targetContext());
+      expect(parsed.intent.replyToEventId).toBe(before);
+    });
+  });
+});

--- a/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser-target-resolution.test.ts
@@ -133,7 +133,10 @@ describe("IntentParser reply/react target resolution", () => {
       const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", targetContext());
       const floored = IntentParser.floorTargets(parsed.intent, targetContext());
 
-      expect(floored.droppedReaction).toBeFalsy();
+      expect(floored.outcome).toBe("floored");
+      expect(floored.field).toBe("replyToEventId");
+      expect(floored.resolvedEventId).toBe("evt_trigger");
+      expect(floored.detail).toContain("evt_trigger");
       expect(floored.intent.intentType).toBe("reply_to_message");
       expect(floored.intent.replyToEventId).toBe("evt_trigger");
       expect(floored.intent.replyToActorId).toBe("agent-peer");
@@ -153,6 +156,7 @@ describe("IntentParser reply/react target resolution", () => {
       const parsed = IntentParser.parse(replyJson("bogus"), actorId, availableActions, "no_op", ctx);
       const floored = IntentParser.floorTargets(parsed.intent, ctx);
 
+      expect(floored.outcome).toBe("downgraded");
       expect(floored.intent.intentType).toBe("send_message");
       expect(floored.intent.replyToEventId).toBeUndefined();
       expect(floored.intent.replyToActorId).toBeUndefined();
@@ -164,7 +168,8 @@ describe("IntentParser reply/react target resolution", () => {
       const parsed = IntentParser.parse(reactJson("bogus"), actorId, availableActions, "no_op", ctx);
       const floored = IntentParser.floorTargets(parsed.intent, ctx);
 
-      expect(floored.droppedReaction).toBe(true);
+      expect(floored.outcome).toBe("dropped");
+      expect(floored.field).toBe("targetEventId");
     });
 
     it("does not mutate the intent passed in", () => {

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -70,6 +70,7 @@ describe("PromptBuilder", () => {
       agentId: "example-friend",
       triggeringEvent: triggeringEvent,
       visibleContextEvents: [triggeringEvent, contextEvent],
+      eventHandles: { e1: "evt-111", e2: "evt-222" },
       ownRecentUtterances: [],
       involvedPeople: ["agent-peer", "agent-peer"],
       relevantChannels: ["general"],
@@ -222,11 +223,21 @@ describe("PromptBuilder", () => {
 
   it("should verify that the prompt includes the triggering event and context", () => {
     const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
-    
+
     expect(prompt.user).toContain("o Example Friend tá sumido hoje né");
     expect(prompt.user).toContain("verdade, deve tá ocupado");
     expect(prompt.user).toContain("agent-peer");
     expect(prompt.user).toContain("agent-peer");
+  });
+
+  it("prefixes context events with their ordinal handle and explains how to reference one", () => {
+    const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(prompt.user).toContain("[e1] [agent-peer in #general]");
+    expect(prompt.user).toContain("[e2] [agent-peer in #general (reply)]");
+    expect(prompt.user).not.toContain("evt-111");
+    expect(prompt.user).toContain("replyToEventId / targetEventId");
+    expect(prompt.system).toContain('set "replyToEventId"');
   });
 
   it("should verify that the prompt includes available actions and target options", () => {

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -40,6 +40,7 @@ export const CANONICAL_TEMPLATE_VERSION_INPUT: AgentRuntimeInput = {
     agentId: "template-version",
     triggeringEvent: null,
     visibleContextEvents: [],
+    eventHandles: {},
     ownRecentUtterances: [],
     involvedPeople: [],
     relevantChannels: [],
@@ -190,7 +191,7 @@ export class ActionIntentPromptBuilder {
   private static renderEvents(s: PromptSection, input: AgentRuntimeInput, perceptionPacket: AgentRuntimeInput["perceptionPacket"]): void {
     s.heading("What you noticed");
     const handleByEventId = new Map(
-      Object.entries(perceptionPacket.eventHandles ?? {}).map(([handle, eventId]) => [eventId, handle]),
+      Object.entries(perceptionPacket.eventHandles).map(([handle, eventId]) => [eventId, handle]),
     );
     if (perceptionPacket.triggeringEvent) {
       s.raw(`Triggering event (what just happened that caught your attention):\n${this.formatEvent(perceptionPacket.triggeringEvent, handleByEventId.get(perceptionPacket.triggeringEvent.id))}`);

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -183,13 +183,17 @@ export class ActionIntentPromptBuilder {
     s.list("Ensure", [
       `"privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").`,
       `Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".`,
+      `For reply_to_message set "replyToEventId", and for react set "targetEventId", to one of the bracketed event handles from <events> (e.g. "e1") — copy the handle text exactly, do not invent an id or describe the message.`,
     ]);
   }
 
   private static renderEvents(s: PromptSection, input: AgentRuntimeInput, perceptionPacket: AgentRuntimeInput["perceptionPacket"]): void {
     s.heading("What you noticed");
+    const handleByEventId = new Map(
+      Object.entries(perceptionPacket.eventHandles ?? {}).map(([handle, eventId]) => [eventId, handle]),
+    );
     if (perceptionPacket.triggeringEvent) {
-      s.raw(`Triggering event (what just happened that caught your attention):\n${this.formatEvent(perceptionPacket.triggeringEvent)}`);
+      s.raw(`Triggering event (what just happened that caught your attention):\n${this.formatEvent(perceptionPacket.triggeringEvent, handleByEventId.get(perceptionPacket.triggeringEvent.id))}`);
     } else {
       s.raw("Triggering event: no specific event triggered this pulse (you have the initiative to speak or act on your own).");
     }
@@ -215,9 +219,14 @@ export class ActionIntentPromptBuilder {
     }
 
     if (perceptionPacket.visibleContextEvents.length > 0) {
-      s.raw(`Recent context (last messages in visible channels):\n${perceptionPacket.visibleContextEvents.map((e) => this.formatEvent(e)).join("\n")}`);
+      s.raw(`Recent context (last messages in visible channels):\n${perceptionPacket.visibleContextEvents.map((e) => this.formatEvent(e, handleByEventId.get(e.id))).join("\n")}`);
     } else {
       s.raw("Recent context: the chat history is currently empty.");
+    }
+    if (handleByEventId.size > 0) {
+      s.raw(
+        "Each event above starts with a short handle in square brackets (e.g. [e1]). To reply to or react to a specific message, set replyToEventId / targetEventId to exactly that handle text (e.g. \"e1\") — never a paraphrase, a name, or any other id. If you are not replying to one specific message, use send_message and leave replyToEventId unset.",
+      );
     }
   }
 
@@ -360,7 +369,8 @@ export class ActionIntentPromptBuilder {
   }
 
   // Event content is LLM-generated (agent outputs), not untrusted user input — no sanitization needed.
-  private static formatEvent(event: CommittedEvent): string {
+  private static formatEvent(event: CommittedEvent, handle?: string): string {
+    const prefix = handle ? `[${handle}] ` : "";
     const actor = event.actorId;
     const type = event.type;
     const channel = event.channelId ? `#${event.channelId}` : "";
@@ -382,14 +392,14 @@ export class ActionIntentPromptBuilder {
     }
 
     switch (type) {
-      case "message_sent": return `[${actor} in ${channelTag}]: ${content}`;
-      case "reply_sent": return `[${actor} in ${channelTag} (reply)]: ${content}`;
-      case "reaction_sent": return `[${actor} in ${channelTag}]: ${content}`;
-      case "channel_created": return `[System]: ${actor} created a new private channel ${channelTag}`;
-      case "agent_invited": return `[System]: ${actor} invited someone to ${channelTag}`;
-      case "presence_changed": return `[System]: ${actor} changed presence to ${event.payload?.presence || "unknown"}`;
-      case "no_op_recorded": return `[System]: ${actor} chose to lurk silently.`;
-      default: return `[${actor} in ${channelTag} (${type})]: ${content}`;
+      case "message_sent": return `${prefix}[${actor} in ${channelTag}]: ${content}`;
+      case "reply_sent": return `${prefix}[${actor} in ${channelTag} (reply)]: ${content}`;
+      case "reaction_sent": return `${prefix}[${actor} in ${channelTag}]: ${content}`;
+      case "channel_created": return `${prefix}[System]: ${actor} created a new private channel ${channelTag}`;
+      case "agent_invited": return `${prefix}[System]: ${actor} invited someone to ${channelTag}`;
+      case "presence_changed": return `${prefix}[System]: ${actor} changed presence to ${event.payload?.presence || "unknown"}`;
+      case "no_op_recorded": return `${prefix}[System]: ${actor} chose to lurk silently.`;
+      default: return `${prefix}[${actor} in ${channelTag} (${type})]: ${content}`;
     }
   }
 }

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -233,21 +233,38 @@ export class IntentParser {
    * triggering event (or, failing that, the most recent visible message) as
    * the target. With neither available, a reply downgrades to send_message
    * and a reaction is dropped. Never leaves the target empty or unresolved.
-   * Mutates a copy — the input intent is left untouched.
+   * Mutates a copy — the input intent is left untouched. The `outcome` and
+   * `resolvedEventId` let the caller emit floor telemetry.
    */
   static floorTargets(
     intent: ActionIntent,
     targetContext: TargetResolutionContext,
-  ): { intent: ActionIntent; detail?: string; droppedReaction?: boolean } {
+  ): {
+    intent: ActionIntent;
+    outcome: "resolved" | "floored" | "downgraded" | "dropped";
+    field: TargetField;
+    detail?: string;
+    resolvedEventId?: string;
+  } {
+    const field: TargetField = intent.intentType === "react" ? "targetEventId" : "replyToEventId";
     const working: ActionIntent = { ...intent };
     const resolution = this.resolveTargets(working, targetContext, { floor: true });
-    if (resolution.kind === "dropped") {
-      return { intent: working, detail: resolution.detail, droppedReaction: true };
+    switch (resolution.kind) {
+      case "dropped":
+        return { intent: working, outcome: "dropped", field, detail: resolution.detail };
+      case "floored":
+        return {
+          intent: working,
+          outcome: "floored",
+          field,
+          detail: resolution.detail,
+          resolvedEventId: working[field],
+        };
+      case "downgraded":
+        return { intent: working, outcome: "downgraded", field, detail: resolution.detail };
+      default:
+        return { intent: working, outcome: "resolved", field };
     }
-    if (resolution.kind === "floored" || resolution.kind === "downgraded") {
-      return { intent: working, detail: resolution.detail };
-    }
-    return { intent: working };
   }
 
   /**
@@ -267,7 +284,7 @@ export class IntentParser {
 
     const field: TargetField = isReply ? "replyToEventId" : "targetEventId";
     const raw = (intent[field] ?? "").trim();
-    const handles = ctx.eventHandles ?? {};
+    const handles = ctx.eventHandles;
     const validHandles = Object.keys(handles);
     const realIds = new Set(Object.values(handles));
     const normalized = raw.replace(/^\[+/, "").replace(/\]+$/, "").trim();

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -1,11 +1,37 @@
 import { ModelIntentPacketSchema, composeIntentPacket } from "@perfectman/shared";
-import type { ActionIntent, AvailableAction, IntentType } from "@perfectman/shared";
+import type { ActionIntent, AvailableAction, CommittedEvent, IntentType } from "@perfectman/shared";
+
+type TargetField = "replyToEventId" | "targetEventId";
+
+/**
+ * Everything `parse` needs to turn a model-supplied event handle ("e1") into
+ * the real `evt_*` id it stands for. Only the `action_intent` step passes
+ * this; without it the parser leaves reply/react target strings untouched
+ * (legacy passthrough).
+ */
+export type TargetResolutionContext = {
+  eventHandles: Record<string, string>; // "e1" -> real event id, as shown to the model this render
+  events: CommittedEvent[]; // triggering event followed by visible-context events (for actor + floor lookup)
+  triggeringEventId?: string; // retry-exhausted floor: infer this as the target
+};
 
 export type IntentParserResult = {
   intent: ActionIntent;
   fallbackApplied: boolean;
   errorDetail?: string;
+  // Set when the intent is a reply/react whose target handle could not be
+  // resolved against `TargetResolutionContext.eventHandles`. The caller
+  // re-prompts once with a targeted note, then applies `floorTargets`.
+  unresolvedTarget?: { field: TargetField; badHandle: string; validHandles: string[] };
 };
+
+type TargetResolution =
+  | { kind: "not_applicable" }
+  | { kind: "resolved" }
+  | { kind: "unresolved"; field: TargetField; badHandle: string; validHandles: string[] }
+  | { kind: "floored"; detail: string }
+  | { kind: "downgraded"; detail: string }
+  | { kind: "dropped"; detail: string };
 
 export class IntentParser {
   /**
@@ -22,6 +48,7 @@ export class IntentParser {
     actorId: string,
     availableActions: AvailableAction[],
     preferredFallbackType: "no_op" | "delay_response" = "no_op",
+    targetContext?: TargetResolutionContext,
   ): IntentParserResult {
     let cleanedText = rawText;
 
@@ -130,6 +157,26 @@ export class IntentParser {
         }
       }
 
+      // 7. Resolve a reply/react target handle ("e1") to the real event id.
+      // Runs only when the step supplies the render's handle map. An
+      // unresolvable handle is a retriable failure, not a fallback: the
+      // original intent is returned so the caller can re-prompt then floor.
+      if (targetContext) {
+        const resolution = this.resolveTargets(intent, targetContext, { floor: false });
+        if (resolution.kind === "unresolved") {
+          return {
+            intent,
+            fallbackApplied: false,
+            errorDetail: `Unresolvable ${resolution.field}: '${resolution.badHandle || "(empty)"}'`,
+            unresolvedTarget: {
+              field: resolution.field,
+              badHandle: resolution.badHandle,
+              validHandles: resolution.validHandles,
+            },
+          };
+        }
+      }
+
       return { intent, fallbackApplied: false };
     } catch (error: any) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -179,5 +226,103 @@ export class IntentParser {
       intentType: fallbackType,
       reason,
     });
+  }
+
+  /**
+   * Retry-exhausted floor for an unresolved reply/react target. Infers the
+   * triggering event (or, failing that, the most recent visible message) as
+   * the target. With neither available, a reply downgrades to send_message
+   * and a reaction is dropped. Never leaves the target empty or unresolved.
+   * Mutates a copy — the input intent is left untouched.
+   */
+  static floorTargets(
+    intent: ActionIntent,
+    targetContext: TargetResolutionContext,
+  ): { intent: ActionIntent; detail?: string; droppedReaction?: boolean } {
+    const working: ActionIntent = { ...intent };
+    const resolution = this.resolveTargets(working, targetContext, { floor: true });
+    if (resolution.kind === "dropped") {
+      return { intent: working, detail: resolution.detail, droppedReaction: true };
+    }
+    if (resolution.kind === "floored" || resolution.kind === "downgraded") {
+      return { intent: working, detail: resolution.detail };
+    }
+    return { intent: working };
+  }
+
+  /**
+   * Resolves `replyToEventId` / `targetEventId` from a per-render handle
+   * ("e1") to the real event id, mutating `intent` in place. `floor: false`
+   * reports an unresolvable handle for the caller to retry; `floor: true`
+   * applies the triggering-event / visible-message / downgrade floor.
+   */
+  private static resolveTargets(
+    intent: ActionIntent,
+    ctx: TargetResolutionContext,
+    opts: { floor: boolean },
+  ): TargetResolution {
+    const isReply = intent.intentType === "reply_to_message";
+    const isReact = intent.intentType === "react";
+    if (!isReply && !isReact) return { kind: "not_applicable" };
+
+    const field: TargetField = isReply ? "replyToEventId" : "targetEventId";
+    const raw = (intent[field] ?? "").trim();
+    const handles = ctx.eventHandles ?? {};
+    const validHandles = Object.keys(handles);
+    const realIds = new Set(Object.values(handles));
+    const normalized = raw.replace(/^\[+/, "").replace(/\]+$/, "").trim();
+
+    let realId: string | undefined;
+    if (normalized && handles[normalized]) realId = handles[normalized];
+    else if (normalized && realIds.has(normalized)) realId = normalized;
+
+    if (realId) {
+      this.assignTarget(intent, field, realId, ctx);
+      return { kind: "resolved" };
+    }
+
+    if (!opts.floor) {
+      return { kind: "unresolved", field, badHandle: raw, validHandles };
+    }
+
+    const lastVisibleMessageId = [...ctx.events]
+      .reverse()
+      .find((e) => e.type === "message_sent" || e.type === "reply_sent")?.id;
+    const floorId = ctx.triggeringEventId ?? lastVisibleMessageId;
+
+    if (floorId) {
+      this.assignTarget(intent, field, floorId, ctx);
+      return {
+        kind: "floored",
+        detail: `unresolvable ${field} '${raw || "(empty)"}'; inferred triggering/visible event ${floorId} as the target`,
+      };
+    }
+
+    if (isReply) {
+      intent.intentType = "send_message";
+      delete intent.replyToEventId;
+      delete intent.replyToActorId;
+      return {
+        kind: "downgraded",
+        detail: `unresolvable replyToEventId '${raw || "(empty)"}' with no event to target; downgraded to send_message`,
+      };
+    }
+    return {
+      kind: "dropped",
+      detail: `unresolvable targetEventId '${raw || "(empty)"}' with no event to target; reaction dropped`,
+    };
+  }
+
+  private static assignTarget(
+    intent: ActionIntent,
+    field: TargetField,
+    realEventId: string,
+    ctx: TargetResolutionContext,
+  ): void {
+    intent[field] = realEventId;
+    if (field === "replyToEventId") {
+      const actor = ctx.events.find((e) => e.id === realEventId)?.actorId;
+      if (actor) intent.replyToActorId = actor;
+    }
   }
 }

--- a/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
+++ b/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
@@ -37,6 +37,7 @@ function makeInput(overrides: Partial<AgentRuntimeInput> = {}): AgentRuntimeInpu
       agentId: "agent-a",
       triggeringEvent: null,
       visibleContextEvents: [],
+      eventHandles: {},
       ownRecentUtterances: [REPEAT_TEXT],
       involvedPeople: [],
       relevantChannels: ["general"],
@@ -333,6 +334,17 @@ describe("ActionIntentStep", () => {
       expect(outcome.value.intent.replyToEventId).toBe("evt_trigger");
       expect(outcome.value.intent.replyToActorId).toBe("agent-peer");
       expect(outcome.value.fallbackApplied).toBe(false);
+
+      const floorEvent = outcome.value.operatorEvents.find((e) => e.type === "target_resolution_floored");
+      expect(floorEvent).toBeDefined();
+      expect(floorEvent!.detail).toContain("bogus-1");
+      expect(floorEvent!.data).toMatchObject({
+        field: "replyToEventId",
+        badHandle: "bogus-1",
+        outcome: "triggering_or_visible_event",
+        resolvedEventId: "evt_trigger",
+      });
+      expect(outcome.value.operatorEvents.some((e) => e.type === "llm_failure")).toBe(false);
     });
 
     it("drops a reaction with an unresolvable target and no triggering event / visible message", async () => {
@@ -371,6 +383,15 @@ describe("ActionIntentStep", () => {
       expect(outcome.value.intent.intentType).toBe("send_message");
       expect(outcome.value.intent.replyToEventId).toBeUndefined();
       expect(outcome.value.intent.visibleContent).toBe("yes I did");
+
+      const floorEvent = outcome.value.operatorEvents.find((e) => e.type === "target_resolution_floored");
+      expect(floorEvent).toBeDefined();
+      expect(floorEvent!.data).toMatchObject({
+        field: "replyToEventId",
+        badHandle: "nope",
+        outcome: "downgraded_to_send_message",
+      });
+      expect(floorEvent!.data?.resolvedEventId).toBeUndefined();
     });
   });
 });

--- a/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
+++ b/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import type { AgentRuntimeInput, CommittedEvent, LLMProviderResult } from "@perfectman/shared";
+import type { AgentRuntimeInput, LLMProviderResult } from "@perfectman/shared";
 import type { LLMConfig } from "../../llm/llm-config.js";
 import { ActionIntentStep } from "../action-intent-step.js";
 import { llmSurfaceRegistry } from "../index.js";
 import type { StepRunContext } from "../llm-step.js";
+import { makeEvent, replyIntentJson, reactIntentJson } from "../../../__tests__/fixtures.js";
 
 function jsonResponse(content: string, promptTokens = 50, completionTokens = 10): LLMProviderResult {
   return {
@@ -235,19 +236,7 @@ describe("ActionIntentStep", () => {
   });
 
   describe("reply/reaction target resolution", () => {
-    const trigger: CommittedEvent = {
-      id: "evt_trigger",
-      simulationId: "sim-1",
-      channelId: "general",
-      actorId: "agent-peer",
-      type: "message_sent",
-      payload: { content: "did you see this?" },
-      createdAt: 1,
-      pulseIndex: 2,
-      sourceEventIds: [],
-      emotionalSalience: "low",
-      visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
-    };
+    const trigger = makeEvent({ id: "evt_trigger", actorId: "agent-peer" });
 
     function targetInput(overrides: Partial<AgentRuntimeInput["perceptionPacket"]> = {}): AgentRuntimeInput {
       const base = makeInput({
@@ -271,21 +260,8 @@ describe("ActionIntentStep", () => {
       };
     }
 
-    function replyJson(replyToEventId: string): string {
-      return JSON.stringify({
-        intentType: "reply_to_message",
-        channelTarget: "general",
-        personTargets: ["agent-peer"],
-        visibleContent: "yes I did",
-        replyToEventId,
-        privateMotiveSummary: "engage",
-        emotionDrivers: [],
-        motivationDrivers: [],
-      });
-    }
-
     it("commits a valid-handle reply with the real event id and resolved actor, no retry", async () => {
-      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyJson("e1"))) };
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyIntentJson("e1"))) };
       const outcome = await runStep(provider, targetInput());
 
       expect(outcome.ok).toBe(true);
@@ -301,8 +277,8 @@ describe("ActionIntentStep", () => {
       const provider = {
         generateIntent: vi
           .fn()
-          .mockResolvedValueOnce(jsonResponse(replyJson("marianas-message")))
-          .mockResolvedValueOnce(jsonResponse(replyJson("e1"))),
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("marianas-message")))
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("e1"))),
       };
       const outcome = await runStep(provider, targetInput());
 
@@ -322,8 +298,8 @@ describe("ActionIntentStep", () => {
       const provider = {
         generateIntent: vi
           .fn()
-          .mockResolvedValueOnce(jsonResponse(replyJson("bogus-1")))
-          .mockResolvedValueOnce(jsonResponse(replyJson("bogus-2"))),
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("bogus-1")))
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("bogus-2"))),
       };
       const outcome = await runStep(provider, targetInput());
 
@@ -337,27 +313,39 @@ describe("ActionIntentStep", () => {
 
       const floorEvent = outcome.value.operatorEvents.find((e) => e.type === "target_resolution_floored");
       expect(floorEvent).toBeDefined();
-      expect(floorEvent!.detail).toContain("bogus-1");
+      // Telemetry describes the floored intent — the model's final answer —
+      // so the second bad handle is the one reported.
+      expect(floorEvent!.detail).toContain("bogus-2");
       expect(floorEvent!.data).toMatchObject({
         field: "replyToEventId",
-        badHandle: "bogus-1",
+        badHandle: "bogus-2",
         outcome: "triggering_or_visible_event",
         resolvedEventId: "evt_trigger",
       });
       expect(outcome.value.operatorEvents.some((e) => e.type === "llm_failure")).toBe(false);
     });
 
+    it("blocks the retry instead of committing when a corrected handle comes back with near-duplicate content", async () => {
+      const provider = {
+        generateIntent: vi
+          .fn()
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("marianas-message")))
+          .mockResolvedValueOnce(jsonResponse(replyIntentJson("e1", { visibleContent: REPEAT_TEXT }))),
+      };
+      const outcome = await runStep(provider, targetInput({ ownRecentUtterances: [REPEAT_TEXT] }));
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(provider.generateIntent).toHaveBeenCalledTimes(2);
+      expect(outcome.value.fallbackApplied).toBe(true);
+      expect(outcome.value.intent.intentType).toBe("no_op");
+      expect(outcome.value.intent.replyToEventId).toBeUndefined();
+      expect(outcome.value.operatorEvents.some((e) => e.type === "intent_blocked")).toBe(true);
+      expect(outcome.value.operatorEvents.some((e) => e.type === "llm_failure")).toBe(false);
+    });
+
     it("drops a reaction with an unresolvable target and no triggering event / visible message", async () => {
-      const reactJson = JSON.stringify({
-        intentType: "react",
-        channelTarget: "general",
-        emoji: "🔥",
-        targetEventId: "some-slug",
-        privateMotiveSummary: "approve",
-        emotionDrivers: [],
-        motivationDrivers: [],
-      });
-      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(reactJson)) };
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(reactIntentJson("some-slug"))) };
       const outcome = await runStep(
         provider,
         targetInput({ triggeringEvent: null, visibleContextEvents: [], eventHandles: {} }),
@@ -372,7 +360,7 @@ describe("ActionIntentStep", () => {
     });
 
     it("downgrades a reply to send_message when there is no event to target", async () => {
-      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyJson("nope"))) };
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyIntentJson("nope"))) };
       const outcome = await runStep(
         provider,
         targetInput({ triggeringEvent: null, visibleContextEvents: [], eventHandles: {} }),

--- a/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
+++ b/packages/server/src/agent/surface/__tests__/action-intent-step.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { AgentRuntimeInput, LLMProviderResult } from "@perfectman/shared";
+import type { AgentRuntimeInput, CommittedEvent, LLMProviderResult } from "@perfectman/shared";
 import type { LLMConfig } from "../../llm/llm-config.js";
 import { ActionIntentStep } from "../action-intent-step.js";
 import { llmSurfaceRegistry } from "../index.js";
@@ -86,6 +86,7 @@ const prompt = {
 
 function runStep(
   provider: { generateIntent: unknown },
+  input: AgentRuntimeInput = makeInput(),
 ): Promise<ReturnType<ActionIntentStep["execute"]>> {
   const step = new ActionIntentStep();
   const ctx: StepRunContext = {
@@ -96,7 +97,7 @@ function runStep(
     profile: {} as StepRunContext["profile"],
     prompt,
   };
-  return step.execute(makeInput(), ctx);
+  return step.execute(input, ctx);
 }
 
 describe("ActionIntentStep", () => {
@@ -230,5 +231,146 @@ describe("ActionIntentStep", () => {
     const failure = outcome.value.operatorEvents.find((e) => e.type === "llm_failure");
     expect(failure).toBeDefined();
     expect(outcome.value.operatorEvents.some((e) => e.type === "intent_blocked")).toBe(false);
+  });
+
+  describe("reply/reaction target resolution", () => {
+    const trigger: CommittedEvent = {
+      id: "evt_trigger",
+      simulationId: "sim-1",
+      channelId: "general",
+      actorId: "agent-peer",
+      type: "message_sent",
+      payload: { content: "did you see this?" },
+      createdAt: 1,
+      pulseIndex: 2,
+      sourceEventIds: [],
+      emotionalSalience: "low",
+      visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
+    };
+
+    function targetInput(overrides: Partial<AgentRuntimeInput["perceptionPacket"]> = {}): AgentRuntimeInput {
+      const base = makeInput({
+        availableActions: [
+          { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
+          { intentType: "send_message", channelTargets: ["general"], personTargets: [], blocked: false },
+          { intentType: "reply_to_message", channelTargets: ["general"], personTargets: ["agent-peer"], blocked: false },
+          { intentType: "react", channelTargets: ["general"], personTargets: [], blocked: false },
+        ],
+      });
+      return {
+        ...base,
+        perceptionPacket: {
+          ...base.perceptionPacket,
+          ownRecentUtterances: [],
+          triggeringEvent: trigger,
+          visibleContextEvents: [trigger],
+          eventHandles: { e1: "evt_trigger" },
+          ...overrides,
+        },
+      };
+    }
+
+    function replyJson(replyToEventId: string): string {
+      return JSON.stringify({
+        intentType: "reply_to_message",
+        channelTarget: "general",
+        personTargets: ["agent-peer"],
+        visibleContent: "yes I did",
+        replyToEventId,
+        privateMotiveSummary: "engage",
+        emotionDrivers: [],
+        motivationDrivers: [],
+      });
+    }
+
+    it("commits a valid-handle reply with the real event id and resolved actor, no retry", async () => {
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyJson("e1"))) };
+      const outcome = await runStep(provider, targetInput());
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(outcome.value.fallbackApplied).toBe(false);
+      expect(outcome.value.intent.intentType).toBe("reply_to_message");
+      expect(outcome.value.intent.replyToEventId).toBe("evt_trigger");
+      expect(outcome.value.intent.replyToActorId).toBe("agent-peer");
+      expect(provider.generateIntent).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries exactly once with a correction note naming the bad handle, then accepts a corrected handle", async () => {
+      const provider = {
+        generateIntent: vi
+          .fn()
+          .mockResolvedValueOnce(jsonResponse(replyJson("marianas-message")))
+          .mockResolvedValueOnce(jsonResponse(replyJson("e1"))),
+      };
+      const outcome = await runStep(provider, targetInput());
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(provider.generateIntent).toHaveBeenCalledTimes(2);
+      const retryPrompt = provider.generateIntent.mock.calls[1]![2] as { system: string };
+      expect(retryPrompt.system).toContain("marianas-message");
+      expect(retryPrompt.system).toContain("e1");
+      expect(retryPrompt.system).toContain("send_message");
+      expect(outcome.value.fallbackApplied).toBe(false);
+      expect(outcome.value.intent.replyToEventId).toBe("evt_trigger");
+      expect(outcome.value.intent.replyToActorId).toBe("agent-peer");
+    });
+
+    it("falls to the triggering-event floor after one failed retry (no empty target committed)", async () => {
+      const provider = {
+        generateIntent: vi
+          .fn()
+          .mockResolvedValueOnce(jsonResponse(replyJson("bogus-1")))
+          .mockResolvedValueOnce(jsonResponse(replyJson("bogus-2"))),
+      };
+      const outcome = await runStep(provider, targetInput());
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(provider.generateIntent).toHaveBeenCalledTimes(2);
+      expect(outcome.value.intent.intentType).toBe("reply_to_message");
+      expect(outcome.value.intent.replyToEventId).toBe("evt_trigger");
+      expect(outcome.value.intent.replyToActorId).toBe("agent-peer");
+      expect(outcome.value.fallbackApplied).toBe(false);
+    });
+
+    it("drops a reaction with an unresolvable target and no triggering event / visible message", async () => {
+      const reactJson = JSON.stringify({
+        intentType: "react",
+        channelTarget: "general",
+        emoji: "🔥",
+        targetEventId: "some-slug",
+        privateMotiveSummary: "approve",
+        emotionDrivers: [],
+        motivationDrivers: [],
+      });
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(reactJson)) };
+      const outcome = await runStep(
+        provider,
+        targetInput({ triggeringEvent: null, visibleContextEvents: [], eventHandles: {} }),
+      );
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(outcome.value.intent.intentType).toBe("no_op");
+      expect(outcome.value.intent.targetEventId).toBeUndefined();
+      expect(outcome.value.fallbackApplied).toBe(true);
+      expect(outcome.value.operatorEvents.some((e) => e.type === "llm_failure")).toBe(true);
+    });
+
+    it("downgrades a reply to send_message when there is no event to target", async () => {
+      const provider = { generateIntent: vi.fn().mockResolvedValue(jsonResponse(replyJson("nope"))) };
+      const outcome = await runStep(
+        provider,
+        targetInput({ triggeringEvent: null, visibleContextEvents: [], eventHandles: {} }),
+      );
+
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) return;
+      expect(outcome.value.intent.intentType).toBe("send_message");
+      expect(outcome.value.intent.replyToEventId).toBeUndefined();
+      expect(outcome.value.intent.visibleContent).toBe("yes I did");
+    });
   });
 });

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -2,6 +2,7 @@ import type {
   AgentRuntimeInput,
   LLMUsage,
   OperatorEvent,
+  TargetResolutionFlooredData,
 } from "@perfectman/shared";
 import type {
   AgentRuntimeContext,
@@ -142,7 +143,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     }
 
     const targetContext: TargetResolutionContext = {
-      eventHandles: input.perceptionPacket.eventHandles ?? {},
+      eventHandles: input.perceptionPacket.eventHandles,
       events: [
         ...(input.perceptionPacket.triggeringEvent ? [input.perceptionPacket.triggeringEvent] : []),
         ...input.perceptionPacket.visibleContextEvents,
@@ -262,6 +263,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     // triggering-event floor — the target is never committed empty or
     // unresolved, and no_op is not this failure path (a reaction with
     // nothing left to target is the sole exception: it is dropped).
+    let targetFloor: { detail: string; data: TargetResolutionFlooredData } | undefined;
     if (!fallbackApplied && !repetitionBlocked && parseResult.unresolvedTarget) {
       const bad = parseResult.unresolvedTarget;
       let resolvedOnRetry = false;
@@ -308,7 +310,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
 
       if (!resolvedOnRetry) {
         const floored = IntentParser.floorTargets(intent, targetContext);
-        if (floored.droppedReaction) {
+        if (floored.outcome === "dropped") {
           fallbackApplied = true;
           retryKind = "parse_failed";
           parseResult = {
@@ -324,6 +326,20 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         } else {
           intent = floored.intent;
           parseResult = { ...parseResult, errorDetail: undefined, unresolvedTarget: undefined };
+          if (floored.outcome === "floored" || floored.outcome === "downgraded") {
+            targetFloor = {
+              detail: floored.detail ?? "",
+              data: {
+                field: floored.field,
+                badHandle: bad.badHandle,
+                outcome:
+                  floored.outcome === "downgraded"
+                    ? "downgraded_to_send_message"
+                    : "triggering_or_visible_event",
+                ...(floored.resolvedEventId ? { resolvedEventId: floored.resolvedEventId } : {}),
+              },
+            };
+          }
         }
       }
     }
@@ -389,6 +405,18 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         outputTokens: totalOutputTokens,
       },
     });
+
+    if (targetFloor) {
+      operatorEvents.push({
+        type: "target_resolution_floored",
+        simulationId,
+        agentId,
+        pulseIndex: ctx.pulseIndex,
+        detail: `Reply/reaction target for agent ${agentId} could not be resolved; engine floor applied: ${targetFloor.detail}`,
+        createdAt: ctx.now,
+        data: targetFloor.data,
+      });
+    }
 
     if (fallbackApplied && !repetitionBlocked) {
       const detail =

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -11,7 +11,7 @@ import type {
 import type { LLMConfig } from "../../llm/llm-config.js";
 import type { LLMProvider } from "../../llm/llm-provider.js";
 import { llmBudget } from "../../llm/llm-budget.js";
-import { IntentParser } from "../intent-parser.js";
+import { IntentParser, type TargetResolutionContext } from "../intent-parser.js";
 import {
   DEFAULT_REPETITION_MAX_RETRIES,
   isNearRepeat,
@@ -37,6 +37,17 @@ type RetryKind = "none" | "repeat_failed" | "parse_failed" | "provider_failed";
  */
 function retryCorrectionNote(lastAttempt: string): string {
   return `IMPORTANT: your last attempt this turn ("${lastAttempt}") was too close to something you already said. Say something genuinely different — a new angle, a reaction to someone else, a topic change — while staying true to what you actually want right now; do not invent novelty that your current motive and emotional state wouldn't justify. Or choose "no_op" if you truly have nothing new to add.`;
+}
+
+/**
+ * Correction appended to the system prompt on the single reply/react target
+ * retry: names the unresolvable handle, lists the valid handle set for this
+ * render, and offers the send_message escape hatch. The retry prompt version
+ * hash covers this text.
+ */
+function targetRetryCorrectionNote(field: string, badHandle: string, validHandles: string[]): string {
+  const valid = validHandles.length > 0 ? validHandles.join(", ") : "(no event handles are available this turn)";
+  return `IMPORTANT: you set "${field}" to "${badHandle || "(empty)"}", which is not one of the event handles shown in <events>. The only valid handles this turn are: ${valid}. Either set "${field}" to exactly one of those handles, or — if this was not actually a reply/reaction to one specific message — set "intentType" to "send_message" and omit "${field}".`;
 }
 
 /**
@@ -130,7 +141,16 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
       };
     }
 
-    let parseResult = IntentParser.parse(providerResult.content, agentId, input.availableActions, "no_op");
+    const targetContext: TargetResolutionContext = {
+      eventHandles: input.perceptionPacket.eventHandles ?? {},
+      events: [
+        ...(input.perceptionPacket.triggeringEvent ? [input.perceptionPacket.triggeringEvent] : []),
+        ...input.perceptionPacket.visibleContextEvents,
+      ],
+      triggeringEventId: input.perceptionPacket.triggeringEvent?.id,
+    };
+
+    let parseResult = IntentParser.parse(providerResult.content, agentId, input.availableActions, "no_op", targetContext);
 
     // Repetition guard: the prompt already tells the model not to repeat
     // itself and shows it the exact text to avoid, but empirically small
@@ -193,7 +213,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
             latencyMs: retryResult.latencyMs,
             promptVersion: retryPrompt.version,
           });
-          const retryParse = IntentParser.parse(retryResult.content, agentId, input.availableActions, "no_op");
+          const retryParse = IntentParser.parse(retryResult.content, agentId, input.availableActions, "no_op", targetContext);
           if (!retryParse.fallbackApplied && !isRepeat(retryParse.intent)) {
             parseResult = retryParse;
             intent = retryParse.intent;
@@ -235,6 +255,77 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         "no_op",
         `${REPETITION_GUARD_MARKER}: near-duplicate of a message you already sent, ${retryPhrase} — blocked structurally.`,
       );
+    }
+
+    // Reply/reaction target resolution: the model referenced an event handle
+    // that does not resolve. One pointed retry (budget permitting), then the
+    // triggering-event floor — the target is never committed empty or
+    // unresolved, and no_op is not this failure path (a reaction with
+    // nothing left to target is the sole exception: it is dropped).
+    if (!fallbackApplied && !repetitionBlocked && parseResult.unresolvedTarget) {
+      const bad = parseResult.unresolvedTarget;
+      let resolvedOnRetry = false;
+      const budgetDecision = llmBudget.canCall({
+        simulationId,
+        agentId,
+        priority: input.budgetPriority,
+        inputTokensEstimate: prompt.inputTokensEstimate,
+      });
+      if (budgetDecision.allowed) {
+        const note = targetRetryCorrectionNote(bad.field, bad.badHandle, bad.validHandles);
+        const retryPrompt = {
+          ...prompt,
+          version: promptVersionHash([`${prompt.system}\n\n${note}`, prompt.user]),
+          system: `${prompt.system}\n\n${note}`,
+        };
+        try {
+          const retryResult = await provider.generateIntent(input, runtimeContext, retryPrompt);
+          retriesAttempted++;
+          totalInputTokens += retryResult.usage.inputTokens;
+          totalOutputTokens += retryResult.usage.outputTokens;
+          retryUsages.push({
+            inputTokens: retryResult.usage.inputTokens,
+            outputTokens: retryResult.usage.outputTokens,
+            latencyMs: retryResult.latencyMs,
+            promptVersion: retryPrompt.version,
+          });
+          const retryParse = IntentParser.parse(
+            retryResult.content,
+            agentId,
+            input.availableActions,
+            "no_op",
+            targetContext,
+          );
+          if (!retryParse.fallbackApplied && !retryParse.unresolvedTarget) {
+            parseResult = retryParse;
+            intent = retryParse.intent;
+            resolvedOnRetry = true;
+          }
+        } catch {
+          // Retry call failed — fall through to the floor below.
+        }
+      }
+
+      if (!resolvedOnRetry) {
+        const floored = IntentParser.floorTargets(intent, targetContext);
+        if (floored.droppedReaction) {
+          fallbackApplied = true;
+          retryKind = "parse_failed";
+          parseResult = {
+            ...parseResult,
+            errorDetail: floored.detail ?? "Reaction target unresolvable; reaction dropped.",
+            unresolvedTarget: undefined,
+          };
+          intent = IntentParser.createFallback(
+            agentId,
+            "no_op",
+            floored.detail ?? "Reaction target unresolvable; reaction dropped.",
+          );
+        } else {
+          intent = floored.intent;
+          parseResult = { ...parseResult, errorDetail: undefined, unresolvedTarget: undefined };
+        }
+      }
     }
 
     const model = providerResult.model || llmConfig.modelName;

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -55,8 +55,9 @@ function targetRetryCorrectionNote(field: string, badHandle: string, validHandle
  * The `action_intent` LLM surface as a typed step. This is the canonical
  * implementation of the project's "engine owns structure, model owns language"
  * rule for the one active production surface: the provider call, strict parse,
- * repetition-guard retry arm and controlled fallback all live here as an
- * explicit, closed outcome instead of ad-hoc branches in the runtime.
+ * the single bounded retry arm (repetition guard + target resolution) and
+ * controlled fallback all live here as an explicit, closed outcome instead of
+ * ad-hoc branches in the runtime.
  */
 export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntimeOutput> {
   readonly purpose = "action_intent" as const;
@@ -153,12 +154,14 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
 
     let parseResult = IntentParser.parse(providerResult.content, agentId, input.availableActions, "no_op", targetContext);
 
-    // Repetition guard: the prompt already tells the model not to repeat
-    // itself and shows it the exact text to avoid, but empirically small
-    // local models repeat anyway. Give the model a bounded number of pointed
-    // retries (default: one), then block structurally. Outcomes are tracked
-    // separately so a failed retry is reported as an llm_failure, not as a
-    // repetition block.
+    // Single bounded retry arm for the two structural guard violations — a
+    // near-duplicate message and an unresolvable reply/react target. The
+    // prompt already instructs the model on both, but empirically small local
+    // models violate them anyway; the re-prompt names every currently
+    // violated constraint (default: one retry, budget permitting), and the
+    // latest attempt is then judged structurally: repetition block first,
+    // then the target floor. A failed retry is reported as an llm_failure,
+    // not as a repetition block.
     const policy = ctx.repetitionPolicy ?? {};
     const threshold = Math.min(1, Math.max(0, policy.threshold ?? REPETITION_SIMILARITY_THRESHOLD));
     const maxRetries = Math.max(0, Math.floor(policy.maxRetries ?? DEFAULT_REPETITION_MAX_RETRIES));
@@ -179,11 +182,13 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
       !!candidateIntent.visibleContent &&
       isNearRepeat(candidateIntent.visibleContent, input.perceptionPacket.ownRecentUtterances, threshold);
 
-    if (!fallbackApplied && isRepeat(intent)) {
+    if (!fallbackApplied && (isRepeat(intent) || parseResult.unresolvedTarget)) {
       for (let attempt = 0; attempt < maxRetries; attempt++) {
         // The gate's budget check runs once before the first call; each retry
         // is a further wire call it did not authorize, so re-check before
-        // issuing one. A denial must not turn into a free retry.
+        // issuing one. A denial must not turn into a free retry. With a
+        // near-duplicate still on the table the pulse is blocked below; a
+        // merely unresolved target falls to the floor instead.
         const budgetDecision = llmBudget.canCall({
           simulationId,
           agentId,
@@ -191,17 +196,28 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
           inputTokensEstimate: prompt.inputTokensEstimate,
         });
         if (!budgetDecision.allowed) {
-          repetitionBlocked = true;
-          retryKind = "repeat_failed";
+          if (isRepeat(intent)) {
+            repetitionBlocked = true;
+            retryKind = "repeat_failed";
+          }
           break;
         }
+        const corrections: string[] = [];
+        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
+        if (parseResult.unresolvedTarget) {
+          corrections.push(
+            targetRetryCorrectionNote(
+              parseResult.unresolvedTarget.field,
+              parseResult.unresolvedTarget.badHandle,
+              parseResult.unresolvedTarget.validHandles,
+            ),
+          );
+        }
+        const correction = corrections.join("\n\n");
         const retryPrompt = {
           ...prompt,
-          version: promptVersionHash([
-            `${prompt.system}\n\n${retryCorrectionNote(intent.visibleContent ?? "")}`,
-            prompt.user,
-          ]),
-          system: `${prompt.system}\n\n${retryCorrectionNote(intent.visibleContent ?? "")}`,
+          version: promptVersionHash([`${prompt.system}\n\n${correction}`, prompt.user]),
+          system: `${prompt.system}\n\n${correction}`,
         };
         try {
           const retryResult = await provider.generateIntent(input, runtimeContext, retryPrompt);
@@ -215,23 +231,26 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
             promptVersion: retryPrompt.version,
           });
           const retryParse = IntentParser.parse(retryResult.content, agentId, input.availableActions, "no_op", targetContext);
-          if (!retryParse.fallbackApplied && !isRepeat(retryParse.intent)) {
+          if (!retryParse.fallbackApplied && !isRepeat(retryParse.intent) && !retryParse.unresolvedTarget) {
             parseResult = retryParse;
             intent = retryParse.intent;
             fallbackApplied = false;
             break;
           }
+          // Adopt the latest attempt even when it still violates a guard, so
+          // the structural outcomes below judge the model's final answer: a
+          // still-repeating answer is blocked, a still-unresolved target is
+          // floored. A parse fallback ends the arm as an llm_failure.
+          parseResult = retryParse;
+          intent = retryParse.intent;
           if (retryParse.fallbackApplied) {
-            parseResult = retryParse;
-            intent = retryParse.intent;
             fallbackApplied = true;
             retryKind = "parse_failed";
             break;
           }
-          // Still a repeat; loop again if the retry budget allows.
         } catch {
           fallbackApplied = true;
-          intent = IntentParser.createFallback(agentId, "no_op", "Repetition retry call failed.");
+          intent = IntentParser.createFallback(agentId, "no_op", "Retry call failed.");
           retryKind = "provider_failed";
           break;
         }
@@ -258,88 +277,45 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
       );
     }
 
-    // Reply/reaction target resolution: the model referenced an event handle
-    // that does not resolve. One pointed retry (budget permitting), then the
-    // triggering-event floor — the target is never committed empty or
-    // unresolved, and no_op is not this failure path (a reaction with
-    // nothing left to target is the sole exception: it is dropped).
+    // Target floor: after the retry arm, an intent whose reply/react target
+    // is still unresolved never commits as-is — the triggering event (or the
+    // most recent visible message) is inferred as the target; with no event
+    // left to target, a reply downgrades to send_message and a reaction is
+    // dropped. The repetition block above takes precedence: a near-duplicate
+    // is never floored into a commit.
     let targetFloor: { detail: string; data: TargetResolutionFlooredData } | undefined;
-    if (!fallbackApplied && !repetitionBlocked && parseResult.unresolvedTarget) {
+    if (!fallbackApplied && parseResult.unresolvedTarget) {
       const bad = parseResult.unresolvedTarget;
-      let resolvedOnRetry = false;
-      const budgetDecision = llmBudget.canCall({
-        simulationId,
-        agentId,
-        priority: input.budgetPriority,
-        inputTokensEstimate: prompt.inputTokensEstimate,
-      });
-      if (budgetDecision.allowed) {
-        const note = targetRetryCorrectionNote(bad.field, bad.badHandle, bad.validHandles);
-        const retryPrompt = {
-          ...prompt,
-          version: promptVersionHash([`${prompt.system}\n\n${note}`, prompt.user]),
-          system: `${prompt.system}\n\n${note}`,
+      const floored = IntentParser.floorTargets(intent, targetContext);
+      if (floored.outcome === "dropped") {
+        fallbackApplied = true;
+        retryKind = "parse_failed";
+        parseResult = {
+          ...parseResult,
+          errorDetail: floored.detail ?? "Reaction target unresolvable; reaction dropped.",
+          unresolvedTarget: undefined,
         };
-        try {
-          const retryResult = await provider.generateIntent(input, runtimeContext, retryPrompt);
-          retriesAttempted++;
-          totalInputTokens += retryResult.usage.inputTokens;
-          totalOutputTokens += retryResult.usage.outputTokens;
-          retryUsages.push({
-            inputTokens: retryResult.usage.inputTokens,
-            outputTokens: retryResult.usage.outputTokens,
-            latencyMs: retryResult.latencyMs,
-            promptVersion: retryPrompt.version,
-          });
-          const retryParse = IntentParser.parse(
-            retryResult.content,
-            agentId,
-            input.availableActions,
-            "no_op",
-            targetContext,
-          );
-          if (!retryParse.fallbackApplied && !retryParse.unresolvedTarget) {
-            parseResult = retryParse;
-            intent = retryParse.intent;
-            resolvedOnRetry = true;
-          }
-        } catch {
-          // Retry call failed — fall through to the floor below.
-        }
-      }
-
-      if (!resolvedOnRetry) {
-        const floored = IntentParser.floorTargets(intent, targetContext);
-        if (floored.outcome === "dropped") {
-          fallbackApplied = true;
-          retryKind = "parse_failed";
-          parseResult = {
-            ...parseResult,
-            errorDetail: floored.detail ?? "Reaction target unresolvable; reaction dropped.",
-            unresolvedTarget: undefined,
+        intent = IntentParser.createFallback(
+          agentId,
+          "no_op",
+          floored.detail ?? "Reaction target unresolvable; reaction dropped.",
+        );
+      } else {
+        intent = floored.intent;
+        parseResult = { ...parseResult, errorDetail: undefined, unresolvedTarget: undefined };
+        if (floored.outcome === "floored" || floored.outcome === "downgraded") {
+          targetFloor = {
+            detail: floored.detail ?? "",
+            data: {
+              field: floored.field,
+              badHandle: bad.badHandle,
+              outcome:
+                floored.outcome === "downgraded"
+                  ? "downgraded_to_send_message"
+                  : "triggering_or_visible_event",
+              ...(floored.resolvedEventId ? { resolvedEventId: floored.resolvedEventId } : {}),
+            },
           };
-          intent = IntentParser.createFallback(
-            agentId,
-            "no_op",
-            floored.detail ?? "Reaction target unresolvable; reaction dropped.",
-          );
-        } else {
-          intent = floored.intent;
-          parseResult = { ...parseResult, errorDetail: undefined, unresolvedTarget: undefined };
-          if (floored.outcome === "floored" || floored.outcome === "downgraded") {
-            targetFloor = {
-              detail: floored.detail ?? "",
-              data: {
-                field: floored.field,
-                badHandle: bad.badHandle,
-                outcome:
-                  floored.outcome === "downgraded"
-                    ? "downgraded_to_send_message"
-                    : "triggering_or_visible_event",
-                ...(floored.resolvedEventId ? { resolvedEventId: floored.resolvedEventId } : {}),
-              },
-            };
-          }
         }
       }
     }
@@ -421,7 +397,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     if (fallbackApplied && !repetitionBlocked) {
       const detail =
         retryKind === "provider_failed"
-          ? `Repetition retry provider call failed for agent ${agentId}; falling back to no_op.`
+          ? `Retry provider call failed for agent ${agentId}; falling back to no_op.`
           : `LLM parsing or target constraint validation failed for agent ${agentId}: ${parseResult.errorDetail}`;
       operatorEvents.push({
         type: "llm_failure",

--- a/packages/server/src/llm/__tests__/mock-llm-provider.test.ts
+++ b/packages/server/src/llm/__tests__/mock-llm-provider.test.ts
@@ -66,7 +66,7 @@ describe("MockLLMProvider", () => {
     perceptionPacket: {
       agentId: "agent-beta",
       triggeringEvent: null,
-      visibleContextEvents: [], ownRecentUtterances: [],
+      visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],

--- a/packages/server/src/llm/__tests__/openai-compatible-provider.test.ts
+++ b/packages/server/src/llm/__tests__/openai-compatible-provider.test.ts
@@ -47,7 +47,7 @@ describe("OpenAiCompatibleProvider", () => {
     perceptionPacket: {
       agentId: "goulart",
       triggeringEvent: null,
-      visibleContextEvents: [], ownRecentUtterances: [],
+      visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: ["general"],
       relevantMemories: [],

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -177,6 +177,34 @@ describe("IntentResolver", () => {
     expect(event.type).toBe("message_sent");
     expect(event.actorId).toBe(AGENT_ID);
   });
+
+  it("carries the resolved reply target's actor into the reply_sent payload", async () => {
+    const intent = makeIntent({
+      intentType: "reply_to_message",
+      channelTarget: CHANNEL_ID,
+      visibleContent: "responding",
+      replyToEventId: "evt_real_42",
+      replyToActorId: "agent_peer",
+    });
+    const result = await resolver.resolve(intent, ctx());
+    expect(result.outcome).toBe("committed");
+    const payload = result.committedEvents[0]!.payload as Record<string, unknown>;
+    expect(payload.replyToEventId).toBe("evt_real_42");
+    expect(payload.replyToActorId).toBe("agent_peer");
+  });
+
+  it("omits replyToActorId from the payload when it was not resolved", async () => {
+    const intent = makeIntent({
+      intentType: "reply_to_message",
+      channelTarget: CHANNEL_ID,
+      visibleContent: "responding",
+      replyToEventId: "evt_real_42",
+    });
+    const result = await resolver.resolve(intent, ctx());
+    const payload = result.committedEvents[0]!.payload as Record<string, unknown>;
+    expect(payload.replyToEventId).toBe("evt_real_42");
+    expect("replyToActorId" in payload).toBe(false);
+  });
 });
 
 describe("private channel event tagging", () => {

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -106,7 +106,7 @@ function makeCannedStep(agentId: string): EngineStepResult {
     newEvents: [],
     attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
     perceptionPacket: {
-      agentId, triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
+      agentId, triggeringEvent: null, visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [], involvedPeople: [],
       relevantChannels: [], relevantMemories: [],
       translatedEmotionalState: { summary: "", emotions: [] },
       availableActions: [],

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -107,7 +107,7 @@ function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").E
     newEvents: [],
     attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
     perceptionPacket: {
-      agentId: "agent_1", triggeringEvent: null, visibleContextEvents: [], ownRecentUtterances: [], involvedPeople: [],
+      agentId: "agent_1", triggeringEvent: null, visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [], involvedPeople: [],
       relevantChannels: [], relevantMemories: [],
       translatedEmotionalState: { summary: "", emotions: [] },
       availableActions: [],

--- a/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
+++ b/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
@@ -59,7 +59,7 @@ function makeStepResult(): EngineStepResult {
     perceptionPacket: {
       agentId: "agent_1",
       triggeringEvent: null,
-      visibleContextEvents: [], ownRecentUtterances: [],
+      visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: [],
       relevantMemories: [],

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -2,6 +2,7 @@ import type {
   ActionIntent,
   CommittedEvent,
   SimulationEvent,
+  EventPayload,
   AgentState,
   Channel,
   ChannelMembership,
@@ -206,7 +207,7 @@ function buildReplyEvent(
   const channelId = intent.channelTarget ?? ctx.channelId;
   const replyToEventId = intent.replyToEventId;
   const vis = channelVisibility(channelId, ctx);
-  const payload: Record<string, unknown> = {
+  const payload: EventPayload = {
     content: intent.visibleContent ?? "",
     replyToEventId: replyToEventId ?? "",
     ...vis.payload,
@@ -217,7 +218,7 @@ function buildReplyEvent(
     channelId,
     actorId: intent.actorId,
     type: "reply_sent",
-    payload: payload as SimulationEvent["payload"],
+    payload,
     sourceIntentId: intent.id,
     sourceEventIds: replyToEventId ? [replyToEventId] : [],
     emotionalSalience: salience,

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -206,12 +206,18 @@ function buildReplyEvent(
   const channelId = intent.channelTarget ?? ctx.channelId;
   const replyToEventId = intent.replyToEventId;
   const vis = channelVisibility(channelId, ctx);
+  const payload: Record<string, unknown> = {
+    content: intent.visibleContent ?? "",
+    replyToEventId: replyToEventId ?? "",
+    ...vis.payload,
+  };
+  if (intent.replyToActorId) payload["replyToActorId"] = intent.replyToActorId;
   return {
     simulationId: ctx.simulationId,
     channelId,
     actorId: intent.actorId,
     type: "reply_sent",
-    payload: { content: intent.visibleContent ?? "", replyToEventId: replyToEventId ?? "", ...vis.payload },
+    payload: payload as SimulationEvent["payload"],
     sourceIntentId: intent.id,
     sourceEventIds: replyToEventId ? [replyToEventId] : [],
     emotionalSalience: salience,
@@ -354,6 +360,7 @@ function deriveFallbackIntent(
   }
   if (fallbackType === "reply_to_message") {
     derived.replyToEventId = primary.replyToEventId;
+    derived.replyToActorId = primary.replyToActorId;
   }
   if (fallbackType === "react") {
     derived.channelTarget = primary.channelTarget;

--- a/packages/shared/src/intent/intent.types.ts
+++ b/packages/shared/src/intent/intent.types.ts
@@ -29,6 +29,11 @@ export type ActionIntent = {
   memoryWrites: MemoryWriteProposal[];
   spectatorSummary?: string;
   replyToEventId?: string;
+  // Actor of the event replyToEventId resolves to, stamped by IntentParser
+  // once the reply target is resolved (handle lookup, retry, or the
+  // triggering-event floor). Carried into the reply_sent payload for
+  // downstream relational-state accretion.
+  replyToActorId?: string;
   emoji?: string;
   targetEventId?: string;
   channelName?: string;

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -18,6 +18,7 @@ export const OPERATOR_EVENT_TYPES = [
   "llm_budget_exceeded",
   "intent_blocked",
   "intent_delayed",
+  "target_resolution_floored",
   "stagnation_warning",
   "scheduler_error",
   "pulse_metrics",
@@ -92,6 +93,18 @@ export type ActionIntentOperatorData = {
   privateMotiveSummary: string;
   emotionDrivers: string[];
   motivationDrivers: string[];
+};
+
+/** `target_resolution_floored` payload — emitted when a reply/react intent's
+ *  target handle could not be resolved and the engine floor took over
+ *  (inferred the triggering/visible event, or downgraded the reply to
+ *  send_message). Makes a model that is systematically bad at targeting
+ *  visible in operator telemetry instead of silently corrected. */
+export type TargetResolutionFlooredData = {
+  field: "replyToEventId" | "targetEventId";
+  badHandle: string;
+  outcome: "triggering_or_visible_event" | "downgraded_to_send_message";
+  resolvedEventId?: string;
 };
 
 /** `event_visibility` payload — per-committed-event visibility/recipient

--- a/packages/shared/src/perception/perception.types.ts
+++ b/packages/shared/src/perception/perception.types.ts
@@ -19,4 +19,11 @@ export type PerceptionPacket = {
   relevantMemories: Memory[];
   translatedEmotionalState: TranslatedEmotionalState;
   availableActions: AvailableAction[];
+  // Per-render map from the short ordinal handle the prompt shows the model
+  // ("e1", "e2", …) to the real event id it stands for, covering the
+  // triggering event and every visible-context event. The model is asked to
+  // reference a handle for replyToEventId / targetEventId; IntentParser
+  // resolves it back to the real id against this map. Absent on packets not
+  // built by buildPerceptionPacket (treat as empty).
+  eventHandles?: Record<string, string>;
 };

--- a/packages/shared/src/perception/perception.types.ts
+++ b/packages/shared/src/perception/perception.types.ts
@@ -23,7 +23,7 @@ export type PerceptionPacket = {
   // ("e1", "e2", …) to the real event id it stands for, covering the
   // triggering event and every visible-context event. The model is asked to
   // reference a handle for replyToEventId / targetEventId; IntentParser
-  // resolves it back to the real id against this map. Absent on packets not
-  // built by buildPerceptionPacket (treat as empty).
-  eventHandles?: Record<string, string>;
+  // resolves it back to the real id against this map. Empty when nothing is
+  // in view, never absent.
+  eventHandles: Record<string, string>;
 };


### PR DESCRIPTION
## What

Gives the model a stable way to point at a specific event and resolves it engine-side:

- `buildPerceptionPacket` emits a per-render `eventHandles` map (`e1` -> real `evt_*` id) covering the triggering event and every visible-context event; one handle per distinct id.
- `ActionIntentPromptBuilder.formatEvent` prefixes each shown event with its `[e1]` handle, and `<output_contract>` / `<events>` instruct the model to set `replyToEventId` / `targetEventId` to a handle, verbatim.
- `IntentParser.parse` takes a `TargetResolutionContext`, resolves the handle (or a bracket-wrapped / verbatim real id) back to the real event id after schema validation, and stamps that event's actor as `replyToActorId`. An unresolvable handle returns `unresolvedTarget` (retriable), not a `no_op` fallback.
- `action-intent-step` re-prompts once with a targeted note naming the bad handle, the valid handle set, and the `send_message` escape hatch; then `IntentParser.floorTargets` infers the triggering event (else the most recent visible message) as the target for both `reply_to_message` and `react`. With neither, the reply downgrades to `send_message` and the reaction is dropped. `replyToEventId` / `targetEventId` is never committed empty or unresolved.
- `buildReplyEvent` writes `replyToActorId` into the `reply_sent` payload; `deriveFallbackIntent` carries it into a reply fallback.
- 23 tests: handle/bracket/verbatim-id resolution, invented-slug and empty-target flagging, legacy passthrough with no context, floor to triggering event / to last visible message / reply downgrade / reaction drop, one-retry-then-floor and one-retry-then-accept in the step, `reply_sent` payload carries `replyToActorId`, `eventHandles` ordinal assignment with and without a triggering event.

## Why

In a 30-reply sample run the model invented readable slugs for `replyToEventId` in 12 cases and left it empty in 18, because `formatEvent` showed it no event ids at all; `intent-parser.ts` passed the string through raw and `buildReplyEvent` / `buildReactionEvent` wrote `?? ""` verbatim, committing `reply_sent` / `reaction_sent` events with dangling targets. Reactions had the identical bug on `targetEventId`.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+23)
- `pnpm build` PASS, `pnpm -r typecheck` PASS across shared/engine/server/eval; server 739 passed, engine 305 passed, shared 132 passed.
- e2e roleplay smoke: mock replies that previously committed `replyToEventId: ""` now commit against the real triggering event id via the floor.

Closes #135


## Review fixes (findings response)
- Target resolution folded into the **single** existing retry arm: one re-prompt per attempt (budget permitting), combined trigger (repetition OR unresolved target), one retry-prompt version — max 2 LLM calls per pulse instead of 3.
- Retry-accept now applies the repetition guard (`isRepeat`); a near-duplicate retry with a valid handle can no longer commit (regression test added).
- Reply payload typed as `EventPayload`, removing the `SimulationEvent["payload"]` cast.
- Engine `build-perception-packet` test now uses the shared `makeAgent`/`makeEvent` fixtures; server gains a minimal shared intent-pipeline fixture module consumed by both new test files.

Semantic notes for reviewers (unifications of previously unpinned behavior):
- A retry returning a parse fallback (or throwing) on a target-only trigger now ends in `no_op` + `llm_failure` instead of flooring the original intent — consistent with the repetition arm.
- Floor telemetry reports the last attempt's bad handle (the intent actually floored).
- Spec gaps kept as implemented, disclosed: `floorTargets` also floors to the most recent visible `message_sent`/`reply_sent` when there is no triggering event (honors "never commit an unresolved target"; can silently re-target); the new `target_resolution_floored` operator event is beyond the spec text.
