### PR TITLE
fix(server): emit one agent_message per committed message (#116)

### DIFF
--- a/packages/server/src/simulation/__tests__/delivery-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/delivery-projection.test.ts
@@ -173,16 +173,27 @@ describe("DeliveryProjection — one emission per committed message", () => {
   const AGENT_3 = "agent_3";
   const AGENT_4 = "agent_4";
   const BIG_CHANNEL_ID = "ch_big";
+  const NOW = 1_700_000_000_000;
+
+  let gateway: MockDeliveryGateway;
+  let projection: DeliveryProjection;
+
+  beforeEach(() => {
+    gateway = new MockDeliveryGateway();
+    projection = new DeliveryProjection(gateway);
+  });
 
   const bigChannel: Channel = {
     ...PUBLIC_CHANNEL,
     id: BIG_CHANNEL_ID,
     memberAgentIds: [AGENT_1, AGENT_2, AGENT_3, AGENT_4],
+    createdAt: NOW,
+    updatedAt: NOW,
   };
   const bigMembership: ChannelMembership[] = [AGENT_1, AGENT_2, AGENT_3, AGENT_4].map(agentId => ({
     channelId: BIG_CHANNEL_ID,
     agentId,
-    joinedAt: Date.now(),
+    joinedAt: NOW,
   }));
   const bigChannelEvent = (type: CommittedEvent["type"]): CommittedEvent =>
     makeCommittedEvent({
@@ -192,15 +203,11 @@ describe("DeliveryProjection — one emission per committed message", () => {
     });
 
   it("a message to a 4-member channel produces exactly one sendAgentMessage call", async () => {
-    const gateway = new MockDeliveryGateway();
-    const projection = new DeliveryProjection(gateway);
     await projection.project(bigChannelEvent("message_sent"), [bigChannel], bigMembership, SETTINGS);
     expect(gateway.agentMessages).toHaveLength(1);
   });
 
   it("reply and reaction events each emit exactly once on an N-member channel", async () => {
-    const gateway = new MockDeliveryGateway();
-    const projection = new DeliveryProjection(gateway);
     await projection.project(bigChannelEvent("reply_sent"), [bigChannel], bigMembership, SETTINGS);
     await projection.project(bigChannelEvent("reaction_sent"), [bigChannel], bigMembership, SETTINGS);
     expect(gateway.agentMessages).toHaveLength(2);
@@ -214,7 +221,7 @@ describe("DeliveryProjection — one emission per committed message", () => {
       return true;
     });
     try {
-      const projection = new DeliveryProjection(new StdoutDeliveryGateway());
+      projection = new DeliveryProjection(new StdoutDeliveryGateway());
       await projection.project(bigChannelEvent("message_sent"), [bigChannel], bigMembership, SETTINGS);
     } finally {
       spy.mockRestore();

--- a/packages/server/src/simulation/__tests__/delivery-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/delivery-projection.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { DeliveryProjection } from "../projections/delivery-projection.js";
 import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import { StdoutDeliveryGateway } from "../../delivery/stdout-delivery-gateway.js";
 import type { CommittedEvent, Channel, ChannelMembership, SimulationSettings } from "@perfectman/shared";
 
 const SIM_ID = "sim_1";
@@ -87,11 +88,12 @@ describe("DeliveryProjection", () => {
     projection = new DeliveryProjection(gateway);
   });
 
-  it("sends a message_sent event to all channel members", async () => {
+  it("emits one agent_message for a message_sent event regardless of member count", async () => {
     const event = makeCommittedEvent({ type: "message_sent" });
     await projection.project(event, [PUBLIC_CHANNEL, PRIVATE_CHANNEL], MEMBERSHIPS, SETTINGS);
-    expect(gateway.agentMessages.length).toBeGreaterThanOrEqual(1);
+    expect(gateway.agentMessages).toHaveLength(1);
     expect(gateway.agentMessages[0]!.message.kind).toBe("message");
+    expect(gateway.agentMessages[0]!.channelId).toBe(PUB_CHANNEL_ID);
   });
 
   it("private channel event does NOT reach non-member agent", async () => {
@@ -155,8 +157,69 @@ describe("DeliveryProjection", () => {
       projection.project(event, [PUBLIC_CHANNEL, PRIVATE_CHANNEL], MEMBERSHIPS, SETTINGS),
     ).resolves.toBeUndefined();
 
-    expect(gateway.operatorEvents).toHaveLength(MEMBERSHIPS.filter(m => m.channelId === PUB_CHANNEL_ID).length);
+    expect(gateway.operatorEvents).toHaveLength(1);
     expect(gateway.operatorEvents[0]?.type).toBe("scheduler_error");
     expect(gateway.operatorEvents[0]?.detail).toContain("Delivery gateway failed");
+  });
+});
+
+describe("DeliveryProjection — one emission per committed message", () => {
+  const AGENT_3 = "agent_3";
+  const AGENT_4 = "agent_4";
+  const BIG_CHANNEL_ID = "ch_big";
+
+  const bigChannel: Channel = {
+    ...PUBLIC_CHANNEL,
+    id: BIG_CHANNEL_ID,
+    memberAgentIds: [AGENT_1, AGENT_2, AGENT_3, AGENT_4],
+  };
+  const bigMembership: ChannelMembership[] = [AGENT_1, AGENT_2, AGENT_3, AGENT_4].map(agentId => ({
+    channelId: BIG_CHANNEL_ID,
+    agentId,
+    joinedAt: Date.now(),
+  }));
+  const bigChannelEvent = (type: CommittedEvent["type"]): CommittedEvent =>
+    makeCommittedEvent({
+      channelId: BIG_CHANNEL_ID,
+      type,
+      payload: { content: "hello", replyToEventId: "evt_0", emoji: "👍", targetEventId: "evt_0" },
+    });
+
+  it("a message to a 4-member channel produces exactly one sendAgentMessage call", async () => {
+    const gateway = new MockDeliveryGateway();
+    const projection = new DeliveryProjection(gateway);
+    await projection.project(bigChannelEvent("message_sent"), [bigChannel], bigMembership, SETTINGS);
+    expect(gateway.agentMessages).toHaveLength(1);
+  });
+
+  it("reply and reaction events each emit exactly once on an N-member channel", async () => {
+    const gateway = new MockDeliveryGateway();
+    const projection = new DeliveryProjection(gateway);
+    await projection.project(bigChannelEvent("reply_sent"), [bigChannel], bigMembership, SETTINGS);
+    await projection.project(bigChannelEvent("reaction_sent"), [bigChannel], bigMembership, SETTINGS);
+    expect(gateway.agentMessages).toHaveLength(2);
+    expect(gateway.agentMessages.map(m => m.message.kind)).toEqual(["reply", "reaction"]);
+  });
+
+  it("StdoutDeliveryGateway writes one agent_message line for an N-member channel", async () => {
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(chunk.toString());
+      return true;
+    });
+    try {
+      const projection = new DeliveryProjection(new StdoutDeliveryGateway());
+      await projection.project(bigChannelEvent("message_sent"), [bigChannel], bigMembership, SETTINGS);
+    } finally {
+      spy.mockRestore();
+    }
+    const agentMessageLines = writes.filter(line => {
+      try {
+        return (JSON.parse(line) as { type: string }).type === "agent_message";
+      } catch {
+        return false;
+      }
+    });
+    expect(agentMessageLines).toHaveLength(1);
   });
 });

--- a/packages/server/src/simulation/__tests__/delivery-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/delivery-projection.test.ts
@@ -96,7 +96,7 @@ describe("DeliveryProjection", () => {
     expect(gateway.agentMessages[0]!.channelId).toBe(PUB_CHANNEL_ID);
   });
 
-  it("private channel event does NOT reach non-member agent", async () => {
+  it("emits once when a visibleToAgents-restricted event is visible to a channel member", async () => {
     const event = makeCommittedEvent({
       channelId: PRIV_CHANNEL_ID,
       type: "message_sent",
@@ -109,18 +109,24 @@ describe("DeliveryProjection", () => {
     });
     gateway.reset();
     await projection.project(event, [PUBLIC_CHANNEL, PRIVATE_CHANNEL], MEMBERSHIPS, SETTINGS);
-    // Delivery only fans out to members of PRIV_CHANNEL (only AGENT_1)
-    // AGENT_2 is not in PRIV_CHANNEL membership so it should never appear as recipient
-    // Since DeliveryProjection uses getMemberAgentIds which filters by membership,
-    // agent_2 will never be iterated over for this private channel event.
-    // The gateway receives at most 1 message (for agent_1), never for agent_2.
-    expect(gateway.agentMessages.length).toBeLessThanOrEqual(1);
-    // All messages must be to the private channel (agent_2 is not a member)
-    // agent_2's absence from PRIV_CHANNEL membership is the invariant
-    const membersOfPrivate = MEMBERSHIPS
-      .filter(m => m.channelId === PRIV_CHANNEL_ID && !m.leftAt)
-      .map(m => m.agentId);
-    expect(membersOfPrivate).not.toContain(AGENT_2);
+    expect(gateway.agentMessages).toHaveLength(1);
+    expect(gateway.agentMessages[0]!.channelId).toBe(PRIV_CHANNEL_ID);
+  });
+
+  it("does not emit when a visibleToAgents-restricted event names only a non-member", async () => {
+    const event = makeCommittedEvent({
+      channelId: PRIV_CHANNEL_ID,
+      type: "message_sent",
+      visibility: {
+        visibleToAgents: [AGENT_2],
+        visibleToSpectators: false,
+        visibleToOperators: true,
+        visibilityReason: "private",
+      },
+    });
+    gateway.reset();
+    await projection.project(event, [PUBLIC_CHANNEL, PRIVATE_CHANNEL], MEMBERSHIPS, SETTINGS);
+    expect(gateway.agentMessages).toHaveLength(0);
   });
 
   it("reply_sent produces a reply delivery message", async () => {

--- a/packages/server/src/simulation/projections/delivery-projection.ts
+++ b/packages/server/src/simulation/projections/delivery-projection.ts
@@ -22,52 +22,43 @@ export class DeliveryProjection {
 
     switch (event.type) {
       case "message_sent": {
+        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
         const content = payloadString(event.payload, "content");
-        for (const agentId of memberAgentIds) {
-          const visible = filterVisibleEventsForAgent([event], agentId, channels, membership);
-          if (visible.length === 0) continue;
-          const msg: DeliveryMessage = {
-            kind: "message",
-            agentId: event.actorId,
-            content,
-            salience: event.emotionalSalience,
-          };
-          await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
-        }
+        const msg: DeliveryMessage = {
+          kind: "message",
+          agentId: event.actorId,
+          content,
+          salience: event.emotionalSalience,
+        };
+        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
         break;
       }
       case "reply_sent": {
+        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
         const content = payloadString(event.payload, "content");
         const replyToEventId = payloadString(event.payload, "replyToEventId");
-        for (const agentId of memberAgentIds) {
-          const visible = filterVisibleEventsForAgent([event], agentId, channels, membership);
-          if (visible.length === 0) continue;
-          const msg: DeliveryMessage = {
-            kind: "reply",
-            agentId: event.actorId,
-            content,
-            replyToEventId,
-            salience: event.emotionalSalience,
-          };
-          await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
-        }
+        const msg: DeliveryMessage = {
+          kind: "reply",
+          agentId: event.actorId,
+          content,
+          replyToEventId,
+          salience: event.emotionalSalience,
+        };
+        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
         break;
       }
       case "reaction_sent": {
+        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
         const emoji = payloadString(event.payload, "emoji", "👍");
         const targetEventId = payloadString(event.payload, "targetEventId");
-        for (const agentId of memberAgentIds) {
-          const visible = filterVisibleEventsForAgent([event], agentId, channels, membership);
-          if (visible.length === 0) continue;
-          const msg: DeliveryMessage = {
-            kind: "reaction",
-            agentId: event.actorId,
-            emoji,
-            targetEventId,
-            salience: event.emotionalSalience,
-          };
-          await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
-        }
+        const msg: DeliveryMessage = {
+          kind: "reaction",
+          agentId: event.actorId,
+          emoji,
+          targetEventId,
+          salience: event.emotionalSalience,
+        };
+        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
         break;
       }
       case "channel_created": {
@@ -92,6 +83,17 @@ export class DeliveryProjection {
       default:
         break;
     }
+  }
+
+  private visibleToAnyMember(
+    event: CommittedEvent,
+    memberAgentIds: string[],
+    channels: Channel[],
+    membership: ChannelMembership[],
+  ): boolean {
+    return memberAgentIds.some(
+      agentId => filterVisibleEventsForAgent([event], agentId, channels, membership).length > 0,
+    );
   }
 
   private getMemberAgentIds(channelId: string, membership: ChannelMembership[]): string[] {

--- a/packages/server/src/simulation/projections/delivery-projection.ts
+++ b/packages/server/src/simulation/projections/delivery-projection.ts
@@ -18,47 +18,34 @@ export class DeliveryProjection {
     membership: ChannelMembership[],
     settings: SimulationSettings,
   ): Promise<void> {
-    const memberAgentIds = this.getMemberAgentIds(event.channelId, membership);
-
     switch (event.type) {
       case "message_sent": {
-        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
-        const content = payloadString(event.payload, "content");
-        const msg: DeliveryMessage = {
+        await this.deliverIfVisible(event, channels, membership, () => ({
           kind: "message",
           agentId: event.actorId,
-          content,
+          content: payloadString(event.payload, "content"),
           salience: event.emotionalSalience,
-        };
-        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
+        }));
         break;
       }
       case "reply_sent": {
-        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
-        const content = payloadString(event.payload, "content");
-        const replyToEventId = payloadString(event.payload, "replyToEventId");
-        const msg: DeliveryMessage = {
+        await this.deliverIfVisible(event, channels, membership, () => ({
           kind: "reply",
           agentId: event.actorId,
-          content,
-          replyToEventId,
+          content: payloadString(event.payload, "content"),
+          replyToEventId: payloadString(event.payload, "replyToEventId"),
           salience: event.emotionalSalience,
-        };
-        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
+        }));
         break;
       }
       case "reaction_sent": {
-        if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) break;
-        const emoji = payloadString(event.payload, "emoji", "👍");
-        const targetEventId = payloadString(event.payload, "targetEventId");
-        const msg: DeliveryMessage = {
+        await this.deliverIfVisible(event, channels, membership, () => ({
           kind: "reaction",
           agentId: event.actorId,
-          emoji,
-          targetEventId,
+          emoji: payloadString(event.payload, "emoji", "👍"),
+          targetEventId: payloadString(event.payload, "targetEventId"),
           salience: event.emotionalSalience,
-        };
-        await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
+        }));
         break;
       }
       case "channel_created": {
@@ -83,6 +70,18 @@ export class DeliveryProjection {
       default:
         break;
     }
+  }
+
+  private async deliverIfVisible(
+    event: CommittedEvent,
+    channels: Channel[],
+    membership: ChannelMembership[],
+    buildMessage: () => DeliveryMessage,
+  ): Promise<void> {
+    const memberAgentIds = this.getMemberAgentIds(event.channelId, membership);
+    if (!this.visibleToAnyMember(event, memberAgentIds, channels, membership)) return;
+    const msg = buildMessage();
+    await this.safeGatewayCall(event, "sendAgentMessage", () => this.gateway.sendAgentMessage(event.channelId, msg));
   }
 
   private visibleToAnyMember(


### PR DESCRIPTION
## What

Collapses the per-member delivery fan-out to a single emission per committed message:

- `DeliveryProjection.project` looped `for (const agentId of memberAgentIds)` and called the channel-scoped `sendAgentMessage(channelId, msg)` once per member, with a byte-identical `{ channelId, message }` payload each pass — an N-member channel produced N calls on every gateway (`StdoutDeliveryGateway`, `DiscordDeliveryGateway`, `CompositeDeliveryGateway`).
- `message_sent`, `reply_sent`, `reaction_sent` now emit once, gated by a new `visibleToAnyMember` helper that preserves the existing `filterVisibleEventsForAgent` semantics (restricted `visibleToAgents`, private-channel non-members).
- Fixed at the caller, not `StdoutDeliveryGateway`: the double-invoke hit every gateway, so the stdout-only symptom was one facet of a caller bug — the stdout gateway's single `this.write("agent_message", ...)` was already correct.
- `3 tests`: message to a 4-member channel emits one `sendAgentMessage`; reply + reaction each emit once on an N-member channel; `StdoutDeliveryGateway` writes exactly one `agent_message` line for a 4-member channel. Existing throwing-gateway assertion retightened from per-member `operatorEvents` count to `1`.

## Why

Every `agent_message` was written to stdout twice, pairs byte-identical and adjacent — 122 lines for 59 real messages in a 2-member run. The projection was treating a channel-scoped gateway call as if it were per-recipient.

## Validation

- `pnpm -r typecheck` PASS (per package) - `pnpm test:all` PASS (`1318 passed`, +3); root `pnpm lint` aggregator OOMs on concurrency, unrelated to this change.
- `pnpm --filter @perfectman/server test` — `722 passed`; new end-to-end test spies `process.stdout.write` and asserts exactly 1 `agent_message` line for a 4-member channel.

Closes #116
