### PR TITLE
fix(engine): relieve initiative accumulators stuck at 1.0 (#132)

### DIFF
--- a/packages/engine/src/__tests__/decision.test.ts
+++ b/packages/engine/src/__tests__/decision.test.ts
@@ -189,6 +189,11 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
     const next = updateInitiativeAccumulators(saturated, ZERO_ACTIONS, agent, CAIO, 1, false);
 
     for (const acc of next) {
+      if (acc.source === "cold_start_bootstrap") {
+        // passive-decay exempt: growth-only, so it rises instead of relaxing
+        expect(acc.value).toBeGreaterThan(0.9);
+        continue;
+      }
       expect(acc.value).toBeLessThan(0.9);
     }
   });
@@ -199,7 +204,10 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
     for (let i = 0; i < 100; i++) {
       accumulators = updateInitiativeAccumulators(accumulators, ZERO_ACTIONS, agent, CAIO, i, false);
     }
+    // cold_start_bootstrap is passive-decay exempt (its 0.30 threshold sits
+    // below the 0.4*energy ceiling); every other source relaxes below 1.0.
     for (const acc of accumulators) {
+      if (acc.source === "cold_start_bootstrap") continue;
       expect(acc.value).toBeLessThan(1);
     }
     // reply_pressure is the fastest grower; its fixed point is
@@ -217,11 +225,29 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
       const current = new Map(accumulators.map(a => [a.source, a.value]));
       if (prev) {
         for (const [source, value] of current) {
+          if (source === "cold_start_bootstrap") continue;
           const stuckAtCeiling = value >= 1 && prev.get(source)! >= 1;
           expect(stuckAtCeiling, `${source} pinned at 1.0 on pulse ${i}`).toBe(false);
         }
       }
       prev = current;
+    }
+  });
+
+  it("cold_start_bootstrap still crosses its threshold within ~2 silent pulses for a calm agent", () => {
+    // Passive-decay exemption regression: with universal passive decay,
+    // cold_start_bootstrap's fixed point (0.4*energy) sits under its 0.30
+    // threshold for typical persona energy, so proceed would never fire.
+    for (const energy of [0.3, 0.5]) {
+      const agent = makeAgent("cold", { coreMood: { ...BASE_MOOD, energy } });
+      let accumulators: InitiativeAccumulator[] = [];
+      let proceeded = false;
+      for (let i = 0; i < 2; i++) {
+        accumulators = updateInitiativeAccumulators(accumulators, ZERO_ACTIONS, agent, CAIO, i, false);
+        const candidates = scoreInitiativeCandidates(accumulators, i, null);
+        if (candidates.find(c => c.source === "cold_start_bootstrap")!.proceed) proceeded = true;
+      }
+      expect(proceeded, `energy ${energy}`).toBe(true);
     }
   });
 
@@ -250,11 +276,8 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
     expect(bootstrap!.score).toBeGreaterThan(0);
   });
 
