### PR TITLE
docs(eval): capture dead-room evidence from a live deepseek run

### DIFF
--- a/docs/eval/evidence/local-deadroom-deepseek/observations.md
+++ b/docs/eval/evidence/local-deadroom-deepseek/observations.md
@@ -1,0 +1,40 @@
+# Dead-room run: `deepseek-api` config, live DeepSeek `deepseek-v4-flash`
+
+Live `pnpm --filter @perfectman/server simulation` run, 2026-09-01, ~6 min
+(63 pulses at 5s), 2 agents (`ana`, `bruno`), public channel `general`.
+Run killed externally via SIGTERM (graceful stop). The build included the
+local retry-prompt/fixture repair for the #141/#145 merge collision; it has
+no bearing on this run (0 retries, 0 trims, no retry path executed).
+
+## What happened
+
+- p0-p2: warm, in-persona opening exchange (3 messages, coherent private
+  motives, reply via event handle, no fallbacks, no prompt trims).
+- p3-p63: zero cognition calls from either agent. The run ends with ana's
+  question ("tudo bem sim, e contigo?") unanswered for ~5 minutes.
+
+## Findings
+
+1. `cold_start_bootstrap` pins at 1.0 and fires every pulse without producing
+   an action-intent call. Both agents: value 1.0 vs threshold 0.3,
+   `lastFiredAt` advancing to 61. This is the residual risk documented in the
+   #142 review: growth-only + clamp, exempt from the passive-decay formula.
+2. A silent room cannot self-start: for the other 16 sources, the passive
+   growth fixed point (`growthRate / (decayRate * 0.5)`) sits below the firing
+   threshold in every case — e.g. `repair_urgency` plateaus at 0.480 vs 0.50,
+   `reply_pressure` 0.400 vs 0.45, `avoidance_exit` 0.400 vs 0.45, both agents.
+   Verified against the logged final snapshots.
+3. The stagnation layer escalates correctly and does nothing else: yellow at
+   p10-p40 (0.604-0.702), red at p50 and p60 (0.843, `message_loop`
+   attractor, BDI 0.96, IGE/ISD/CNS 1.0). Six warnings total; no intervention
+   is wired to the red level (see #129).
+
+## Context
+
+- LLM budget (`llmCallBudgetPerMinute: 10`) was never the constraint: 3 calls
+  in the first 20s, none after. No budget-denial events in the stream.
+- No `llm_failure`, no `prompt_trimmed` events: prompts stayed under the
+  2048-token cap; the trim machinery never engaged.
+- Rumination bookkeeping advances (`lastRuminationPulse: 63`) but no
+  reflection LLM calls are made and no memories commit (`memories: []`
+  throughout).

--- a/docs/eval/evidence/local-deadroom-deepseek/run-meta.json
+++ b/docs/eval/evidence/local-deadroom-deepseek/run-meta.json
@@ -1,0 +1,35 @@
+{
+  "scenarioId": "deepseek-api",
+  "source": "pnpm --filter @perfectman/server simulation (config/index.json, live run 2026-09-01)",
+  "model": "deepseek-v4-flash",
+  "temperature": 0.7,
+  "pulses": 63,
+  "events": 3,
+  "socialEvents": [
+    "message_sent by ana",
+    "reply_sent by bruno",
+    "message_sent by ana"
+  ],
+  "fallbacks": 0,
+  "llmCalls": {
+    "ana": 2,
+    "bruno": 1
+  },
+  "llmFailures": 0,
+  "promptTrims": 0,
+  "elapsedMs": 362104,
+  "stagnation": {
+    "checkpoints": 6,
+    "cadencePulses": 10,
+    "compositeScores": [
+      0.674,
+      0.644,
+      0.643,
+      0.702,
+      0.843,
+      0.843
+    ],
+    "attractor": "message_loop",
+    "escalation": "yellow x4 (p10-p40) -> red x2 (p50, p60); no intervention configured"
+  }
+}

--- a/docs/eval/evidence/local-deadroom-deepseek/transcript.json
+++ b/docs/eval/evidence/local-deadroom-deepseek/transcript.json
@@ -1,0 +1,26 @@
+[
+  {
+    "pulse": 0,
+    "agent": "ana",
+    "type": "message_sent",
+    "channelId": "general",
+    "private": false,
+    "content": "oi gente"
+  },
+  {
+    "pulse": 1,
+    "agent": "bruno",
+    "type": "reply_sent",
+    "channelId": "general",
+    "private": false,
+    "content": "hm, oi. tudo bem?"
+  },
+  {
+    "pulse": 2,
+    "agent": "ana",
+    "type": "message_sent",
+    "channelId": "general",
+    "private": false,
+    "content": "tudo bem sim, e contigo?"
+  }
+]

--- a/docs/eval/evidence/local-deadroom-deepseek/transcript.txt
+++ b/docs/eval/evidence/local-deadroom-deepseek/transcript.txt
@@ -1,0 +1,4 @@
+p  0 ana        message_sent       "oi gente"
+p  1 bruno      reply_sent         "hm, oi. tudo bem?"
+p  2 ana        message_sent       "tudo bem sim, e contigo?"
+# pulses 3-63 (~5 min): zero cognition calls from either agent - run ends here


### PR DESCRIPTION
## What

Captures a live 63-pulse run of the `deepseek-api` config under `docs/eval/evidence/local-deadroom-deepseek/`:

- `run-meta.json`: `deepseek-v4-flash`, 63 pulses at 5s, 3 social events, `ana` 2 / `bruno` 1 LLM calls, 0 fallbacks / 0 trims / 0 failures, 362s elapsed
- `transcript.json` + `transcript.txt`: the 3-message opening exchange in the house format, dead window annotated
- `observations.md`: `cold_start_bootstrap` pinned at 1.0 firing every pulse without producing cognition; the passive fixed point `growthRate / (decayRate * 0.5)` sits below the firing threshold for all 16 other sources, both agents; rumination bookkeeping advances but 0 memories commit
- Stagnation trajectory: yellow x4 (p10-p40, 0.604-0.702) -> red x2 (p50/p60, 0.843), `message_loop` attractor, no intervention wired
- Grounds the #129 threshold/decay tuning and the #142 residual-risk follow-up in committed evidence

## Why

First live post-merge run of the #139-#146 stack; the room went silent for ~5 minutes after a clean 3-message opening, and the stagnation layer escalated to red with nothing listening — the accumulator snapshots pin the exact state for tuning.

## Validation

- `[docs-lint] PASS` - `[audit-tests] PASS` (70 docs files, 0 violations; evidence dir included)
- `pnpm lint` / full suite not green on this branch alone: it stacks behind #148, which repairs the #141/#145 merge break in `main`; docs-only change
