### PR TITLE
feat(agent): form memories from action intents and persist them

### DIFF
--- a/docs/adr/0013-memory-formation-and-relational-accretion.md
+++ b/docs/adr/0013-memory-formation-and-relational-accretion.md
@@ -1,0 +1,79 @@
+# ADR-0013: Memory Formation And Relational Accretion
+
+**Status**: Accepted (LOCKED, 2026-09-02) — rationale and rejected alternatives inline in this ADR (decisions **D-37..D-45**).
+
+**Numbering note**: written against the merged-tree ADRs 0001..0012 (0012 duplicated: `0012-goal-layer-meaning-made-gate.md` and `0012-goal-registry-persistence.md`); in-tree decision high-water mark **D-36** (ADR-0012). The source run's decision log numbered its decisions run-locally D-1..D-10; D-1..D-9 map to **D-37..D-45** here. Run-local D-10 (two-PR merge sequencing) is not converted — sequencing decisions expire at merge. The D-37..D-45 range is this ADR's; if another unmerged slice claims the range first, renumber here and reconcile the inline D-refs.
+
+## Context
+
+A 63-pulse live deepseek run (PR #149 evidence branch) showed both mechanisms absent: `memories: []` and `relationalStates: {}` for every agent despite a 3-message exchange. Issues #136 and #138 (parent plan #119, decisions #126/#127) are the direct fixes.
+
+**#136 — memory formation.** The action-intent prompt's `<output_contract>` listed the `memoryWrites` field but never asked the model to use it. Committed `memory_written` events (engine path only, from `stepResult.memoryProposals`, which `runEngineStep()` always leaves empty) never reached `agentState.memories`, and `write_memory` sat in every agent's permitted actions as a turn-consuming choice the issue wants retired ("memory is a side-channel on a normal action, not a turn-consuming choice").
+
+**#138 — relational accretion.** `updateRelationalEmotions` runs every pulse but no-ops in practice: resolver event payloads carried no participant identifiers (so `isTarget` was false for every observer on message/reaction events), `RELATIONAL_UPDATE_RULES` had no `message_sent` entry, and `isTarget` ignored `invitedAgentIds` so a channel invitee accreted nothing.
+
+Constraints carried into the decisions: `EventPayload` is a loose `Record<string, EventPayloadValue>` (payload additions need no shared schema change); every existing projection under `simulation/projections/` is a read-side view emitter; `rules/10-code-shape.md` forbids abstractions without a second caller; the issue mandates keeping `write_memory` schema/resolver plumbing while removing it from permitted actions.
+
+## Decision
+
+**1. Memory persistence is a scheduler-private method, not a projection class (D-37).** `applyMemoryProjection` lives inside `pulse-scheduler.ts`, consumes committed `memory_written` events, and pushes the payload-mapped `Memory` (id via `createId()`, `sourceEventIds: [event.id]`, commit-assigned timestamps — no wall clock) onto `stepResult.updatedAgentState.memories` in place, at the two agent-loop append sites. No repo upsert inside the hook: the same iteration's `persistAndSnapshot` is the single write point, so the same pulse's `agent_state_snapshot` carries the memory. This is the first projection-shaped step that mutates agent state instead of emitting an audience view — the deviation from the `projections/` precedent is deliberate and recorded here.
+
+**2. Memory application consumes only returned committed events (D-38).** `appendAndProject` changes return type `number` → `CommittedEvent[]` (5 call sites take `.length`). A failed append returns `[]`, so a failed commit can never fabricate a memory.
+
+**3. The mention parser is module-local; names arrive via `ResolveContext.agentNames` (D-39).** Exact, case-insensitive, boundary-aware display-name and `@handle` matching over `visibleContent`, against an **optional** `agentNames: Record<string, string>` (agentId → display name) that the scheduler builds once from `config.agents[].persona.name` and passes in the resolve ctx. An unwired map degrades to zero mentions parsed — same as pre-#138 behavior; the risk is accepted and owned by the eval bench.
+
+**4. The co-presence bump is a data-only bystander rule (D-40).** A `message_sent` role=`bystander` entry in `RELATIONAL_UPDATE_RULES` (magnitude 0.3) rides the existing `targetIds` machinery (`{actor}` when no `personTargets`/mentions). No `channelMemberIds` payload stamping and no engine signature change: the visibility filter already bounds the observer set (private channels members-only; all active agents are seeded members of the sole public channel and `leave_channel` on it is blocked). A directed `message_sent` role=`target` entry (magnitude 0.5) accompanies it, ordered below `reply_sent`'s 1.0.
+
+**5. Reaction registration rides intent-carried `personTargets` (D-41).** `buildReactionEvent` stamps `personTargets` (and the mention parser where content exists) exactly as the message/reply builders do. No `targetEventId`→actor resolution — the resolver has no event-repository access. Residual risk accepted: if the model omits `personTargets` on react, the reaction still does not register; observed via eval bench, not unit-asserted.
+
+**6. `isTarget` consults `invitedAgentIds` and folds the singular key (D-42).** One comparison line folds `invitedAgentId` (`agent_invited`) into the consulted set alongside the plural `invitedAgentIds` (`channel_created`), removing a live plural/singular asymmetry. The fold touches `isTarget` only; the `agent_invited` exclusion-cascade bystander rule still resolves `affectedTargets` via the plural-only `targetIds` (pre-existing behavior, deliberately unchanged).
+
+**7. AC-138-3 is invitee-side only (D-43).** "Accretes a relational entry for that invitee" reads as the invitee's entry about the creator (covered by D-42 via the pre-existing `channel_created` target rule). The creator's entry about the invitee would need a new actor-role rule for `channel_created`/`agent_invited` (none exists) — deferred to a follow-up if wanted.
+
+**8. `mock-llm-provider.ts` stays `memoryWrites: []` (D-44).** Deterministic suites inject intents carrying `memoryWrites` through the resolver/scheduler seam; eval bench runs exercise memory formation end-to-end via `PersonaAwareMockProvider`'s seeded emission. Teaching the server mock to emit memories would change every mock-based suite's fixtures for no test need.
+
+**9. The `write_memory` sweep removes only the always-available action (D-45).** Deleted: the entry in `computeAvailableActions` (count 11→10). Kept: `ALL_INTENT_TYPES` (the offline branch's contract is "list every type, blocked"), the shared schema/type union, `validate-intent`, the resolver plumbing (`memoryProposalEvents` guard, `case "write_memory"`), and the historical plan doc `dev3-domain-engine-integration.md:511` (documents the type union, which stays). Blocked ≠ permitted; widening the sweep would broaden the diff without serving AC-136-4.
+
+## Rationale
+
+- **Scheduler-private over projection class (D-37):** the conversion is ~20 lines with exactly one caller pair, both inside `executePulse`'s agent loop; in-place mutation of `updatedAgentState` has exact precedent (the `lastActionAt` stamp in the same file). A `projections/agent-memory-projection.ts` would need a `PulseSchedulerConfig` field plus wiring in `simulation-runtime`/`simulation-manager` for no second caller. A dedicated `agentStateRepo.upsert` inside the hook would double-write per turn and create a second persist point to keep consistent with `persistAndSnapshot`.
+- **Returned committed events over a count delta (D-38):** a `eventsCommitted` before/after heuristic silently relies on repo-append atomicity; returning the committed list makes "only committed events become memories" explicit and testable.
+- **Module-local parser over a module (D-39):** single caller pair (message + reply builders); the scheduler is the only place holding both agent ids and personas; the optional field keeps the 6+ existing `resolve` call sites compiling.
+- **Visibility filter over member stamping (D-40):** resolver-stamped `channelMemberIds` plus an engine gate is an extra payload field and a special-case branch for a distinction the filter already approximates; rule magnitudes bound the approximation error (non-member viewers of public-channel messages receive a 0.3 bump).
+- **Intent payload over event lookup (D-41):** the issue prescribes exactly this; the intent schema already allows `personTargets` on react and `computeAvailableActions` grants react reachable people. A scheduler-supplied lookup or new resolver dependency is a bigger seam than the issue asks for.
+- **Singular fold (D-42):** plural alone satisfies AC-138-3 via `channel_created`; the fold is one line that removes an asymmetry rather than inventing behavior.
+- **Invitee-side reading (D-43):** the issue's wording reads naturally invitee-side; creator-side would invent rule semantics the issue never specifies (dead code today — no actor rule consumes the extension).
+- **Sweep boundary (D-45):** the issue says "leave the schema / resolver plumbing"; the offline branch lists every type as blocked by design, so changing it broadens the diff without changing what any agent may do.
+
+## Rejected Alternatives
+
+- **`projections/agent-memory-projection.ts` mirroring `spectator-projection.ts`** — single caller, no seam, 3 extra wiring points (D-37).
+- **Repo upsert inside the memory hook** — double write per turn; second persist point (D-37).
+- **Count-delta `eventsCommitted` heuristic** — silent reliance on append atomicity (D-38).
+- **Required `agentNames` on `ResolveContext`** — breaks every existing resolver call site/test for no behavioral gain (D-39).
+- **Standalone `mention-parser.ts`** — no second caller (D-39).
+- **Resolver stamps `channelMemberIds`; engine gates bystander targets on it** — extra payload field + special-case branch for an already-approximated distinction (D-40).
+- **`targetEventId`→original-actor resolution for reactions** — the resolver has no event-repo access; a scheduler-supplied lookup or new dependency is a bigger seam than the issue asks; re-flag as follow-up if eval shows reactions not registering (D-41).
+- **Plural-only `isTarget` consult** — viable for AC-138-3; the fold is cheaper than the asymmetry it removes (D-42).
+- **Creator-side relational entry via actor-role `affectedTargets` extension** — dead code today (no actor rule consumes it) (D-43).
+- **Teaching the server mock to emit memories** — broadens mocked-run behavior and changes every mock fixture (D-44).
+- **Removing `write_memory` from `ALL_INTENT_TYPES` too** — the offline branch's contract is "list every type, blocked"; blocked ≠ permitted (D-45).
+
+## Consequences
+
+- **The live memory path is now intent-side**: prompt criteria (one line in `renderOutputContract`'s Ensure list) → model emits `memoryWrites` on a normal action intent → resolver commits `memory_written` post-LLM-path → `applyMemoryProjection` → `agentState.memories` → `selectRelevantMemories` → the next prompt's "What you remember". The engine path (`EngineEventBuilder` from `stepResult.memoryProposals`) remains as redundant-but-harmless plumbing — cleanup is a separate issue, not folded in silently.
+- **`agentState.memories` grows unbounded over long runs** (over-emission bounded only by prompt criteria); a cap was deliberately deferred — no speculative limits — and the rate is observed via eval bench artifacts.
+- **Dormant paths activate**: populating `personTargets`/`mentionedAgentIds` switches on mention-based attention and involved-people derivation (`score-attention.ts`, `build-perception-packet.ts`, `interpret-programmatic-signals.ts`). Expected per plan; tuning explicitly out of scope. In the canned 4-persona e2e room this makes every agent LLM-attentive every pulse, which forced removal of the parity fixture's `staleFrames > 0` counter — the staleness axis ("receiver drops thinking rows whose intent the pulse lacks") is currently unowned until the follow-up assertion lands in `html-snapshot-gateway.test.ts`.
+- **`templateVersion` hash moves with the prompt edit** (`1lzz3tz` → `1e65v2f` at implementation time); nothing pins the computed value.
+- **`agentNames` is optional, so typecheck cannot catch a dropped wire** — a scheduler regression degrades mentions silently; a test asserting the scheduler→resolver wiring is owed (mutation-proven gap).
+- **Payload absence ≡ empty** for the engine's `?? []` reads; identifiers are stamped only when non-empty, mirroring `buildReplyEvent`'s `replyToActorId` precedent.
+- **The ownership map needs no row moves**: memory persistence stays Dev2 (`simulation/`), the mention parser stays Dev2 (`intent-resolver.ts`), `RELATIONAL_UPDATE_RULES` stays Dev3 (`shared/constants`). The master-contract's Key Type Flow does not yet show the intent-side memory path — the doc touch is flagged with proposed wording in this run's doc-report, deliberately not edited there.
+
+## Cross-links
+
+- Issues #136/#138 (parent plan #119; decisions #126/#127); run decision log D-1..D-9 → D-37..D-45 per the numbering note.
+- [ADR-0001](./0001-event-visibility-operator-event.md) — `appendAndProject`'s per-committed-event `event_visibility` emission semantics are unchanged by D-38 (return type only).
+- [ADR-0012](./0012-goal-registry-persistence.md) — `PulseScheduler` call sites of `appendAndProject`; numbering convention source.
+- Contract: `docs/plans/master-contract.md` — Key Type Flow (intent-side memory path flagged for addition); Canonical Event Types unchanged (no new event types; payload fields ride the loose `EventPayload` record).
+- Code: `packages/server/src/simulation/{pulse-scheduler,intent-resolver}.ts`, `packages/server/src/agent/action-intent-prompt-builder.ts`, `packages/engine/src/action/compute-available-actions.ts`, `packages/engine/src/emotion/update-relational-emotions.ts`, `packages/shared/src/constants/emotion-rules.ts`.
+- Tests: `pulse-scheduler.test.ts` (memory persistence, both paths), `prompt-builder.test.ts` (emission criteria + memory render), `emotion-stack.test.ts` (rule ordering, invitee accretion, co-presence, reaction), `intent-resolver-relational.test.ts` (real-resolver → real-accretion regression).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ ADR-0001..0007 pre-date this convention and are historical records: their Status
 | [ADR-0008](0008-world-goal-layer.md) | World Goal Layer |
 | [ADR-0009](0009-goal-layer-runtime-wiring.md) | Goal-Layer Runtime Wiring |
 | [ADR-0010](0010-goal-layer-llm-slice.md) | Goal-Layer LLM Slice |
+| [ADR-0013](0013-memory-formation-and-relational-accretion.md) | Memory Formation And Relational Accretion |
 
 ## Template
 

--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -921,7 +921,6 @@ actionIntent:
 - `leave_channel`
 - `typing_start`
 - `typing_cancel`
-- `write_memory`
 - `delay_response`
 - `no_op`
 

--- a/docs/architecture/social-presence.md
+++ b/docs/architecture/social-presence.md
@@ -1080,7 +1080,6 @@ change_channel_permission
 symbolic_action
 delay_response
 type_and_delete
-write_memory
 set_private_focus
 ```
 
@@ -1474,7 +1473,6 @@ intentBundle:
     - react
     - symbolic_action
   privateActions:
-    - write_memory
     - update_person_focus
     - mark_suspicion
     - request_rest

--- a/docs/concepts/concept-map.md
+++ b/docs/concepts/concept-map.md
@@ -775,7 +775,6 @@ symbolic actions:
   mock
 
 internal actions:
-  write_memory
   delay_response
   type_and_delete
   set_private_focus

--- a/docs/observability-stream.md
+++ b/docs/observability-stream.md
@@ -35,8 +35,9 @@ The e2e 4-persona scenario (Ana, Bruno, Carla, Diego; 15 pulses) stays within:
 - plus the pre-existing `pulse_metrics` per LLM call (≤ ~60)
 
 Payloads stay bounded per the spec's current-state-only framing: snapshots carry
-the full serialized `AgentState` (including `memories` — bounded by the engine's
-memory lifecycle — and no history/deltas); `action_intent` carries the five
+the full serialized `AgentState` (including `memories` — growing with agent
+memory formation; unbounded over long runs by design, see ADR-0013 — and no
+history/deltas); `action_intent` carries the five
 FR-002 fields verbatim; `event_visibility` carries id/type/actor/channel/
 `visibleToAgents` plus content/channelName where present.
 

--- a/docs/plans/dev2-runtime.md
+++ b/docs/plans/dev2-runtime.md
@@ -203,7 +203,7 @@ Projection invariants:
 
 `runEngineStep()` returns deterministic outputs even when `decision.needsLLM === false`. Dev2 must commit those outputs, when present, before deciding whether to call the LLM:
 
-- `memoryProposals[]` → one `memory_written` event per proposal when present; current dev3 engine returns `[]` and dev1/parser work may populate proposals later
+- `memoryProposals[]` → one `memory_written` event per proposal when present; current dev3 engine returns `[]` and dev1/parser work may populate proposals later — populated instead via the action intent's `memoryWrites` (resolver path); the engine path stays empty
 - `noOpRecord` → one `no_op_recorded` event when present
 - `stagnation_detected` → committed from periodic `computeStagnationMetrics()` when thresholds trip
 

--- a/docs/plans/master-contract.md
+++ b/docs/plans/master-contract.md
@@ -98,12 +98,13 @@ Command | ActionIntent
   → buildAgentRuntimeInput (dev2 assembles from EngineStepResult + persona + budget)
   → AgentRuntimeInput (dev3 defines type, dev2 builds instance)
   → AgentRuntime.generateIntent (dev1)
+  → memoryWrites on ActionIntent (dev1 prompt contract) → IntentResolver commits memory_written (dev2) → PulseScheduler.applyMemoryProjection appends to agentState.memories before persistAndSnapshot (dev2; deliberately not a projections/ class — ADR-0013 D-37)
   → ActionIntent (dev3 defines type, dev1 produces instance)
 ```
 
 Only `CommittedEvent[]` are appended to the event log. Commands and intents are requests/proposals; the event log contains accepted facts.
 
-Engine-related facts (`memory_written`, `no_op_recorded`, `stagnation_detected`) are committed before the optional LLM path when their source data exists. Current dev3 `runEngineStep()` emits `noOpRecord` and an empty `memoryProposals[]`; memory proposals may be populated by later dev1/parser work. Resolver-emitted facts (`message_sent`, `reply_sent`, `reaction_sent`, `channel_created`, `intent_delayed`, `intent_blocked`) are committed only after `IntentResolver.resolve()`.
+Engine-related facts (`memory_written`, `no_op_recorded`, `stagnation_detected`) are committed before the optional LLM path when their source data exists. Current dev3 `runEngineStep()` emits `noOpRecord` and an empty `memoryProposals[]`. Memory formation now rides the action intent: the model emits `memoryWrites` on a normal action intent (dev1 prompt criteria), the resolver commits `memory_written` after the LLM path, and the scheduler's private `applyMemoryProjection` copies committed events into `agentState.memories` before the end-of-turn `persistAndSnapshot` (the single write point). The engine path — `EngineEventBuilder` committing `memory_written` from `stepResult.memoryProposals` — remains as redundant-but-harmless plumbing; `runEngineStep()` still emits an empty `memoryProposals[]`. Resolver-emitted facts (`message_sent`, `reply_sent`, `reaction_sent`, `channel_created`, `intent_delayed`, `intent_blocked`) are committed only after `IntentResolver.resolve()`.
 
 ## Runtime / Projection / Delivery Boundary
 

--- a/packages/engine/src/__tests__/available-actions.test.ts
+++ b/packages/engine/src/__tests__/available-actions.test.ts
@@ -100,25 +100,34 @@ describe("computeAvailableActions", () => {
     expect(actions.every(a => a.blockReason === "agent_offline")).toBe(true);
   });
 
-  it("returns all 11 intent types", () => {
+  it("returns all 10 intent types", () => {
     const agent = makeAgent();
     const channels = [makeChannel("ch1")];
     const membership = [makeMembership("ch1")];
     const actions = computeAvailableActions(agent, channels, membership, DEFAULT_SETTINGS, makeRateLimit());
     const types = new Set(actions.map(a => a.intentType));
-    expect(types.size).toBe(11);
+    expect(types.size).toBe(10);
   });
 
-  it("no_op and write_memory always available", () => {
+  it("no_op always available", () => {
     const agent = makeAgent({ presence: "active" });
     const actions = computeAvailableActions(agent, [], [], DEFAULT_SETTINGS, makeRateLimit({
       blocked: true,
       blockReason: "global_block",
     }));
     const noOp = actions.find(a => a.intentType === "no_op");
-    const writeMemory = actions.find(a => a.intentType === "write_memory");
     expect(noOp?.blocked).toBe(false);
-    expect(writeMemory?.blocked).toBe(false);
+  });
+
+  it("write_memory is never a permitted action (memory rides a normal action's memoryWrites)", () => {
+    const agent = makeAgent({ presence: "active" });
+    const channels = [makeChannel("ch1")];
+    const membership = [makeMembership("ch1")];
+    const actions = computeAvailableActions(agent, channels, membership, DEFAULT_SETTINGS, makeRateLimit());
+    expect(
+      actions.some(a => a.intentType === "write_memory"),
+      `write_memory must not appear in permitted actions, got: ${actions.map(a => a.intentType).join(", ")}`,
+    ).toBe(false);
   });
 
   it("send_message blocked when message rate limit reached", () => {

--- a/packages/engine/src/__tests__/engine-step.test.ts
+++ b/packages/engine/src/__tests__/engine-step.test.ts
@@ -245,9 +245,9 @@ describe("runEngineStep", () => {
     expect(result.perceptionPacket.agentId).toBe("a1");
   });
 
-  it("availableActions contains 11 intent types", () => {
+  it("availableActions contains 10 intent types", () => {
     const result = runEngineStep(makeSnapshot());
-    expect(result.availableActions).toHaveLength(11);
+    expect(result.availableActions).toHaveLength(10);
   });
 
   it("deterministic output for same seed and inputs", () => {

--- a/packages/engine/src/__tests__/scenarios.test.ts
+++ b/packages/engine/src/__tests__/scenarios.test.ts
@@ -99,7 +99,7 @@ describe("buildSimulationFixture scenario", () => {
       expect(result.perceptionPacket.agentId).toBe(persona.id);
       expect(result.updatedAgentState.agentId).toBe(persona.id);
       assertEmotionBounds(result.updatedAgentState);
-      expect(result.availableActions).toHaveLength(11);
+      expect(result.availableActions).toHaveLength(10);
       expect(result.initiativeCandidates).toHaveLength(17);
     }
   });

--- a/packages/engine/src/action/compute-available-actions.ts
+++ b/packages/engine/src/action/compute-available-actions.ts
@@ -160,14 +160,6 @@ export function computeAvailableActions(
       blocked: false,
     },
 
-    // write_memory — always available (no rate limit)
-    {
-      intentType: "write_memory",
-      channelTargets: [],
-      personTargets: [],
-      blocked: false,
-    },
-
     // delay_response — always available
     {
       intentType: "delay_response",

--- a/packages/eval/src/test/persona-mock-memory-writes.test.ts
+++ b/packages/eval/src/test/persona-mock-memory-writes.test.ts
@@ -58,6 +58,7 @@ function makeInput(): AgentRuntimeInput {
       agentId: "agent-a",
       triggeringEvent: null,
       visibleContextEvents: [],
+      eventHandles: {},
       ownRecentUtterances: [],
       involvedPeople: [],
       relevantChannels: [],

--- a/packages/server/src/__e2e__/persona-aware-runtime.ts
+++ b/packages/server/src/__e2e__/persona-aware-runtime.ts
@@ -97,12 +97,6 @@ const SCRIPTS: Record<string, Script> = {
         "Já ouvi o suficiente. Sair sem fazer barulho.",
         "Esse canal perdeu o ponto. Vou embora.",
       ],
-      write_memory: [
-        "Preciso registrar isso. Pode ser útil mais tarde.",
-        "Não quero esquecer essa troca. Vou guardar.",
-        "Algo aqui vale a pena registrar antes que se perca.",
-        "Memória falha. Melhor anotar enquanto ainda está fresco.",
-      ],
       delay_response: [
         "Melhor esperar um pouco antes de responder. Quero pensar.",
         "Não tenho certeza do que dizer. Preciso de mais um segundo.",
@@ -186,12 +180,6 @@ const SCRIPTS: Record<string, Script> = {
         "Cansada desse lugar. Tem coisa mais interessante em outro canto.",
         "Já vi o que precisava ver. Vou embora.",
         "Ficou entediante. Próximo.",
-      ],
-      write_memory: [
-        "Anotando isso aqui — pode virar munição depois.",
-        "Guardando esse momento. Vai ser útil quando precisar.",
-        "Registro. Nunca se sabe quando isso vai servir.",
-        "Não quero esquecer o que aconteceu aqui.",
       ],
       delay_response: [
         "Deixar a tensão crescer um pouco antes de responder.",
@@ -277,12 +265,6 @@ const SCRIPTS: Record<string, Script> = {
         "Saindo antes que o canal esgote qualquer utilidade.",
         "Canal sem mais valor. Meu tempo vale mais em outro lugar.",
       ],
-      write_memory: [
-        "Registrando para análise futura. Informação é poder.",
-        "Guardar isso. Pode mudar o jogo mais tarde.",
-        "Anotando. Padrões aqui revelam muito sobre a dinâmica.",
-        "Isso vai ser útil. Registrar agora.",
-      ],
       delay_response: [
         "Timing é tudo. Esperando o momento mais vantajoso.",
         "Responder agora seria fraco. Deixar marinar.",
@@ -318,7 +300,6 @@ const FALLBACK_SCRIPT: Script = {
     react: ["Deixando uma reação.", "Uma reação breve basta aqui."],
     invite_agent: ["Convidando alguém para o canal.", "Trazendo alguém para essa conversa."],
     leave_channel: ["Saindo deste canal.", "Não preciso mais deste espaço."],
-    write_memory: ["Registrando algo importante.", "Vale guardar esse momento."],
     delay_response: ["Aguardando antes de responder.", "Vou esperar um pouco."],
     typing_start: ["Digitando uma resposta.", "Vou tentar formular algo."],
     typing_cancel: ["Cancelando a resposta.", "Mudei de ideia."],

--- a/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
+++ b/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
@@ -83,6 +83,14 @@ export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): A
       agentId,
       triggeringEvent: options.triggeringEvent ?? null,
       visibleContextEvents: options.visibleContextEvents ?? [],
+      // Same numbering the perception builder emits: e1 = triggering event
+      // (when present), then context events in order.
+      eventHandles: Object.fromEntries(
+        (options.triggeringEvent
+          ? [options.triggeringEvent, ...(options.visibleContextEvents ?? [])]
+          : (options.visibleContextEvents ?? [])
+        ).map((e, i) => [`e${i + 1}`, e.id]),
+      ),
       ownRecentUtterances: options.ownRecentUtterances ?? [],
       involvedPeople: [],
       relevantChannels: ["general"],

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -279,6 +279,25 @@ describe("PromptBuilder", () => {
     expect(prompt.system).toContain('"privateMotiveSummary" (required): string');
   });
 
+  describe("memoryWrites emission criteria", () => {
+    it.each([
+      ["first-person framing", "first person"],
+      ["event grounding in <events>", "grounded in what actually happened in <events>"],
+      ["only when the exchange matters", "only when this exchange actually matters"],
+      ["empty when nothing qualifies", 'leave "memoryWrites" empty'],
+    ])("output contract instructs memoryWrites emission: %s", (_label, marker) => {
+      const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+      expect(prompt.system).toContain(marker);
+    });
+  });
+
+  it("renders a relevant memory under the What you remember section", () => {
+    const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+    const memoriesSection = prompt.user.split("<memories>")[1]?.split("</memories>")[0] ?? "";
+    expect(memoriesSection).toContain("What you remember");
+    expect(memoriesSection).toContain("[Memory (relationship)] This friend is often quiet and indirect");
+  });
+
   describe("PromptPurpose policy", () => {
     it("action_intent: BuiltPrompt.purpose is 'action_intent'", () => {
       const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -343,6 +343,7 @@ export class ActionIntentPromptBuilder {
       `"privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").`,
       `Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".`,
       `For reply_to_message set "replyToEventId", and for react set "targetEventId", to one of the bracketed event handles from <events> (e.g. "e1") — copy the handle text exactly, do not invent an id or describe the message.`,
+      `Use "memoryWrites" only when this exchange actually matters to your relationships or intentions — not on every turn. Each proposal must be written in first person ("I…") and grounded in what actually happened in <events> (a promise made, a slight received, a revealed preference, a plan formed), filling every field (type, subjectAgentIds, summary, emotionalTone, confidence, intensity, unresolved) per the field contract above. When nothing qualifies, leave "memoryWrites" empty.`,
     ]);
   }
 

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -199,10 +199,22 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
 
     if (!fallbackApplied && (isRepeat(intent) || parseResult.unresolvedTarget)) {
       for (let attempt = 0; attempt < maxRetries; attempt++) {
-        // The correction note re-inflates the (already-capped) base prompt, so
+        // The correction notes re-inflate the (already-capped) base prompt, so
         // the retry prompt is re-assembled and re-trimmed against the same cap
-        // before it goes anywhere near the wire.
-        const retryPrompt = this.buildRetryPrompt(input, ctx, prompt, intent.visibleContent ?? "");
+        // before it goes anywhere near the wire; the trim event and the budget
+        // gate below therefore see the corrected, final estimate.
+        const corrections: string[] = [];
+        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
+        if (parseResult.unresolvedTarget) {
+          corrections.push(
+            targetRetryCorrectionNote(
+              parseResult.unresolvedTarget.field,
+              parseResult.unresolvedTarget.badHandle,
+              parseResult.unresolvedTarget.validHandles,
+            ),
+          );
+        }
+        const retryPrompt = this.buildRetryPrompt(input, ctx, prompt, corrections.join("\n\n"));
         const retryTrimEvent = this.promptTrimEvent(
           retryPrompt,
           simulationId,
@@ -229,23 +241,6 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
           }
           break;
         }
-        const corrections: string[] = [];
-        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
-        if (parseResult.unresolvedTarget) {
-          corrections.push(
-            targetRetryCorrectionNote(
-              parseResult.unresolvedTarget.field,
-              parseResult.unresolvedTarget.badHandle,
-              parseResult.unresolvedTarget.validHandles,
-            ),
-          );
-        }
-        const correction = corrections.join("\n\n");
-        const retryPrompt = {
-          ...prompt,
-          version: promptVersionHash([`${prompt.system}\n\n${correction}`, prompt.user]),
-          system: `${prompt.system}\n\n${correction}`,
-        };
         try {
           const retryResult = await provider.generateIntent(input, runtimeContext, retryPrompt);
           retriesAttempted++;
@@ -467,21 +462,21 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
   }
 
   /**
-   * Assemble the repetition-guard retry prompt with the cap re-enforced.
-   * `retryCorrectionNote` is appended to the system text *after* the base
-   * render, so a base prompt that `trimToFit` left just under the cap would
-   * cross it once the note is added. The base is therefore rebuilt against a
-   * cap lowered by the note's own token estimate; `base + note` is then within
-   * the original cap by construction. Falls back to a plain append when the
-   * agent has no configured cap.
+   * Assemble the retry prompt with the cap re-enforced. The composed
+   * correction text is appended to the system text *after* the base render,
+   * so a base prompt that `trimToFit` left just under the cap would cross it
+   * once the correction is added. The base is therefore rebuilt against a cap
+   * lowered by the correction's own token estimate; `base + correction` is
+   * then within the original cap by construction. Falls back to a plain
+   * append when the agent has no configured cap.
    */
   private buildRetryPrompt(
     input: AgentRuntimeInput,
     ctx: StepRunContext,
     basePrompt: BuiltPrompt,
-    lastAttempt: string,
+    correction: string,
   ): BuiltPrompt {
-    const suffix = `\n\n${retryCorrectionNote(lastAttempt)}`;
+    const suffix = correction ? `\n\n${correction}` : "";
     const cap = ctx.llmConfig.maxInputTokens;
 
     if (typeof cap !== "number" || cap <= 0) {

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -11,7 +11,7 @@ import { OperatorProjection } from "../projections/operator-projection.js";
 import { EngineEventBuilder } from "../engine-event-builder.js";
 import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
 import type { AgentContext, AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
-import type { Simulation, SimulationSettings, AgentState, PersonaConfig, ActionIntent, EndingOffer, GoalSynthesisResult, SimulationEvent } from "@perfectman/shared";
+import type { Simulation, SimulationSettings, AgentState, PersonaConfig, ActionIntent, EndingOffer, GoalSynthesisResult, SimulationEvent, Memory, MemoryWriteProposal } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
 import { runEngineStep } from "@perfectman/engine";
 import { resolveGoalLayerConfig, WorldEvaluator } from "../world/world-evaluator.js";
@@ -101,6 +101,16 @@ const ZERO_ACTION = {
   dominanceAssertion: 0, repairImpulse: 0,
 };
 
+const CANNED_MEMORY_PROPOSAL = {
+  type: "relationship",
+  subjectAgentIds: ["agent-B"],
+  summary: "agent-B promised to keep the plan secret",
+  emotionalTone: "suspicious",
+  confidence: 0.7,
+  intensity: 0.6,
+  unresolved: true,
+} as const;
+
 /** Canned step result for driving the real PulseScheduler through its commit-ordering. */
 function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").EngineStepResult {
   return {
@@ -123,9 +133,7 @@ function makeCannedStep({ memory = false } = {}): import("@perfectman/shared").E
     decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
     availableActions: [],
     initiativeCandidates: [],
-    memoryProposals: memory
-      ? [{ type: "relationship", subjectAgentIds: ["agent-B"], summary: "agent-B seems untrustworthy", emotionalTone: "suspicious", confidence: 0.7, intensity: 0.6, unresolved: true }]
-      : [],
+    memoryProposals: memory ? [CANNED_MEMORY_PROPOSAL] : [],
     noOpRecord: { agentId: "agent_1", pulseIndex: 0, privateMotiveSummary: "nothing to do", reason: "test" },
     operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 1, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
   };
@@ -253,10 +261,90 @@ describe("PulseScheduler", () => {
     const events = await eventRepo.getAfter("sim_test");
     const mem = events.filter((e) => e.type === "memory_written");
     expect(mem).toHaveLength(1);
-    expect(mem[0]!.payload["summary"]).toBe("agent-B seems untrustworthy");
-    expect(mem[0]!.payload["intensity"]).toBe(0.6);
+    expect(mem[0]!.payload["summary"]).toBe(CANNED_MEMORY_PROPOSAL.summary);
+    expect(mem[0]!.payload["intensity"]).toBe(CANNED_MEMORY_PROPOSAL.intensity);
     // noOpRecord present with needsLLM=false — the LLM path must not be invoked
     expect(mockAgentRuntime.generateIntent).not.toHaveBeenCalled();
+  });
+
+  describe("memory persistence", () => {
+    const PROPOSAL: MemoryWriteProposal = CANNED_MEMORY_PROPOSAL;
+
+    interface MemoryScenario {
+      name: string;
+      arrange: () => void;
+    }
+
+    const scenarios: MemoryScenario[] = [
+      {
+        name: "engine path: canned step memoryProposals commit memory_written",
+        arrange: () => {
+          scheduler = buildScheduler(() => makeCannedStep({ memory: true }));
+        },
+      },
+      {
+        name: "intent path: an intent carrying memoryWrites commits memory_written through the real resolver",
+        arrange: () => {
+          scheduler = buildScheduler(() => ({
+            ...makeCannedStep(),
+            decision: { outcome: "act", needsLLM: true, initiativeProceed: false },
+            noOpRecord: null,
+            availableActions: [
+              { intentType: "send_message", channelTargets: ["ch_public"], personTargets: [], blocked: false },
+            ],
+          }));
+          mockAgentRuntime.generateIntent = vi.fn().mockResolvedValue({
+            intent: {
+              ...makeNoOpIntent("agent_1"),
+              intentType: "send_message",
+              visibleContent: "keep it between us",
+              memoryWrites: [PROPOSAL],
+            },
+            llmUsage: null,
+            latencyMs: 10,
+            fallbackApplied: false,
+            operatorEvents: [],
+          });
+        },
+      },
+    ];
+
+    it.each(scenarios)("$name and persists the Memory into agent state + snapshot", async ({ arrange }) => {
+      arrange();
+      await scheduler.runPulse();
+
+      const committed = await eventRepo.getAfter("sim_test");
+      const memoryEvents = committed.filter((e) => e.type === "memory_written");
+      expect(memoryEvents).toHaveLength(1);
+      const memoryEvent = memoryEvents[0]!;
+
+      const state = await agentStateRepo.get("sim_test", "agent_1");
+      const memory = state?.memories.find((m) => m.summary === PROPOSAL.summary);
+      expect(memory).toBeDefined();
+      expect(memory).toMatchObject({
+        agentId: memoryEvent.actorId,
+        simulationId: "sim_test",
+        type: PROPOSAL.type,
+        subjectAgentIds: PROPOSAL.subjectAgentIds,
+        sourceEventIds: [memoryEvent.id],
+        emotionalTone: PROPOSAL.emotionalTone,
+        confidence: PROPOSAL.confidence,
+        intensity: PROPOSAL.intensity,
+        unresolved: PROPOSAL.unresolved,
+        createdAt: memoryEvent.createdAt,
+        lastReinforcedAt: memoryEvent.createdAt,
+      });
+
+      const snapshots = gateway.operatorEvents.filter((e) => e.type === "agent_state_snapshot");
+      expect(snapshots.length).toBeGreaterThan(0);
+      const snapshotMemories = snapshots.flatMap(
+        (s) => (s.data?.["state"] as { memories?: Memory[] } | undefined)?.memories ?? [],
+      );
+      expect(
+        snapshotMemories.some((m) => m.summary === PROPOSAL.summary && m.sourceEventIds[0] === memoryEvent.id),
+        "agent_state_snapshot must include the persisted memory",
+      ).toBe(true);
+    });
   });
 
   it("commit-ordering: a needsLLM step is resolved (not committed as no-op) through the real scheduler", async () => {

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -12,8 +12,9 @@ import type {
   EngineSnapshot,
   EngineStepResult,
   EndingOffer,
+  Memory,
 } from "@perfectman/shared";
-import { createSeededRng, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
+import { createId, createSeededRng, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
 import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
@@ -264,7 +265,9 @@ export class PulseScheduler {
       });
 
       if (engineEvents.length > 0) {
-        eventsCommitted += await this.appendAndProject(engineEvents, channels, membership);
+        const committed = await this.appendAndProject(engineEvents, channels, membership);
+        eventsCommitted += committed.length;
+        this.applyMemoryProjection(committed, stepResult.updatedAgentState);
       }
 
       if (stepResult.decision.needsLLM) {
@@ -276,7 +279,7 @@ export class PulseScheduler {
           now,
         }).catch(async (err) => {
           const failureEvent = this.llmFailureEvent(agent.id, channelAnchorId, err);
-          eventsCommitted += await this.appendAndProject([failureEvent], channels, membership);
+          eventsCommitted += (await this.appendAndProject([failureEvent], channels, membership)).length;
           return null;
         });
 
@@ -324,7 +327,9 @@ export class PulseScheduler {
         });
 
         if (resolved.committedEvents.length > 0) {
-          eventsCommitted += await this.appendAndProject(resolved.committedEvents, channels, membership);
+          const committed = await this.appendAndProject(resolved.committedEvents, channels, membership);
+          eventsCommitted += committed.length;
+          this.applyMemoryProjection(committed, stepResult.updatedAgentState);
         }
 
         for (const opEv of [...resolved.operatorEvents, ...runtimeOutput.operatorEvents]) {
@@ -404,7 +409,7 @@ export class PulseScheduler {
           pulseIndex: this.pulseIndex,
         });
         if (stagnationEvent) {
-          eventsCommitted += await this.appendAndProject([stagnationEvent], channels, membership);
+          eventsCommitted += (await this.appendAndProject([stagnationEvent], channels, membership)).length;
         }
       }
     }
@@ -425,10 +430,10 @@ export class PulseScheduler {
         });
         if (review.events.length > 0) {
           const committed = await this.appendAndProject(review.events, channels, membership);
-          eventsCommitted += committed;
+          eventsCommitted += committed.length;
           // The ending offer fires only after its events actually commit: a
           // failed append leaves the offer pending for the next review.
-          if (committed > 0 && review.endingOffer) {
+          if (committed.length > 0 && review.endingOffer) {
             await this.config.onEndOffered?.(review.endingOffer, this.pulseIndex);
           }
         } else if (review.endingOffer) {
@@ -466,13 +471,13 @@ export class PulseScheduler {
     events: SimulationEvent[],
     channels: Channel[],
     membership: ChannelMembership[],
-  ): Promise<number> {
+  ): Promise<CommittedEvent[]> {
     let committed: CommittedEvent[];
     try {
       committed = await this.config.eventRepo.append(this.config.simulation.id, events);
     } catch (err) {
       await this.emitOperatorEvent(this.schedulerError("Failed to append events", err));
-      return 0;
+      return [];
     }
 
     for (const ev of committed) {
@@ -482,7 +487,34 @@ export class PulseScheduler {
       await this.emitEventVisibility(ev);
     }
 
-    return committed.length;
+    return committed;
+  }
+
+  /**
+   * Copies committed `memory_written` events into the acting agent's state.
+   * Mutates `updatedAgentState` in place — same-pulse `persistAndSnapshot` is
+   * the single write point, and a failed append never reaches here because
+   * only returned (committed) events are passed in.
+   */
+  private applyMemoryProjection(committed: CommittedEvent[], agentState: AgentState): void {
+    for (const event of committed) {
+      if (event.type !== "memory_written") continue;
+      agentState.memories.push({
+        id: createId(),
+        agentId: event.actorId,
+        simulationId: event.simulationId,
+        type: event.payload["memoryType"] as Memory["type"],
+        subjectAgentIds: event.payload["subjectAgentIds"] as string[],
+        sourceEventIds: [event.id],
+        summary: event.payload["summary"] as string,
+        emotionalTone: event.payload["emotionalTone"] as string,
+        confidence: event.payload["confidence"] as number,
+        intensity: event.payload["intensity"] as number,
+        unresolved: event.payload["unresolved"] as boolean,
+        createdAt: event.createdAt,
+        lastReinforcedAt: event.createdAt,
+      });
+    }
   }
 
   private async emitEventVisibility(event: CommittedEvent): Promise<void> {


### PR DESCRIPTION
## What

Makes an agent form a first-person memory during a normal turn and persists it (implements #136):

- **Prompt contract**: the action-intent prompt now instructs the model, with concrete criteria, when to emit `memoryWrites` (first-person, grounded in `<events>`, only when it matters, empty array otherwise); `templateVersion` `1lzz3tz` -> `1e65v2f`
- **Persistence**: scheduler-private `applyMemoryProjection` copies committed `memory_written` events into the acting agent's `updatedAgentState.memories` before the same iteration's `persistAndSnapshot` — one write point, no repo upsert in the hook (ADR-0013 D-37)
- **Commit-gated**: `appendAndProject` returns `CommittedEvent[]`; memory applies only from events that actually committed; the 5 call sites keep their count via `.length`
- **`write_memory` removal**: leaves the always-available action list (11 -> 10); schema, resolver plumbing and the offline blocked-listing stay per the issue's leave-clause; sweep covers engine count assertions, e2e canned motive tables, 3 docs listings
- **Docs**: ADR-0013 records the formation/accretion decisions; `master-contract.md` + `dev2-runtime.md` flow lines updated to the intent path; `observability-stream.md` snapshot-volume claim made honest
- Four tests: memory-projection persistence, snapshot visibility, prompt recall, action-list absence

## Why

The live 63-pulse evidence run (`docs/eval/evidence/local-deadroom-deepseek/`) showed `memories: []` for every agent across the whole run — nothing accumulates between turns, so no pressure, no stakes, dead room.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS
- 1412 tests / 125 files on this branch; cost gate: `cost impact: low | quality risk: medium | rollout: canary` — eval bench canary owed before merge
- Stacks on #148 (merge repair, merge that first); the diff then shows only the #136 work
