### PR TITLE
fix(agent): build the retry prompt once with composed corrections

### DIFF
--- a/packages/eval/src/test/persona-mock-memory-writes.test.ts
+++ b/packages/eval/src/test/persona-mock-memory-writes.test.ts
@@ -58,6 +58,7 @@ function makeInput(): AgentRuntimeInput {
       agentId: "agent-a",
       triggeringEvent: null,
       visibleContextEvents: [],
+      eventHandles: {},
       ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: [],

--- a/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
+++ b/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
@@ -83,6 +83,14 @@ export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): A
       agentId,
       triggeringEvent: options.triggeringEvent ?? null,
       visibleContextEvents: options.visibleContextEvents ?? [],
+      // Same numbering the perception builder emits: e1 = triggering event
+      // (when present), then context events in order.
+      eventHandles: Object.fromEntries(
+        (options.triggeringEvent
+          ? [options.triggeringEvent, ...(options.visibleContextEvents ?? [])]
+          : (options.visibleContextEvents ?? [])
+        ).map((e, i) => [`e${i + 1}`, e.id]),
+      ),
       ownRecentUtterances: options.ownRecentUtterances ?? [],
       involvedPeople: [],
       relevantChannels: ["general"],

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -199,10 +199,22 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
 
     if (!fallbackApplied && (isRepeat(intent) || parseResult.unresolvedTarget)) {
       for (let attempt = 0; attempt < maxRetries; attempt++) {
-        // The correction note re-inflates the (already-capped) base prompt, so
+        // The correction notes re-inflate the (already-capped) base prompt, so
         // the retry prompt is re-assembled and re-trimmed against the same cap
-        // before it goes anywhere near the wire.
-        const retryPrompt = this.buildRetryPrompt(input, ctx, prompt, intent.visibleContent ?? "");
+        // before it goes anywhere near the wire; the trim event and the budget
+        // gate below therefore see the corrected, final estimate.
+        const corrections: string[] = [];
+        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
+        if (parseResult.unresolvedTarget) {
+          corrections.push(
+            targetRetryCorrectionNote(
+              parseResult.unresolvedTarget.field,
+              parseResult.unresolvedTarget.badHandle,
+              parseResult.unresolvedTarget.validHandles,
+            ),
+          );
+        }
+        const retryPrompt = this.buildRetryPrompt(input, ctx, prompt, corrections.join("\n\n"));
         const retryTrimEvent = this.promptTrimEvent(
           retryPrompt,
           simulationId,
@@ -229,23 +241,6 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
           }
           break;
         }
-        const corrections: string[] = [];
-        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
-        if (parseResult.unresolvedTarget) {
-          corrections.push(
-            targetRetryCorrectionNote(
-              parseResult.unresolvedTarget.field,
-              parseResult.unresolvedTarget.badHandle,
-              parseResult.unresolvedTarget.validHandles,
-            ),
-          );
-        }
-        const correction = corrections.join("\n\n");
-        const retryPrompt = {
-          ...prompt,
-          version: promptVersionHash([`${prompt.system}\n\n${correction}`, prompt.user]),
-          system: `${prompt.system}\n\n${correction}`,
-        };
         try {
           const retryResult = await provider.generateIntent(input, runtimeContext, retryPrompt);
           retriesAttempted++;
@@ -467,21 +462,21 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
   }
 
   /**
-   * Assemble the repetition-guard retry prompt with the cap re-enforced.
-   * `retryCorrectionNote` is appended to the system text *after* the base
-   * render, so a base prompt that `trimToFit` left just under the cap would
-   * cross it once the note is added. The base is therefore rebuilt against a
-   * cap lowered by the note's own token estimate; `base + note` is then within
-   * the original cap by construction. Falls back to a plain append when the
-   * agent has no configured cap.
+   * Assemble the retry prompt with the cap re-enforced. The composed
+   * correction text is appended to the system text *after* the base render,
+   * so a base prompt that `trimToFit` left just under the cap would cross it
+   * once the correction is added. The base is therefore rebuilt against a cap
+   * lowered by the correction's own token estimate; `base + correction` is
+   * then within the original cap by construction. Falls back to a plain
+   * append when the agent has no configured cap.
    */
   private buildRetryPrompt(
     input: AgentRuntimeInput,
     ctx: StepRunContext,
     basePrompt: BuiltPrompt,
-    lastAttempt: string,
+    correction: string,
   ): BuiltPrompt {
-    const suffix = `\n\n${retryCorrectionNote(lastAttempt)}`;
+    const suffix = correction ? `\n\n${correction}` : "";
     const cap = ctx.llmConfig.maxInputTokens;
 
     if (typeof cap !== "number" || cap <= 0) {


### PR DESCRIPTION
## What

Resolves the `action-intent-step.ts` collision left by the #141 / #145 merge:

- **Collision**: the merged retry arm declared `retryPrompt` twice — the #145 cap-checked `buildRetryPrompt` assembly and the #141 correction spread — failing `tsc` outright (`TS2451`), and past the compile error it would have double-applied `retryCorrectionNote`
- **Fix**: corrections are composed first (`retryCorrectionNote` when `isRepeat(intent)`, plus `targetRetryCorrectionNote` when `parseResult.unresolvedTarget`) and passed into `buildRetryPrompt`; one prompt then serves the retry trim event, the `llmBudget.canCall` estimate, and the wire call, re-trimmed against `maxInputTokens` with the correction's own tokens reserved
- **Fixtures**: `agent-input-test-helpers.ts` and the eval `persona-mock-memory-writes` input now set `eventHandles` with the same numbering `build-perception-packet.ts` emits (`e1` = triggering event, then context order); both predated the field #141 made required and failed at runtime on `Object.entries(undefined)`
- Three tests re-greened: retry-phase re-trim, budget-block trim log, trim-record existence

## Why

Both PRs restructured the same retry arm; the merge kept both prompt builds stacked, so `main` does not compile and the shared fixtures predate the `eventHandles` requirement.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS
- 1404 tests / 125 files, `[audit-tests] PASS` (1225 its), `[docs-lint] PASS` (70 files, 0 violations)
