### PR TITLE
fix(server): correct spectator snapshot path, hint truncation, and reaction emoji (#130)

### DIFF
--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -182,7 +182,7 @@ presence_changed, intent_delayed, intent_blocked,
 memory_written, no_op_recorded,
 private_motive_summary, operator_warning, llm_failure,
 simulation_started, simulation_paused, simulation_resumed, simulation_stopped,
-recap_generated, reflection_completed, stagnation_detected
+reflection_completed, stagnation_detected
 ```
 
 Socket messages are projections of these committed events, not a separate source of truth. Only some events should be visible to agents. Spectators and operators get richer feeds.

--- a/docs/notes/discord/guild-channels-roles-permissions.md
+++ b/docs/notes/discord/guild-channels-roles-permissions.md
@@ -258,7 +258,7 @@ Spectator channel:
 
 - visible to humans/operators,
 - not visible to persona bots unless product explicitly wants them to observe recap narration,
-- receives `recap_generated`, `private_motive_summary`, and narrative summaries after projection.
+- receives `private_motive_summary` and narrative summaries after projection.
 
 If `omniscientSpectatorMode` is false, the projection layer must filter facts before the Discord gateway sees them.
 

--- a/docs/notes/discord/implementation-checklist.md
+++ b/docs/notes/discord/implementation-checklist.md
@@ -81,7 +81,7 @@ Independent test: creating a private channel denies `@everyone`, grants private 
 Independent test: committed events become Discord-safe message payloads with mentions disabled and bounded length.
 
 - [ ] T019 [US-005] Create `packages/server/src/discord/discord-formatter.ts`.
-- [ ] T020 [US-005] Format `message_sent`, `reply_sent`, `reaction_sent`, `private_motive_summary`, `recap_generated`, and `operator_warning`.
+- [ ] T020 [US-005] Format `message_sent`, `reply_sent`, `reaction_sent`, `private_motive_summary`, and `operator_warning`.
 - [ ] T021 [US-005] Disable `allowedMentions` by default.
 - [ ] T022 [US-005] Add tests for mention suppression, long text handling, and event-type coverage.
 

--- a/docs/notes/discord/implementation/implementation-skeleton.md
+++ b/docs/notes/discord/implementation/implementation-skeleton.md
@@ -463,7 +463,6 @@ export function formatCommittedEventForDiscord(event: CommittedEvent): DiscordFo
       return safeContent(String(event.payload.emoji ?? ""));
 
     case "private_motive_summary":
-    case "recap_generated":
       return safeContent(`[recap] ${String(event.payload.summary ?? "")}`);
 
     case "operator_warning":

--- a/docs/plans/dev3-domain-engine-integration.md
+++ b/docs/plans/dev3-domain-engine-integration.md
@@ -349,7 +349,7 @@ type EventType =
   | 'memory_written' | 'no_op_recorded'
   | 'private_motive_summary' | 'operator_warning' | 'llm_failure'
   | 'simulation_started' | 'simulation_paused' | 'simulation_resumed' | 'simulation_stopped'
-  | 'recap_generated' | 'reflection_completed' | 'stagnation_detected';
+  | 'reflection_completed' | 'stagnation_detected';
 
 type EmotionalSalience = 'low' | 'medium' | 'high' | 'critical';
 

--- a/docs/plans/master-contract.md
+++ b/docs/plans/master-contract.md
@@ -65,10 +65,10 @@ presence_changed, intent_delayed, intent_blocked,
 memory_written, no_op_recorded,
 private_motive_summary, operator_warning, llm_failure,
 simulation_started, simulation_paused, simulation_resumed, simulation_stopped,
-recap_generated, reflection_completed, stagnation_detected
+reflection_completed, stagnation_detected
 ```
 
-23 total. Dev2 and Dev1 consume these — never invent new event types outside shared.
+22 total. Dev2 and Dev1 consume these — never invent new event types outside shared.
 
 ## Command / Intent / Event Split
 

--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -22,7 +22,7 @@ import { selectRelevantMemories } from "./memory-salience.js";
  */
 
 const CONTEXT_WINDOW = 10;
-const SPECTATOR_EVENT_TYPES = new Set(["recap_generated", "reflection_completed"]);
+const SPECTATOR_EVENT_TYPES = new Set(["reflection_completed"]);
 const OPERATOR_EVENT_TYPES = new Set([
   "operator_warning",
   "llm_failure",

--- a/packages/eval/src/test/intent-entropy.test.ts
+++ b/packages/eval/src/test/intent-entropy.test.ts
@@ -102,7 +102,7 @@ describe("intentEntropyScore (#32)", () => {
   });
 
   it("ignores operator and spectator event types", () => {
-    const noisy = [ev("llm_failure"), ev("recap_generated"), ev("operator_warning")];
+    const noisy = [ev("llm_failure"), ev("reflection_completed"), ev("operator_warning")];
     expect(intentEntropyScore(noisy)).toBe(0);
   });
 

--- a/packages/server/src/cli/env.ts
+++ b/packages/server/src/cli/env.ts
@@ -1,6 +1,5 @@
-import { existsSync } from "node:fs";
-import { dirname, join, parse } from "node:path";
 import { config as loadDotenv } from "dotenv";
+import { findUp } from "../config/simulation-config.js";
 
 type LoadDotenv = typeof loadDotenv;
 
@@ -12,16 +11,4 @@ export function loadEnvFile(
   if (!envPath) return;
 
   load({ path: envPath, quiet: true });
-}
-
-export function findUp(filename: string, startDir: string): string | null {
-  let current = startDir;
-  const root = parse(current).root;
-
-  while (true) {
-    const candidate = join(current, filename);
-    if (existsSync(candidate)) return candidate;
-    if (current === root) return null;
-    current = dirname(current);
-  }
 }

--- a/packages/server/src/config/__tests__/fixtures.ts
+++ b/packages/server/src/config/__tests__/fixtures.ts
@@ -1,0 +1,27 @@
+export const persona = {
+  id: "ana",
+  name: "Ana",
+  archetype: "observer",
+  writingStyle: "brief and careful",
+  styleExamples: ["oi", "entendi"],
+};
+
+export const promptProfile = {
+  personaId: "ana",
+  displayName: "Ana",
+  identityFrame: "You are Ana.",
+  voiceGuidelines: ["Keep it short."],
+  styleExamples: ["oi"],
+  relationshipBiases: {},
+  language: "pt-BR",
+};
+
+export const llm = {
+  providerType: "mock",
+  modelName: "mock-model",
+  maxInputTokens: 2048,
+  maxOutputTokens: 512,
+  temperature: 0.7,
+  timeoutMs: 5000,
+  retryCount: 1,
+};

--- a/packages/server/src/config/__tests__/html-snapshot-output-path.test.ts
+++ b/packages/server/src/config/__tests__/html-snapshot-output-path.test.ts
@@ -3,34 +3,7 @@ import { isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { loadSimulationConfig } from "../simulation-config.js";
-
-const persona = {
-  id: "ana",
-  name: "Ana",
-  archetype: "observer",
-  writingStyle: "brief and careful",
-  styleExamples: ["oi", "entendi"],
-};
-
-const promptProfile = {
-  personaId: "ana",
-  displayName: "Ana",
-  identityFrame: "You are Ana.",
-  voiceGuidelines: ["Keep it short."],
-  styleExamples: ["oi"],
-  relationshipBiases: {},
-  language: "pt-BR",
-};
-
-const llm = {
-  providerType: "mock",
-  modelName: "mock-model",
-  maxInputTokens: 2048,
-  maxOutputTokens: 512,
-  temperature: 0.7,
-  timeoutMs: 5000,
-  retryCount: 1,
-};
+import { llm, persona, promptProfile } from "./fixtures.js";
 
 async function loadWithSnapshotGateway(outputPath: string): Promise<{
   root: string;

--- a/packages/server/src/config/__tests__/html-snapshot-output-path.test.ts
+++ b/packages/server/src/config/__tests__/html-snapshot-output-path.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { loadSimulationConfig } from "../simulation-config.js";
+
+const persona = {
+  id: "ana",
+  name: "Ana",
+  archetype: "observer",
+  writingStyle: "brief and careful",
+  styleExamples: ["oi", "entendi"],
+};
+
+const promptProfile = {
+  personaId: "ana",
+  displayName: "Ana",
+  identityFrame: "You are Ana.",
+  voiceGuidelines: ["Keep it short."],
+  styleExamples: ["oi"],
+  relationshipBiases: {},
+  language: "pt-BR",
+};
+
+const llm = {
+  providerType: "mock",
+  modelName: "mock-model",
+  maxInputTokens: 2048,
+  maxOutputTokens: 512,
+  temperature: 0.7,
+  timeoutMs: 5000,
+  retryCount: 1,
+};
+
+async function loadWithSnapshotGateway(outputPath: string): Promise<{
+  root: string;
+  resolved: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "perfectman-ws-"));
+  await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+  const configDir = join(root, "config");
+  await mkdir(configDir);
+  const configPath = join(configDir, "index.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      simulation: {
+        id: "snapshot_path_test",
+        name: "Snapshot Path Test",
+        seed: 42,
+        settings: {
+          omniscientSpectatorMode: false,
+          allowPrivateChannels: true,
+          maxPrivateChannelsPerAgent: 3,
+          maxMessagesPerMinutePerAgent: 30,
+          llmCallBudgetPerMinute: 100,
+          pulseIntervalMs: 1000,
+          tokenBudgetPerHour: 1_000_000,
+        },
+      },
+      persistence: { type: "memory" },
+      deliveryGateways: [{ id: "html", type: "html-snapshot", outputPath }],
+      channels: [{
+        id: "general",
+        type: "public_channel",
+        name: "general",
+        default: true,
+        memberAgentIds: ["ana"],
+      }],
+      agents: [{ id: "ana", persona, promptProfile, llm }],
+    }, null, 2),
+  );
+  const config = await loadSimulationConfig(configPath);
+  const gateway = config.deliveryGateways.find((g) => g.type === "html-snapshot");
+  return {
+    root,
+    resolved: (gateway as { outputPath: string }).outputPath,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+describe("html-snapshot outputPath resolution", () => {
+  it("anchors a relative outputPath to the workspace root, not the config dir or cwd", async () => {
+    const { root, resolved, cleanup } = await loadWithSnapshotGateway("tmp/snapshot.html");
+    try {
+      expect(resolved).toBe(join(root, "tmp/snapshot.html"));
+      expect(resolved).not.toContain(join("config", "tmp"));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("leaves an absolute outputPath untouched", async () => {
+    const abs = join(tmpdir(), "perfectman-abs-snapshot.html");
+    const { resolved, cleanup } = await loadWithSnapshotGateway(abs);
+    try {
+      expect(isAbsolute(resolved)).toBe(true);
+      expect(resolved).toBe(abs);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/server/src/config/__tests__/simulation-config.test.ts
+++ b/packages/server/src/config/__tests__/simulation-config.test.ts
@@ -11,34 +11,7 @@ import {
 } from "../simulation-config.js";
 import { resolveGoalLayerConfig } from "../../simulation/world/world-evaluator.js";
 import { MockDeliveryGateway } from "../../delivery/index.js";
-
-const persona = {
-  id: "ana",
-  name: "Ana",
-  archetype: "observer",
-  writingStyle: "brief and careful",
-  styleExamples: ["oi", "entendi"],
-};
-
-const promptProfile = {
-  personaId: "ana",
-  displayName: "Ana",
-  identityFrame: "You are Ana.",
-  voiceGuidelines: ["Keep it short."],
-  styleExamples: ["oi"],
-  relationshipBiases: {},
-  language: "pt-BR",
-};
-
-const llm = {
-  providerType: "mock",
-  modelName: "mock-model",
-  maxInputTokens: 2048,
-  maxOutputTokens: 512,
-  temperature: 0.7,
-  timeoutMs: 5000,
-  retryCount: 1,
-};
+import { llm, persona, promptProfile } from "./fixtures.js";
 
 function baseConfig(): SimulationAppConfig {
   return parseSimulationConfig({

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -237,6 +237,19 @@ const DEFAULT_PERSONA_CALIBRATION: Omit<PersonaConfig, keyof ConfigPersona> = {
 
 export const DEFAULT_SIMULATION_CONFIG_FILENAME = "config/index.json";
 
+/** Walk up from `startDir` for the nearest ancestor containing `filename`. */
+export function findUp(filename: string, startDir: string): string | null {
+  let current = startDir;
+  const root = parse(current).root;
+
+  while (true) {
+    const candidate = join(current, filename);
+    if (existsSync(candidate)) return candidate;
+    if (current === root) return null;
+    current = dirname(current);
+  }
+}
+
 export function findDefaultConfigPath(
   filename: string,
   startDir = process.cwd(),
@@ -298,13 +311,8 @@ function anchorHtmlSnapshotOutputPaths(
 }
 
 function findWorkspaceRoot(startDir: string): string | undefined {
-  let current = startDir;
-  const root = parse(current).root;
-  while (true) {
-    if (existsSync(join(current, "pnpm-workspace.yaml"))) return current;
-    if (current === root) return undefined;
-    current = dirname(current);
-  }
+  const found = findUp("pnpm-workspace.yaml", startDir);
+  return found ? dirname(found) : undefined;
 }
 
 async function hydrateAgentPersonaFiles(

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -273,7 +273,38 @@ export async function loadSimulationConfig(
     );
   }
   const hydrated = await hydrateAgentPersonaFiles(parsed, path);
-  return parseSimulationConfig(hydrated);
+  const config = parseSimulationConfig(hydrated);
+  anchorHtmlSnapshotOutputPaths(config, path);
+  return config;
+}
+
+/**
+ * `html-snapshot` `outputPath` values are authored relative to the checkout,
+ * but the simulation runs with `process.cwd()` at `packages/server`. Anchor
+ * relative paths to the workspace root (the `pnpm-workspace.yaml` directory),
+ * falling back to the config file's own directory outside a workspace.
+ */
+function anchorHtmlSnapshotOutputPaths(
+  config: SimulationAppConfig,
+  configPath: string,
+): void {
+  const configDir = dirname(configPath);
+  const base = findWorkspaceRoot(configDir) ?? configDir;
+  for (const gateway of config.deliveryGateways) {
+    if (gateway.type === "html-snapshot" && !isAbsolute(gateway.outputPath)) {
+      gateway.outputPath = resolve(base, gateway.outputPath);
+    }
+  }
+}
+
+function findWorkspaceRoot(startDir: string): string | undefined {
+  let current = startDir;
+  const root = parse(current).root;
+  while (true) {
+    if (existsSync(join(current, "pnpm-workspace.yaml"))) return current;
+    if (current === root) return undefined;
+    current = dirname(current);
+  }
 }
 
 async function hydrateAgentPersonaFiles(

--- a/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
+++ b/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
@@ -354,7 +354,10 @@ describe("HtmlSnapshotGateway (stream-fed receiver)", () => {
     });
     await gw.onSimulationStopped("sim_rcv");
 
-    const row = gw.toReplay().pulses[0]!.committedEvents[0]!;
+    const replay = gw.toReplay();
+    expect(replay.pulses).toHaveLength(1);
+    expect(replay.pulses[0]!.committedEvents).toHaveLength(1);
+    const row = replay.pulses[0]!.committedEvents[0]!;
     expect(row.type).toBe("reaction_sent");
     expect(row.payload["emoji"]).toBe("🎉");
     expect(row.payload["targetEventId"]).toBe("ev_m1");

--- a/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
+++ b/packages/server/src/delivery/__tests__/html-snapshot-gateway.test.ts
@@ -332,6 +332,37 @@ describe("HtmlSnapshotGateway (stream-fed receiver)", () => {
     expect(html).toContain("Preciso marcar presença sem chamar atenção.");
   });
 
+  it("carries the reaction emoji from event_visibility into the replay and artifact", async () => {
+    const { gw, outputPath } = buildGateway();
+    await gw.sendOperatorEvent(snapshot("ana", 0));
+    await gw.sendOperatorEvent({
+      type: "event_visibility",
+      simulationId: "sim_rcv",
+      agentId: "ana",
+      pulseIndex: 0,
+      detail: "Event visibility: reaction_sent",
+      data: {
+        eventId: "ev_react",
+        eventType: "reaction_sent",
+        actorId: "ana",
+        channelId: "general",
+        visibleToAgents: [],
+        emoji: "🎉",
+        targetEventId: "ev_m1",
+      },
+      createdAt: 1,
+    });
+    await gw.onSimulationStopped("sim_rcv");
+
+    const row = gw.toReplay().pulses[0]!.committedEvents[0]!;
+    expect(row.type).toBe("reaction_sent");
+    expect(row.payload["emoji"]).toBe("🎉");
+    expect(row.payload["targetEventId"]).toBe("ev_m1");
+
+    const html = readFileSync(outputPath, "utf-8");
+    expect(html).toContain("🎉");
+  });
+
   it("keeps the partial frame when stopped mid-pulse", async () => {
     const { gw } = buildGateway();
     await gw.sendOperatorEvent(snapshot("ana", 0));

--- a/packages/server/src/delivery/html-snapshot-gateway.ts
+++ b/packages/server/src/delivery/html-snapshot-gateway.ts
@@ -26,7 +26,7 @@ import type {
 } from "@perfectman/shared";
 import type { GatewayRuntimeMetadata } from "../config/simulation-config.js";
 import type { DeliveryMessage, IDeliveryGateway } from "../simulation/scheduler-contracts.js";
-import { payloadString, payloadStringArray } from "../simulation/payload-readers.js";
+import { payloadDisplayFields, payloadString, payloadStringArray } from "../simulation/payload-readers.js";
 import type { SerializedAgentState } from "../agent/agent-state-serializer.js";
 import type { AgentThinking, GoalPanel, PulseFrame, SimulationReplay } from "../html/replay-types.js";
 import { generateHtml } from "../html/snapshot-html-generator.js";
@@ -269,22 +269,13 @@ export class HtmlSnapshotGateway implements IDeliveryGateway {
 
   private eventRowFromVisibility(event: OperatorEvent): CommittedEvent {
     const data = event.data ?? {};
-    const content = payloadString(data, "content");
-    const channelName = payloadString(data, "channelName");
-    const emoji = payloadString(data, "emoji");
-    const targetEventId = payloadString(data, "targetEventId");
     return {
       id: payloadString(data, "eventId"),
       simulationId: event.simulationId,
       channelId: payloadString(data, "channelId"),
       actorId: payloadString(data, "actorId", event.agentId ?? ""),
       type: payloadString(data, "eventType") as CommittedEvent["type"],
-      payload: {
-        ...(content ? { content } : {}),
-        ...(channelName ? { channelName } : {}),
-        ...(emoji ? { emoji } : {}),
-        ...(targetEventId ? { targetEventId } : {}),
-      },
+      payload: payloadDisplayFields(data),
       sourceEventIds: [],
       emotionalSalience: "low",
       visibility: {

--- a/packages/server/src/delivery/html-snapshot-gateway.ts
+++ b/packages/server/src/delivery/html-snapshot-gateway.ts
@@ -271,6 +271,8 @@ export class HtmlSnapshotGateway implements IDeliveryGateway {
     const data = event.data ?? {};
     const content = payloadString(data, "content");
     const channelName = payloadString(data, "channelName");
+    const emoji = payloadString(data, "emoji");
+    const targetEventId = payloadString(data, "targetEventId");
     return {
       id: payloadString(data, "eventId"),
       simulationId: event.simulationId,
@@ -280,6 +282,8 @@ export class HtmlSnapshotGateway implements IDeliveryGateway {
       payload: {
         ...(content ? { content } : {}),
         ...(channelName ? { channelName } : {}),
+        ...(emoji ? { emoji } : {}),
+        ...(targetEventId ? { targetEventId } : {}),
       },
       sourceEventIds: [],
       emotionalSalience: "low",

--- a/packages/server/src/html/snapshot-html-generator.ts
+++ b/packages/server/src/html/snapshot-html-generator.ts
@@ -461,6 +461,14 @@ function escHtml(s) {
     .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 
+const STORY_EVENTS = {
+  message_sent: { sigil: '💬', tag: '' },
+  reply_sent: { sigil: '↩', tag: '<span class="msg-type-tag">↳reply</span>' },
+  channel_created: { sigil: '📢', tag: '<span class="msg-type-tag">canal criado</span>' },
+  reaction_sent: { sigil: '+', tag: '<span class="msg-type-tag">reação</span>' },
+};
+const isStoryEvent = evt => !!STORY_EVENTS[evt.type];
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 function init() {
@@ -569,9 +577,7 @@ function renderStory() {
     section.dataset.pulse = String(pi);
 
     // Count meaningful events
-    const visibleEvts = frame.committedEvents.filter(
-      e => e.type === 'message_sent' || e.type === 'reply_sent' || e.type === 'channel_created' || e.type === 'reaction_sent'
-    );
+    const visibleEvts = frame.committedEvents.filter(isStoryEvent);
 
     // ── Divider ──
     const divider = document.createElement('div');
@@ -590,7 +596,7 @@ function renderStory() {
     let hasContent = false;
 
     for (const evt of frame.committedEvents) {
-      if (evt.type !== 'message_sent' && evt.type !== 'reply_sent' && evt.type !== 'channel_created' && evt.type !== 'reaction_sent') continue;
+      if (!isStoryEvent(evt)) continue;
 
       const agentId = evt.actorId || '';
       const agentName = AGENT_NAMES[agentId] || agentId;
@@ -608,12 +614,10 @@ function renderStory() {
       msgRow.dataset.channelId = evt.channelId || '';
       msgRow.dataset.visibleTo = JSON.stringify(visibleTo);
 
-      const sigil = evt.type === 'reply_sent' ? '↩' : (evt.type === 'channel_created' ? '📢' : (evt.type === 'reaction_sent' ? '+' : '💬'));
+      const storyStyle = STORY_EVENTS[evt.type];
+      const sigil = storyStyle.sigil;
       const content = (evt.payload && (evt.payload.content || evt.payload.channelName || evt.payload.emoji)) || '';
-      const typeTag = evt.type === 'reply_sent'
-        ? '<span class="msg-type-tag">↳reply</span>'
-        : (evt.type === 'channel_created' ? '<span class="msg-type-tag">canal criado</span>'
-        : (evt.type === 'reaction_sent' ? '<span class="msg-type-tag">reação</span>' : ''));
+      const typeTag = storyStyle.tag;
       const channelTag = isPrivate
         ? '<span class="msg-channel-tag">🔒 ' + escHtml(ch.name || ch.id) + '</span>'
         : '';

--- a/packages/server/src/html/snapshot-html-generator.ts
+++ b/packages/server/src/html/snapshot-html-generator.ts
@@ -570,7 +570,7 @@ function renderStory() {
 
     // Count meaningful events
     const visibleEvts = frame.committedEvents.filter(
-      e => e.type === 'message_sent' || e.type === 'reply_sent' || e.type === 'channel_created'
+      e => e.type === 'message_sent' || e.type === 'reply_sent' || e.type === 'channel_created' || e.type === 'reaction_sent'
     );
 
     // ── Divider ──
@@ -590,7 +590,7 @@ function renderStory() {
     let hasContent = false;
 
     for (const evt of frame.committedEvents) {
-      if (evt.type !== 'message_sent' && evt.type !== 'reply_sent' && evt.type !== 'channel_created') continue;
+      if (evt.type !== 'message_sent' && evt.type !== 'reply_sent' && evt.type !== 'channel_created' && evt.type !== 'reaction_sent') continue;
 
       const agentId = evt.actorId || '';
       const agentName = AGENT_NAMES[agentId] || agentId;
@@ -608,11 +608,12 @@ function renderStory() {
       msgRow.dataset.channelId = evt.channelId || '';
       msgRow.dataset.visibleTo = JSON.stringify(visibleTo);
 
-      const sigil = evt.type === 'reply_sent' ? '↩' : (evt.type === 'channel_created' ? '📢' : '💬');
-      const content = (evt.payload && (evt.payload.content || evt.payload.channelName)) || '';
+      const sigil = evt.type === 'reply_sent' ? '↩' : (evt.type === 'channel_created' ? '📢' : (evt.type === 'reaction_sent' ? '+' : '💬'));
+      const content = (evt.payload && (evt.payload.content || evt.payload.channelName || evt.payload.emoji)) || '';
       const typeTag = evt.type === 'reply_sent'
         ? '<span class="msg-type-tag">↳reply</span>'
-        : (evt.type === 'channel_created' ? '<span class="msg-type-tag">canal criado</span>' : '');
+        : (evt.type === 'channel_created' ? '<span class="msg-type-tag">canal criado</span>'
+        : (evt.type === 'reaction_sent' ? '<span class="msg-type-tag">reação</span>' : ''));
       const channelTag = isPrivate
         ? '<span class="msg-channel-tag">🔒 ' + escHtml(ch.name || ch.id) + '</span>'
         : '';

--- a/packages/server/src/simulation/__tests__/spectator-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/spectator-projection.test.ts
@@ -115,4 +115,45 @@ describe("SpectatorProjection", () => {
     const result = projection.buildSpectatorEvent(event, omniSettings);
     expect(result).not.toBeNull();
   });
+
+  it("truncates an over-long motive hint on a word boundary with an ellipsis", () => {
+    const summary = `${"x".repeat(50)} ${"y".repeat(50)}`;
+    const event = makeEvent({
+      type: "no_op_recorded",
+      payload: { privateMotiveSummary: summary },
+    });
+    const result = projection.buildSpectatorEvent(event, SETTINGS);
+    expect(result?.visibleContent).toBe(`${"x".repeat(50)}...`);
+    expect(result?.visibleContent?.length ?? 0).toBeLessThanOrEqual(80);
+    expect(result?.visibleContent).not.toContain("y");
+  });
+
+  it("leaves a short motive hint intact with no ellipsis", () => {
+    const event = makeEvent({
+      type: "no_op_recorded",
+      payload: { privateMotiveSummary: "weighing whether to speak" },
+    });
+    const result = projection.buildSpectatorEvent(event, SETTINGS);
+    expect(result?.visibleContent).toBe("weighing whether to speak");
+  });
+
+  it("surfaces the emoji in a reaction_sent spectator event", () => {
+    const event = makeEvent({
+      type: "reaction_sent",
+      payload: { emoji: "🎉", targetEventId: "evt_42" },
+    });
+    const result = projection.buildSpectatorEvent(event, SETTINGS);
+    expect(result?.type).toBe("reaction_sent");
+    expect(result?.visibleContent).toBe("🎉");
+  });
+
+  it("delivers the reaction emoji through project()", async () => {
+    const event = makeEvent({
+      type: "reaction_sent",
+      payload: { emoji: "👍", targetEventId: "evt_42" },
+    });
+    await projection.project(event, [PUBLIC_CHANNEL], SETTINGS);
+    expect(gateway.spectatorEvents).toHaveLength(1);
+    expect(gateway.spectatorEvents[0]?.visibleContent).toBe("👍");
+  });
 });

--- a/packages/server/src/simulation/payload-readers.ts
+++ b/packages/server/src/simulation/payload-readers.ts
@@ -1,4 +1,9 @@
-import type { ChannelType, EventPayload, EventPayloadValue } from "@perfectman/shared";
+import type {
+  ChannelType,
+  EventPayload,
+  EventPayloadValue,
+  EventVisibilityData,
+} from "@perfectman/shared";
 
 export function payloadString(payload: EventPayload, key: string, fallback = ""): string {
   const value = payload[key];
@@ -23,4 +28,29 @@ function isChannelType(value: EventPayloadValue | undefined): value is ChannelTy
     value === "spectator_channel" ||
     value === "operator_channel"
   );
+}
+
+export type PayloadDisplayFields = Pick<
+  EventVisibilityData,
+  "content" | "channelName" | "emoji" | "targetEventId"
+>;
+
+/**
+ * The display fields that ride an `event_visibility` payload. Both directions
+ * of the event_visibility round-trip spread this set: the scheduler builds the
+ * operator event from a CommittedEvent, and receivers rebuild the
+ * CommittedEvent payload from the operator event. Keys without a value are
+ * omitted rather than empty-stringed so absence survives the round-trip.
+ */
+export function payloadDisplayFields(payload: EventPayload): PayloadDisplayFields {
+  const content = payloadString(payload, "content");
+  const channelName = payloadString(payload, "channelName");
+  const emoji = payloadString(payload, "emoji");
+  const targetEventId = payloadString(payload, "targetEventId");
+  return {
+    ...(content ? { content } : {}),
+    ...(channelName ? { channelName } : {}),
+    ...(emoji ? { emoji } : {}),
+    ...(targetEventId ? { targetEventId } : {}),
+  };
 }

--- a/packages/server/src/simulation/projections/spectator-projection.ts
+++ b/packages/server/src/simulation/projections/spectator-projection.ts
@@ -20,9 +20,14 @@ function sanitize(event: CommittedEvent): Omit<SpectatorEvent, "narrativeHint"> 
   };
 }
 
+const MOTIVE_SUMMARY_LIMIT = 80;
+const MOTIVE_SUMMARY_ELLIPSIS = "...";
+
 function sanitizeMotiveSummary(summary: string): string {
-  // Truncate private details — keep to a safe length
-  return summary.slice(0, 80);
+  if (summary.length <= MOTIVE_SUMMARY_LIMIT) return summary;
+  const capped = summary.slice(0, MOTIVE_SUMMARY_LIMIT - MOTIVE_SUMMARY_ELLIPSIS.length);
+  const wordSafe = capped.replace(/\s+\S*$/, "");
+  return `${(wordSafe || capped).trimEnd()}${MOTIVE_SUMMARY_ELLIPSIS}`;
 }
 
 function summarizeDelay(event: CommittedEvent): string {
@@ -65,8 +70,13 @@ export class SpectatorProjection {
     switch (event.type) {
       case "message_sent":
       case "reply_sent":
-      case "reaction_sent":
         return { ...sanitize(event), narrativeHint: null };
+      case "reaction_sent":
+        return {
+          ...sanitize(event),
+          visibleContent: payloadString(event.payload, "emoji"),
+          narrativeHint: null,
+        };
       case "no_op_recorded":
         return {
           type: "spectator_hint",

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -24,7 +24,7 @@ import type { DeliveryProjection } from "./projections/delivery-projection.js";
 import type { SpectatorProjection } from "./projections/spectator-projection.js";
 import type { OperatorProjection } from "./projections/operator-projection.js";
 import type { EngineEventBuilder } from "./engine-event-builder.js";
-import { payloadString } from "./payload-readers.js";
+import { payloadDisplayFields } from "./payload-readers.js";
 import { serializeAgentState } from "../agent/agent-state-serializer.js";
 import type { ActionIntentOperatorData, EventVisibilityData } from "@perfectman/shared";
 import { buildAgentRuntimeInput } from "./runtime-input-builder.js";
@@ -416,20 +416,13 @@ export class PulseScheduler {
   }
 
   private async emitEventVisibility(event: CommittedEvent): Promise<void> {
-    const content = payloadString(event.payload, "content");
-    const channelName = payloadString(event.payload, "channelName");
-    const emoji = payloadString(event.payload, "emoji");
-    const targetEventId = payloadString(event.payload, "targetEventId");
     const data: EventVisibilityData = {
       eventId: event.id,
       eventType: event.type,
       actorId: event.actorId,
       channelId: event.channelId,
       visibleToAgents: event.visibility.visibleToAgents,
-      ...(content ? { content } : {}),
-      ...(channelName ? { channelName } : {}),
-      ...(emoji ? { emoji } : {}),
-      ...(targetEventId ? { targetEventId } : {}),
+      ...payloadDisplayFields(event.payload),
     };
     await this.emitOperatorEvent({
       type: "event_visibility",

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -418,6 +418,8 @@ export class PulseScheduler {
   private async emitEventVisibility(event: CommittedEvent): Promise<void> {
     const content = payloadString(event.payload, "content");
     const channelName = payloadString(event.payload, "channelName");
+    const emoji = payloadString(event.payload, "emoji");
+    const targetEventId = payloadString(event.payload, "targetEventId");
     const data: EventVisibilityData = {
       eventId: event.id,
       eventType: event.type,
@@ -426,6 +428,8 @@ export class PulseScheduler {
       visibleToAgents: event.visibility.visibleToAgents,
       ...(content ? { content } : {}),
       ...(channelName ? { channelName } : {}),
+      ...(emoji ? { emoji } : {}),
+      ...(targetEventId ? { targetEventId } : {}),
     };
     await this.emitOperatorEvent({
       type: "event_visibility",

--- a/packages/shared/src/__tests__/constants.test.ts
+++ b/packages/shared/src/__tests__/constants.test.ts
@@ -101,8 +101,8 @@ describe("Personas", () => {
 
 // --- Emotion Rules ---
 describe("EVENT_IMPULSE_TABLE", () => {
-  it("has 15 well-formed impulse rules", () => {
-    expect(EVENT_IMPULSE_TABLE).toHaveLength(15);
+  it("has 14 well-formed impulse rules", () => {
+    expect(EVENT_IMPULSE_TABLE).toHaveLength(14);
     for (const rule of EVENT_IMPULSE_TABLE) {
       expect(["actor", "target", "bystander"]).toContain(rule.role);
       expectAllInRange([rule.magnitude], 0, 1, `${rule.role}.magnitude`, { exclusiveMin: true });

--- a/packages/shared/src/constants/emotion-rules.ts
+++ b/packages/shared/src/constants/emotion-rules.ts
@@ -164,16 +164,6 @@ export const EVENT_IMPULSE_TABLE: readonly EventImpulseRule[] = [
     magnitude:          0.18,
     affectedDimensions: ["neediness", "socialAnxiety"],
   },
-
-  // 15. recap_generated — recap reminds agents of past events
-  {
-    eventType:          "recap_generated",
-    role:               "bystander",
-    valenceShift:       0.05,
-    arousalShift:       0.08,
-    magnitude:          0.12,
-    affectedDimensions: ["pride", "resentment"],  // can go either way — engine picks based on valence
-  },
 ];
 
 // ── Social Emotion Decay Rates ────────────────────────────────────────────────

--- a/packages/shared/src/event/event.schema.ts
+++ b/packages/shared/src/event/event.schema.ts
@@ -22,7 +22,6 @@ export const EventTypeSchema = z.enum([
   "simulation_paused",
   "simulation_resumed",
   "simulation_stopped",
-  "recap_generated",
   "reflection_completed",
   "stagnation_detected",
   "goal_proposed",

--- a/packages/shared/src/event/event.types.ts
+++ b/packages/shared/src/event/event.types.ts
@@ -19,7 +19,6 @@ export type EventType =
   | "simulation_paused"
   | "simulation_resumed"
   | "simulation_stopped"
-  | "recap_generated"
   | "reflection_completed"
   | "stagnation_detected"
   | "goal_proposed"

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -104,4 +104,6 @@ export type EventVisibilityData = {
   visibleToAgents: string[];
   content?: string;
   channelName?: string;
+  emoji?: string;
+  targetEventId?: string;
 };

--- a/packages/shared/src/scenarios/library.test.ts
+++ b/packages/shared/src/scenarios/library.test.ts
@@ -23,7 +23,7 @@ const EVENT_TYPES = new Set([
   "presence_changed", "intent_delayed", "intent_blocked", "memory_written",
   "no_op_recorded", "private_motive_summary", "operator_warning",
   "llm_failure", "simulation_started", "simulation_paused",
-  "simulation_resumed", "simulation_stopped", "recap_generated",
+  "simulation_resumed", "simulation_stopped",
   "reflection_completed", "stagnation_detected",
 ]);
 


### PR DESCRIPTION
## What

Fixes four spectator-layer defects from #130:

- `HtmlSnapshotGateway` `outputPath` resolved against `process.cwd()` (`packages/server`) while the config file is found by an upward tree-walk, so the artifact landed at `packages/server/tmp/snapshot.html`. `loadSimulationConfig` now anchors a relative `outputPath` to the workspace root (the `pnpm-workspace.yaml` directory), falling back to the config file's own directory.
- `sanitizeMotiveSummary` did `summary.slice(0, 80)` — spectator hints cut mid-word with no ellipsis. It now breaks on the last whitespace within the cap and appends `...` when truncated.
- `reaction_sent` payloads carry `emoji` / `targetEventId`, but `SpectatorProjection`, `PulseScheduler.emitEventVisibility`, and the HTML snapshot only read `payload.content`, so the emoji was dropped (`visibleContent: ""`). Added a `reaction_sent` branch to each; `EventVisibilityData` gains `emoji` / `targetEventId`.
- Removes the dead `recap_generated` committed-event type (`EventType`, `EventTypeSchema`, `EVENT_IMPULSE_TABLE`, the perception spectator-type filter). A committed recap is agent-perceivable by design, and the narrative layer it scaffolded for (#128) is descoped. The spectator-only `recap` kind in `spectator.types.ts` is untouched.
- 7 tests: snapshot path anchored to workspace root + absolute path left intact; motive-hint word-boundary truncation, ellipsis, short-string passthrough; reaction emoji in the spectator projection (direct + via `project()`); reaction emoji carried into the snapshot replay payload.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+7)
- `pnpm build` + `pnpm -r typecheck` green across all four packages; `[audit-tests] PASS — 119 files, no violations`; `[docs-lint] PASS`.
- `pnpm lint` printed a transient pnpm OOM warning on one invocation; `pnpm -r typecheck` re-run reported `Done` for shared/engine/server/eval.
- New `html-snapshot-output-path.test.ts`: relative `tmp/snapshot.html` resolves to `<workspace-root>/tmp/snapshot.html`, not `<config-dir>/tmp` or cwd.

Closes #130


## Review fixes (findings response)
- Extracted `config/__tests__/fixtures.ts` — the `ana` persona/promptProfile/llm triple is now shared by `simulation-config.test.ts` and `html-snapshot-output-path.test.ts` (Q5).
- Extracted a shared `event_visibility` display-field builder (`payloadDisplayFields` in `payload-readers.ts`) used by both `pulse-scheduler` and `html-snapshot-gateway`.
- `snapshot-html-generator` now table-drives the story-event cascade (`STORY_EVENTS` + `isStoryEvent`), removing the hand-synced filters/ternaries.
- Replay frame existence asserted before non-null access in the gateway test (Q11).
- Removed `recap_generated` residue from four docs (discord notes ×3, dev3 plan).

Not changed, per verification:
- `spectator_recap` (`prompt.types.ts:35`) is a live reserved **PromptPurpose** (reject-path pinned in tests, documented "Reserved; no builder yet") and `"recap"` (`discord-formatter.ts:36`) is a live **SpectatorEventType** member — both serve the spectator-only recap kind; they are not `recap_generated` residue.
- Word-boundary trim behavior stays as pinned by its test (accepted judgement call).
- Reaction `targetEventId` spectator rendering deferred: it lives in embedded client JS and the repo has no DOM-rendering test pattern; a throwaway DOM-stub smoke confirmed the reaction row renders correctly.