-  it("scoreInitiativeCandidates no longer accepts lastActionAt / pulseIntervalMs", () => {
+  it("scoreInitiativeCandidates takes 3 args and still gates on arrivalPulse as the third", () => {
     expect(scoreInitiativeCandidates.length).toBe(3);
-  });
-
-  it("scoreInitiativeCandidates still gates on arrivalPulse as its third argument", () => {
     const accumulators = updateInitiativeAccumulators([], ZERO_ACTIONS, makeAgent(), CAIO, 0, false)
       .map(a => ({ ...a, value: 0.99 }));
     const beforeArrival = scoreInitiativeCandidates(accumulators, 2, 5);

--- a/packages/engine/src/__tests__/decision.test.ts
+++ b/packages/engine/src/__tests__/decision.test.ts
@@ -180,6 +180,51 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
     expect(afterAct).toBeLessThan(beforeAct);
   });
 
+  it("passive decay: a silent pulse relaxes every accumulator that is above its fixed point", () => {
+    const agent = makeAgent();
+    const saturated: InitiativeAccumulator[] = (
+      updateInitiativeAccumulators([], ZERO_ACTIONS, agent, CAIO, 0, false)
+    ).map(a => ({ ...a, value: 0.9 }));
+
+    const next = updateInitiativeAccumulators(saturated, ZERO_ACTIONS, agent, CAIO, 1, false);
+
+    for (const acc of next) {
+      expect(acc.value).toBeLessThan(0.9);
+    }
+  });
+
+  it("passive decay: a silent agent's accumulators converge below 1.0 instead of re-saturating", () => {
+    const agent = makeAgent();
+    let accumulators: InitiativeAccumulator[] = [];
+    for (let i = 0; i < 100; i++) {
+      accumulators = updateInitiativeAccumulators(accumulators, ZERO_ACTIONS, agent, CAIO, i, false);
+    }
+    for (const acc of accumulators) {
+      expect(acc.value).toBeLessThan(1);
+    }
+    // reply_pressure is the fastest grower; its fixed point is
+    // growth/(decayRate*0.5) = (0.08*energy)/0.20, still well under 1.0.
+    const replyPressure = accumulators.find(a => a.source === "reply_pressure");
+    expect(replyPressure!.value).toBeLessThan(0.6);
+  });
+
+  it("no initiative source stays at 1.0 across consecutive pulses over a 40-pulse silent run", () => {
+    const agent = makeAgent();
+    let accumulators: InitiativeAccumulator[] = [];
+    let prev: Map<string, number> | null = null;
+    for (let i = 0; i < 40; i++) {
+      accumulators = updateInitiativeAccumulators(accumulators, ZERO_ACTIONS, agent, CAIO, i, false);
+      const current = new Map(accumulators.map(a => [a.source, a.value]));
+      if (prev) {
+        for (const [source, value] of current) {
+          const stuckAtCeiling = value >= 1 && prev.get(source)! >= 1;
+          expect(stuckAtCeiling, `${source} pinned at 1.0 on pulse ${i}`).toBe(false);
+        }
+      }
+      prev = current;
+    }
+  });
+
   it("accumulator values stay in [0, 1]", () => {
     const agent = makeAgent();
     let accumulators: InitiativeAccumulator[] = [];
@@ -198,11 +243,24 @@ describe("updateInitiativeAccumulators + scoreInitiativeCandidates", () => {
     for (let i = 0; i < 5; i++) {
       accumulators = updateInitiativeAccumulators(accumulators, ZERO_ACTIONS, agent, CAIO, i, false);
     }
-    const candidates = scoreInitiativeCandidates(accumulators, 5, null, 3000);
+    const candidates = scoreInitiativeCandidates(accumulators, 5, null);
     const bootstrap = candidates.find(c => c.source === "cold_start_bootstrap");
     expect(bootstrap).toBeDefined();
     // May or may not proceed depending on accumulation, but score should be > 0
     expect(bootstrap!.score).toBeGreaterThan(0);
+  });
+
+  it("scoreInitiativeCandidates no longer accepts lastActionAt / pulseIntervalMs", () => {
+    expect(scoreInitiativeCandidates.length).toBe(3);
+  });
+
+  it("scoreInitiativeCandidates still gates on arrivalPulse as its third argument", () => {
+    const accumulators = updateInitiativeAccumulators([], ZERO_ACTIONS, makeAgent(), CAIO, 0, false)
+      .map(a => ({ ...a, value: 0.99 }));
+    const beforeArrival = scoreInitiativeCandidates(accumulators, 2, 5);
+    const afterArrival = scoreInitiativeCandidates(accumulators, 6, 5);
+    expect(beforeArrival.every(c => !c.proceed)).toBe(true);
+    expect(afterArrival.some(c => c.proceed)).toBe(true);
   });
 
   it("anyInitiativeProceed returns true when any candidate proceeds", () => {

--- a/packages/engine/src/attention/score-attention.ts
+++ b/packages/engine/src/attention/score-attention.ts
@@ -151,7 +151,8 @@ export function scoreAttention(
   const presencePenalty = PRESENCE_PENALTY[agent.presence] ?? 0;
   dueScore -= presencePenalty;
 
-  // Suppress: recent action cooldown
+  // Suppress: recent action cooldown. The 0.20 magnitude and the
+  // pulseIntervalMs * 3 horizon are provisional — both are tuned in #129.
   if (lastActionAt !== null) {
     const msSinceAction = now - lastActionAt;
     const cooldownRatio = Math.max(0, 1 - msSinceAction / (pulseIntervalMs * 3));

--- a/packages/engine/src/initiative/update-initiative-accumulators.ts
+++ b/packages/engine/src/initiative/update-initiative-accumulators.ts
@@ -34,7 +34,16 @@ const DEFAULTS: Record<InitiativeSource, { threshold: number; growthRate: number
   cold_start_bootstrap:     { threshold: 0.30, growthRate: 0.10, decayRate: 0.50 },
 };
 
-/** Map initiative source → relevant action emotion for growth modulation */
+/**
+ * Map initiative source → relevant action emotion for growth modulation.
+ *
+ * TODO(owner: team): emotion-modulated accumulator growth is designed but
+ * unwired — `run-engine-step` passes zeroed action emotions into this
+ * function (initiative updates before the emotion stack runs), so
+ * `emotionBoost` is always 0 in production. This map and the `emotionBoost`
+ * term are kept intact for the "emotion-modulated accumulator growth" fog
+ * item on issue #119. Designed-but-unwired since 63141c9 — not a regression.
+ */
 const SOURCE_EMOTION_MAP: Partial<Record<InitiativeSource, keyof ActionEmotions>> = {
   boredom_accumulator:   "curiousApproach",
   curiosity_accumulator: "curiousApproach",
@@ -48,6 +57,40 @@ const SOURCE_EMOTION_MAP: Partial<Record<InitiativeSource, keyof ActionEmotions>
   vulnerability_opening: "vulnerableRetreat",
 };
 
+/**
+ * Accumulator dynamics model
+ * ==========================
+ * Each of the 17 initiative sources carries a `value` in [0, 1] that pushes
+ * the agent toward acting once `value > threshold`. The value evolves per
+ * pulse under three regimes plus a firing cooldown:
+ *
+ * 1. Growth (silent pulse): `value += growthRate * energy`. `growthRate` is
+ *    per-source (see DEFAULTS); `energy` is `coreMood.energy`. The
+ *    `emotionBoost` term is present but inert in production (see
+ *    SOURCE_EMOTION_MAP's TODO).
+ *
+ * 2. Passive decay (silent pulse): before growth is added, the value relaxes
+ *    by `value *= 1 - decayRate * 0.5`. Without this a silent agent's motives
+ *    only ever ratchet up and re-saturate at 1.0. With it, each source has a
+ *    fixed point `growth / (decayRate * 0.5)` well below 1.0. The `0.5`
+ *    coefficient is provisional — it is retuned in #129.
+ *
+ * 3. Global relief on action: when the agent committed an outward social act
+ *    on the previous pulse (`justActed`), ALL 17 accumulators are multiplied
+ *    by `1 - decayRate * 2`. Relief is deliberately global, not
+ *    per-motive — targeted relief is deferred (parent #124). `justActed` is
+ *    derived in `run-engine-step` from `AgentState.lastActionAt`, which the
+ *    pulse scheduler stamps after a `send_message` / `reply_to_message` /
+ *    `react` / `create_channel` commit.
+ *
+ * 4. Firing cooldown: after a source fires, `lastFiredAt` is set and
+ *    `scoreInitiativeCandidates` blocks that source for
+ *    INITIATIVE_COOLDOWN_PULSES (5) pulses.
+ *
+ * A related post-action suppression lives in `score-attention.ts`: for
+ * `pulseIntervalMs * 3` after `lastActionAt` it subtracts up to `0.20` from
+ * the attention due-score. Both magnitudes there are provisional.
+ */
 export function updateInitiativeAccumulators(
   current: InitiativeAccumulator[],
   actionEmotions: ActionEmotions,
@@ -72,7 +115,7 @@ export function updateInitiativeAccumulators(
       lastFiredAt: null,
     };
 
-    // If just acted, decay strongly
+    // If just acted, apply global relief (multiply all 17 accumulators)
     if (justActed) {
       return { ...acc, value: clamp(acc.value * (1 - acc.decayRate * 2), 0, 1) };
     }
@@ -82,7 +125,10 @@ export function updateInitiativeAccumulators(
     const emotionBoost = emotionKey ? (actionEmotions[emotionKey] as number) * 0.3 : 0;
     const growth = (acc.growthRate + emotionBoost) * agentState.coreMood.energy;
 
-    const newValue = clamp(acc.value + growth, 0, 1);
+    // Passive decay on the silent branch so unspoken motives also relax and
+    // don't re-saturate at 1.0. The 0.5 coefficient is provisional (#129).
+    const decayed = acc.value * (1 - acc.decayRate * 0.5);
+    const newValue = clamp(decayed + growth, 0, 1);
 
     return {
       ...acc,
@@ -99,8 +145,6 @@ export function updateInitiativeAccumulators(
 export function scoreInitiativeCandidates(
   accumulators: InitiativeAccumulator[],
   pulseIndex: number,
-  lastActionAt: number | null,
-  pulseIntervalMs: number,
   arrivalPulse: number | null,
 ): InitiativeCandidate[] {
   const notArrived = arrivalPulse !== null && pulseIndex < arrivalPulse;

--- a/packages/engine/src/initiative/update-initiative-accumulators.ts
+++ b/packages/engine/src/initiative/update-initiative-accumulators.ts
@@ -75,6 +75,14 @@ const SOURCE_EMOTION_MAP: Partial<Record<InitiativeSource, keyof ActionEmotions>
  *    fixed point `growth / (decayRate * 0.5)` well below 1.0. The `0.5`
  *    coefficient is provisional — it is retuned in #129.
  *
+ *    `cold_start_bootstrap` is exempt and stays growth-only on the silent
+ *    branch. Its threshold (0.30) sits below the passive-decay ceiling
+ *    `0.4 * energy`, so at typical persona energy (~0.3–0.5) the decayed
+ *    fixed point never reaches the threshold. Decaying it would gate an
+ *    always-on silence-breaker for a room that hasn't warmed up behind agent
+ *    energy — for a calm agent the source would never cross and
+ *    `scoreInitiativeCandidates` would never return `proceed` for it.
+ *
  * 3. Global relief on action: when the agent committed an outward social act
  *    on the previous pulse (`justActed`), ALL 17 accumulators are multiplied
  *    by `1 - decayRate * 2`. Relief is deliberately global, not
@@ -127,7 +135,13 @@ export function updateInitiativeAccumulators(
 
     // Passive decay on the silent branch so unspoken motives also relax and
     // don't re-saturate at 1.0. The 0.5 coefficient is provisional (#129).
-    const decayed = acc.value * (1 - acc.decayRate * 0.5);
+    // cold_start_bootstrap is exempt: its 0.30 threshold sits below the
+    // passive-decay ceiling 0.4*energy, so decaying it would gate the
+    // always-on cold-start stagger behind agent energy.
+    const decayed =
+      source === "cold_start_bootstrap"
+        ? acc.value
+        : acc.value * (1 - acc.decayRate * 0.5);
     const newValue = clamp(decayed + growth, 0, 1);
 
     return {

--- a/packages/engine/src/step/run-engine-step.ts
+++ b/packages/engine/src/step/run-engine-step.ts
@@ -192,8 +192,6 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
   const initiativeCandidates = scoreInitiativeCandidates(
     updatedAccumulators,
     pulseIndex,
-    agentState.lastActionAt,
-    simulation.settings.pulseIntervalMs,
     agentState.arrivalPulse,
   );
   const isOffline = agentState.presence === "offline";

--- a/packages/eval/src/goal-layer/scenario-recipes.ts
+++ b/packages/eval/src/goal-layer/scenario-recipes.ts
@@ -390,13 +390,22 @@ const RECIPES: Record<GoalScenarioId, GoalScenarioRecipe> = {
     id: "hollow-completion",
     mode: "deterministic",
     agents: makeAgents(),
-    channels: [GENERAL_CHANNEL],
+    channels: [GENERAL_CHANNEL, SIDELINE_CHANNEL],
     settings: SETTINGS,
     // The seeded follow-up commits in the same batch as the blocks, so its
     // createdAt equals goal.createdAt — the completion-beat gate needs a
     // strictly later message, so the seed alone never fires the beat.
     seedEvents: [...RESOLVE_SEEDS, followUpEvent(0)],
-    inject: (review) => [witnessEvent(review), followUpEvent(review)],
+    // Sideline chatter ana cannot see, on every review: the world reads
+    // reached and ana's completion beat fires, but her narrative stays
+    // under-informed, holding log divergence above the meaning-made ceiling
+    // so the goal re-goals as hollow instead of ending. Explicit invisible
+    // events carry this rather than relying on per-pulse operator-only noise.
+    inject: (review) => [
+      witnessEvent(review),
+      followUpEvent(review),
+      ...sidelineBurst(),
+    ],
   },
 
   "world-briefly-wrong": {

--- a/packages/server/src/simulation/__tests__/initiative-two-agent-run.test.ts
+++ b/packages/server/src/simulation/__tests__/initiative-two-agent-run.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { PulseScheduler } from "../pulse-scheduler.js";
+import {
+  InMemoryEventRepository,
+  InMemoryAgentStateRepository,
+  InMemoryChannelRepository,
+} from "../in-memory-stores.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { IntentResolver } from "../intent-resolver.js";
+import { EngineSnapshotProjection } from "../projections/engine-snapshot-projection.js";
+import { DeliveryProjection } from "../projections/delivery-projection.js";
+import { SpectatorProjection } from "../projections/spectator-projection.js";
+import { OperatorProjection } from "../projections/operator-projection.js";
+import { EngineEventBuilder } from "../engine-event-builder.js";
+import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import type { AgentContext, AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
+import type {
+  ActionIntent,
+  AgentState,
+  EngineSnapshot,
+  EngineStepResult,
+  PersonaConfig,
+  Simulation,
+  SimulationSettings,
+} from "@perfectman/shared";
+import { BRUNO, GOULART, createId } from "@perfectman/shared";
+import { runEngineStep } from "@perfectman/engine";
+
+/**
+ * Spec acceptance criterion (issue #132): over a 40-pulse 2-agent run, no
+ * initiative source stays at 1.0 across consecutive pulses. The run lives at
+ * the scheduler layer because the relief half of that invariant —
+ * lastActionAt stamping feeding justActed on the next pulse — only exists in
+ * the PulseScheduler wiring, not in the pure engine loop.
+ */
+
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  // RateLimitGate's minute window runs on wall clock; sizing the cap above
+  // the run's traffic keeps the seeded dynamics free of real-time influence.
+  maxMessagesPerMinutePerAgent: 1000,
+  llmCallBudgetPerMinute: 1000,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+const SIM: Simulation = {
+  id: "sim_initiative_run",
+  name: "initiative-run",
+  status: "running",
+  agentIds: ["agent_bruno", "agent_goulart"],
+  channelIds: ["ch_public"],
+  settings: SETTINGS,
+  seed: 7,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+const PULSES = 40;
+
+function makeAgentState(agentId: string, persona: PersonaConfig): AgentState {
+  return {
+    agentId,
+    simulationId: SIM.id,
+    personaId: persona.id,
+    presence: "active",
+    coreMood: {
+      valence: persona.baselineValence,
+      arousal: persona.baselineArousal,
+      stability: persona.baselineStability,
+      energy: persona.baselineEnergy,
+      circumplexAngle: 0,
+      circumplexRadius: 0.3,
+      momentumValence: 0,
+      momentumArousal: 0,
+    },
+    socialEmotions: {
+      jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0,
+      affection: 0, resentment: 0, suspicion: 0, admiration: 0,
+      contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0,
+      desireForStatus: 0, desireForIntimacy: 0,
+    },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/** Canned LLM: every needsLLM decision becomes a committed public message. */
+function makeCannedRuntime(): AgentRuntime {
+  return {
+    generateIntent: async (input) => ({
+      intent: {
+        id: createId(),
+        actorId: input.agentId,
+        intentType: "send_message" as ActionIntent["intentType"],
+        visibleContent: `${input.agentId} breaks the silence`,
+        personTargets: [],
+        privateMotiveSummary: "something needs saying",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+      },
+      llmUsage: null,
+      latencyMs: 0,
+      fallbackApplied: false,
+      operatorEvents: [],
+    }),
+  };
+}
+
+const mockLLMBudget: LLMBudget = {
+  getPriority: () => "normal",
+};
+
+type AccumulatorTrace = Map<string, Map<number, Map<string, number>>>;
+
+async function runTwoAgentSimulation(): Promise<{
+  trace: AccumulatorTrace;
+  eventRepo: InMemoryEventRepository;
+}> {
+  const eventRepo = new InMemoryEventRepository();
+  const agentStateRepo = new InMemoryAgentStateRepository();
+  const channelRepo = new InMemoryChannelRepository();
+  const channelRegistry = new ChannelRegistry(channelRepo);
+  const gateway = new MockDeliveryGateway();
+  const rateLimitGate = new RateLimitGate(SETTINGS);
+  const intentResolver = new IntentResolver(rateLimitGate, channelRegistry);
+  const engineEventBuilder = new EngineEventBuilder();
+
+  await channelRepo.create({
+    id: "ch_public",
+    simulationId: SIM.id,
+    type: "public_channel",
+    name: "general",
+    createdBy: "system",
+    memberAgentIds: SIM.agentIds,
+    spectatorVisible: true,
+    operatorVisible: true,
+    createdForMotives: [],
+    status: "active",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  for (const agentId of SIM.agentIds) {
+    await channelRepo.addMembership({ channelId: "ch_public", agentId, joinedAt: Date.now() });
+  }
+
+  const agents: AgentContext[] = [];
+  for (const persona of [BRUNO, GOULART]) {
+    const agentId = `agent_${persona.id}`;
+    const state = makeAgentState(agentId, persona);
+    await agentStateRepo.upsert(state);
+    agents.push({ id: agentId, state, persona });
+  }
+
+  const trace: AccumulatorTrace = new Map();
+  const stepResolver = (snapshot: EngineSnapshot): EngineStepResult => {
+    const result = runEngineStep(snapshot);
+    const byPulse = trace.get(snapshot.agentState.agentId) ?? new Map();
+    byPulse.set(
+      snapshot.pulseIndex,
+      new Map(result.updatedAgentState.initiativeAccumulators.map(a => [a.source, a.value])),
+    );
+    trace.set(snapshot.agentState.agentId, byPulse);
+    return result;
+  };
+
+  const scheduler = new PulseScheduler({
+    simulation: SIM,
+    agents,
+    defaultPublicChannelId: "ch_public",
+    eventRepo,
+    agentStateRepo,
+    channelRegistry,
+    rateLimitGate,
+    intentResolver,
+    engineSnapshotProjection: new EngineSnapshotProjection(),
+    deliveryProjection: new DeliveryProjection(gateway),
+    spectatorProjection: new SpectatorProjection(gateway),
+    operatorProjection: new OperatorProjection(gateway),
+    engineEventBuilder,
+    agentRuntime: makeCannedRuntime(),
+    llmBudget: mockLLMBudget,
+    pulseIntervalMs: SETTINGS.pulseIntervalMs,
+    stepResolver,
+  });
+
+  for (let i = 0; i < PULSES; i++) {
+    await scheduler.runPulse();
+  }
+
+  return { trace, eventRepo };
+}
+
+describe("40-pulse two-agent initiative run", () => {
+  it("is a live run: both agents are stepped every pulse and commit messages", async () => {
+    const { trace, eventRepo } = await runTwoAgentSimulation();
+
+    const events = await eventRepo.getAfter(SIM.id);
+    for (const agentId of SIM.agentIds) {
+      const byPulse = trace.get(agentId);
+      expect(byPulse?.size, `${agentId} observed on every pulse`).toBe(PULSES);
+      expect(
+        events.some(e => e.type === "message_sent" && e.actorId === agentId),
+        `${agentId} committed at least one message`,
+      ).toBe(true);
+    }
+  });
+
+  it("no initiative source stays at 1.0 across consecutive pulses", async () => {
+    const { trace } = await runTwoAgentSimulation();
+
+    for (const [agentId, byPulse] of trace) {
+      let prev: Map<string, number> | null = null;
+      for (let pulse = 0; pulse < PULSES; pulse++) {
+        const current = byPulse.get(pulse)!;
+        if (prev) {
+          for (const [source, value] of current) {
+            // Unlike the engine-level silent loop, cold_start_bootstrap is
+            // NOT skipped: a live run fires it, and the committed act's
+            // justActed relief resets it before it can pin at the ceiling.
+            const pinned = value >= 1 && prev.get(source)! >= 1;
+            expect(
+              pinned,
+              `${agentId}/${source} pinned at 1.0 across pulses ${pulse - 1}-${pulse}`,
+            ).toBe(false);
+          }
+        }
+        prev = current;
+      }
+    }
+  });
+});

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -13,6 +13,7 @@ import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
 import type { AgentContext, AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
 import type { Simulation, SimulationSettings, AgentState, PersonaConfig, ActionIntent, EndingOffer, GoalSynthesisResult, SimulationEvent } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
+import { runEngineStep } from "@perfectman/engine";
 import { resolveGoalLayerConfig, WorldEvaluator } from "../world/world-evaluator.js";
 import type { GoalLayerRuntime, WorldReview } from "../world/world-evaluator.js";
 
@@ -347,6 +348,72 @@ describe("PulseScheduler", () => {
         "fallback_committed",
       );
       expect(socialFallback?.lastActionAt).toBe(SETTINGS.pulseIntervalMs);
+    });
+  });
+
+  describe("stamp → relief seam (real engine step)", () => {
+    it("a committed act stamps lastActionAt and the next real engine step relieves the accumulators", async () => {
+      const ACT_PULSE = 3;
+      const sched = buildScheduler((snap) => {
+        const real = runEngineStep(snap);
+        if (snap.pulseIndex === ACT_PULSE) {
+          return {
+            ...real,
+            decision: { ...real.decision, outcome: "act", needsLLM: true, initiativeProceed: false },
+          };
+        }
+        return real;
+      });
+
+      mockAgentRuntime.generateIntent = vi.fn().mockResolvedValue({
+        intent: {
+          id: createId(),
+          actorId: "agent_1",
+          intentType: "send_message",
+          visibleContent: "hi",
+          personTargets: [],
+          privateMotiveSummary: "test motive",
+          emotionDrivers: [],
+          motivationDrivers: [],
+          memoryWrites: [],
+        },
+        llmUsage: null,
+        latencyMs: 10,
+        fallbackApplied: false,
+        operatorEvents: [],
+      });
+      vi.spyOn(intentResolver, "resolve").mockResolvedValue({
+        outcome: "committed",
+        committedEvents: [],
+        operatorEvents: [],
+      });
+
+      for (let i = 0; i <= ACT_PULSE; i++) await sched.runPulse();
+
+      const afterAct = await agentStateRepo.get("sim_test", "agent_1");
+      expect(afterAct?.lastActionAt).toBe(SETTINGS.pulseIntervalMs * (ACT_PULSE + 1));
+      const before = new Map((afterAct?.initiativeAccumulators ?? []).map((a) => [a.source, a.value]));
+      expect(before.size).toBeGreaterThan(0);
+
+      // Next pulse: now - lastActionAt = pulseIntervalMs < pulseIntervalMs * 1.5,
+      // so run-engine-step derives justActed === true and applies global relief.
+      await sched.runPulse();
+
+      const afterRelief = await agentStateRepo.get("sim_test", "agent_1");
+      const after = new Map((afterRelief?.initiativeAccumulators ?? []).map((a) => [a.source, a.value]));
+
+      // cold_start_bootstrap is passive-decay exempt, so any drop here is the
+      // justActed relief, not silent decay.
+      expect(before.get("cold_start_bootstrap")!).toBeGreaterThan(0);
+      expect(after.get("cold_start_bootstrap")!).toBeLessThan(before.get("cold_start_bootstrap")!);
+
+      let totalBefore = 0;
+      let totalAfter = 0;
+      for (const [source, value] of before) {
+        totalBefore += value;
+        totalAfter += after.get(source)!;
+      }
+      expect(totalAfter).toBeLessThan(totalBefore);
     });
   });
 

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -270,6 +270,86 @@ describe("PulseScheduler", () => {
     expect(mockAgentRuntime.generateIntent).toHaveBeenCalled();
   });
 
+  describe("lastActionAt stamping", () => {
+    function makeIntent(
+      intentType: ActionIntent["intentType"],
+      extra: Partial<ActionIntent> = {},
+    ): ActionIntent {
+      return {
+        id: createId(),
+        actorId: "agent_1",
+        intentType,
+        personTargets: [],
+        privateMotiveSummary: "test motive",
+        emotionDrivers: [],
+        motivationDrivers: [],
+        memoryWrites: [],
+        ...extra,
+      };
+    }
+
+    async function runAndReadState(
+      intent: ActionIntent,
+      outcome: import("@perfectman/shared").ResolvedIntentOutcome,
+    ): Promise<AgentState | null> {
+      const sched = buildScheduler(() => ({
+        ...makeCannedStep(),
+        decision: { outcome: "act", needsLLM: true, initiativeProceed: false },
+        noOpRecord: null,
+      }));
+      mockAgentRuntime.generateIntent = vi.fn().mockResolvedValue({
+        intent,
+        llmUsage: null,
+        latencyMs: 10,
+        fallbackApplied: false,
+        operatorEvents: [],
+      });
+      vi.spyOn(intentResolver, "resolve").mockResolvedValue({
+        outcome,
+        committedEvents: [],
+        operatorEvents: [],
+      });
+      await sched.runPulse();
+      return agentStateRepo.get("sim_test", "agent_1");
+    }
+
+    for (const intentType of ["send_message", "reply_to_message", "react", "create_channel"] as const) {
+      it(`stamps lastActionAt after a committed ${intentType}`, async () => {
+        const state = await runAndReadState(makeIntent(intentType), "committed");
+        expect(state?.lastActionAt).toBe(SETTINGS.pulseIntervalMs);
+      });
+    }
+
+    it("does not stamp lastActionAt for a committed no_op", async () => {
+      const state = await runAndReadState(makeIntent("no_op"), "committed");
+      expect(state?.lastActionAt).toBeNull();
+    });
+
+    it("does not stamp lastActionAt for a committed write_memory (memory-only)", async () => {
+      const state = await runAndReadState(makeIntent("write_memory"), "committed");
+      expect(state?.lastActionAt).toBeNull();
+    });
+
+    it("does not stamp lastActionAt when an outward act is blocked", async () => {
+      const state = await runAndReadState(makeIntent("send_message"), "blocked");
+      expect(state?.lastActionAt).toBeNull();
+    });
+
+    it("stamps on fallback_committed only when the fallback itself is an outward act", async () => {
+      const noOpFallback = await runAndReadState(
+        makeIntent("send_message", { fallbackIfBlocked: "no_op" }),
+        "fallback_committed",
+      );
+      expect(noOpFallback?.lastActionAt).toBeNull();
+
+      const socialFallback = await runAndReadState(
+        makeIntent("react", { fallbackIfBlocked: "send_message" }),
+        "fallback_committed",
+      );
+      expect(socialFallback?.lastActionAt).toBe(SETTINGS.pulseIntervalMs);
+    });
+  });
+
   describe("goal-layer wiring (TT401)", () => {
     const GOAL_SETTINGS: SimulationSettings = { ...SETTINGS, omniscientSpectatorMode: true };
     const GOAL_SIM: Simulation = { ...SIM, settings: GOAL_SETTINGS };

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -32,6 +32,19 @@ import { buildWorldSignals } from "./world-signals-builder.js";
 import type { AgentRuntimeContext, AgentRuntimeOutput } from "../agent/agent-runtime.types.js";
 import type { GoalLayerRuntime } from "./world/world-evaluator.js";
 
+/**
+ * Intent types that count as an outward social act for the purpose of
+ * stamping `AgentState.lastActionAt`. The engine reads that field to grant
+ * initiative-accumulator relief on the next pulse (`justActed`); `no_op`,
+ * `write_memory`, and typing/lifecycle intents must not trigger it.
+ */
+const OUTWARD_SOCIAL_ACT_TYPES: ReadonlySet<ActionIntent["intentType"]> = new Set([
+  "send_message",
+  "reply_to_message",
+  "react",
+  "create_channel",
+]);
+
 export type AgentContext = {
   id: string;
   state: AgentState;
@@ -311,6 +324,19 @@ export class PulseScheduler {
 
         for (const opEv of [...resolved.operatorEvents, ...runtimeOutput.operatorEvents]) {
           await this.emitOperatorEvent(opEv);
+        }
+
+        // Stamp lastActionAt when the act that actually committed is an
+        // outward social act. On fallback_committed the primary intent was
+        // blocked and the fallback ran, so fallbackIfBlocked is what landed.
+        const committedActType =
+          resolved.outcome === "committed"
+            ? intent.intentType
+            : resolved.outcome === "fallback_committed"
+              ? intent.fallbackIfBlocked
+              : undefined;
+        if (committedActType && OUTWARD_SOCIAL_ACT_TYPES.has(committedActType)) {
+          stepResult.updatedAgentState.lastActionAt = now;
         }
       }
 


### PR DESCRIPTION
## What

Unsticks the initiative-accumulator relief path so the 17 sources stop pinning at `1.0`:

- The pulse scheduler stamps `stepResult.updatedAgentState.lastActionAt = now` before `persistAndSnapshot` when the committed act is `send_message` / `reply_to_message` / `react` / `create_channel`. `no_op`, `write_memory`, and typing/lifecycle intents are excluded; on `fallback_committed` the `fallbackIfBlocked` type decides.
- Passive decay on the silent branch of `updateInitiativeAccumulators`: `value *= 1 - decayRate * 0.5` before growth, giving a quiet agent a fixed point well below `1.0` instead of a monotone climb. The `0.5` coefficient is provisional, retuned in #129.
- `scoreInitiativeCandidates` drops its never-read `lastActionAt` and `pulseIntervalMs` parameters; both call sites updated.
- `SOURCE_EMOTION_MAP` / `emotionBoost` kept as-is with a `TODO(owner: team)` pointing at the emotion-modulated-growth item on #119. The accumulator-dynamics model (growth, global `1 - decayRate*2` relief on `justActed`, passive decay, 5-pulse `lastFiredAt` cooldown, the provisional `score-attention` `0.20` / `pulseIntervalMs*3` post-action cooldown) is documented alongside the function.
- `hollow-completion` eval recipe gains `SIDELINE_CHANNEL` + a per-review `sidelineBurst()` ana cannot see, so its log divergence rides on explicit invisible events instead of the per-pulse operator-only no-op noise that relaxed accumulators remove.
- 13 tests: engine — silent relaxation above the fixed point, 100-pulse convergence `< 1.0`, no source pinned at `1.0` across 40 consecutive silent pulses, `scoreInitiativeCandidates` arity, `arrivalPulse` still gates; server — each of the four outward-act types stamps `lastActionAt`, and `no_op` / `write_memory` / blocked / fallback-to-`no_op` do not while fallback-to-`send_message` does.

## Why

`AgentState.lastActionAt` was never written non-null, so `justActed` in `run-engine-step` was always false, the sole relief branch in `update-initiative-accumulators` was unreachable, and every initiative source clamped at `1.0` within ~18 pulses and stayed there. Parent decision #124, plan #119.

## Validation

- `pnpm lint` per-package typecheck PASS for `shared` / `engine` / `server`, `eval` compiles clean via `pnpm build` (aggregate `pnpm -r typecheck` OOMs in this sandbox) - `pnpm test:all` PASS 1328 (+13)
- `pnpm build` PASS all 4 packages; `pnpm --filter @perfectman/engine test` 307 (+5); `pnpm --filter @perfectman/server test` 727 (+8)
- `hollow-completion` divergenceFromLog `0.34 -> 0.30` after the accumulator change dropped it under the `0.33` meaning-made ceiling and ended the run at pulse 2; the recipe fix restores the 120-pulse cap with every resolve record `kind: re_goal`, reason `hollow completion re-goals`

Closes #132


## Review fixes (findings response)
- Added `initiative-two-agent-run.test.ts`: a real 40-pulse two-agent run (canned AgentRuntime, no live LLM, fully seeded, ~40ms) asserting no initiative source — including `cold_start_bootstrap` — stays at 1.0 across consecutive pulses. Mutation-checked: it fails when both decay and relief are removed.
- AC2 coverage note: the engine-level silent-loop test skips `cold_start_bootstrap`; the new run-level test covers it.

Spec deviation, disclosed: `cold_start_bootstrap` is exempt from the passive-decay formula — its decayed fixed point would be `0.4·energy`, below the 0.30 firing threshold for energy ≤ 0.75, so the source could never fire. It remains growth-only + clamp; the run-level fire→relief cycle caps it. Residual risk: it is the only source that could still pin at 1.0 if every initiative-driven act fails to commit outward.
