### PR TITLE
fix(server): stamp LLM rate windows with wall-clock time (#147)

### DIFF
--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -27,6 +27,7 @@ import {
   AgentConfigRegistry,
   MockDeliveryGateway,
   createLLMProvider,
+  llmBudget,
   personaPackToProfile,
 } from "@perfectman/server";
 import type { PersonaPromptProfile } from "@perfectman/server";
@@ -146,6 +147,11 @@ class TrackingRuntime {
 
 export class ScenarioRunner {
   static async run(scenario: RoleplayScenario, opts: RunnerOpts = {}): Promise<ScenarioRunArtifact> {
+    // The cognition path records usage into the shared llmBudget singleton
+    // with wall-clock stamps (#147). Reset this scenario's windows up front
+    // so back-to-back runs in one process (e.g. the pinned-seed replay test)
+    // start from identical budget state and stay deterministic.
+    llmBudget.reset(scenario.id);
     const started = Date.now();
     const packs = new Map<string, import("@perfectman/shared").PersonaPack>();
     for (const p of ALL_PERSONAS) {

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -441,6 +441,12 @@ export async function buildConfiguredSimulation(
   if (!options.llmBudget) {
     llmBudget.registerLimits(simulationId, config.simulation.settings);
   }
+  // Fresh simulation, fresh rate windows (#147): the shared singleton keeps
+  // usage keyed by simulationId across builds in one process (CLI reruns,
+  // back-to-back eval runs, restart tests re-attaching the same id), so a
+  // new build must not inherit another run's wall-clock usage. Limits are
+  // kept — reset() only clears recorded calls/tokens.
+  (budget as LLMBudgetTracker).reset(simulationId);
 
   const runtime = new SimulationRuntime({
     delivery,

--- a/packages/server/src/llm/__tests__/llm-budget.test.ts
+++ b/packages/server/src/llm/__tests__/llm-budget.test.ts
@@ -211,8 +211,58 @@ describe("LLMBudgetTracker", () => {
     expect(budget.getPriority("sim-test", "goulart")).toBe("blocked");
   });
 
-  it("should get complete status", () => {
+  it("accumulates sim-clock usage in the per-minute window (#147)", () => {
+    // Production callers stamp LLMUsage.createdAt with the pulse-relative sim
+    // clock (~10^3-10^6). Those records must still count toward the wall-clock
+    // rate windows — previously cleanup() pruned them instantly because it
+    // compared sim-time stamps against Date.now().
+    for (let i = 0; i < 10; i++) {
+      budget.recordUsage({
+        simulationId: "sim-test",
+        agentId: "goulart",
+        model: "mock-model",
+        inputTokens: 10,
+        outputTokens: 20,
+        latencyMs: 100,
+        callType: "cognition",
+        pulseIndex: i,
+        createdAt: (i + 1) * 3000,
+      });
+    }
+
+    const dec = budget.canCall({
+      simulationId: "sim-test",
+      agentId: "goulart",
+      priority: "high",
+    });
+    expect(dec.allowed).toBe(false);
+    expect(dec.reason).toContain("Call budget exhausted");
+  });
+
+  it("accumulates sim-clock tokens in the per-hour window (#147)", () => {
     budget.recordUsage({
+      simulationId: "sim-test",
+      agentId: "goulart",
+      model: "mock-model",
+      inputTokens: 5000,
+      outputTokens: 5000,
+      latencyMs: 100,
+      callType: "cognition",
+      pulseIndex: 1,
+      createdAt: 3000,
+    });
+
+    const dec = budget.canCall({
+      simulationId: "sim-test",
+      agentId: "goulart",
+      priority: "high",
+      inputTokensEstimate: 50,
+    });
+    expect(dec.allowed).toBe(false);
+    expect(dec.reason).toContain("Token budget exhausted");
+  });
+
+  it("should get complete status", () => {    budget.recordUsage({
       simulationId: "sim-test",
       agentId: "goulart",
       model: "mock-model",

--- a/packages/server/src/llm/__tests__/llm-budget.test.ts
+++ b/packages/server/src/llm/__tests__/llm-budget.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { LLMBudgetTracker } from "../llm-budget.js";
 
 describe("LLMBudgetTracker", () => {
@@ -11,6 +11,21 @@ describe("LLMBudgetTracker", () => {
       tokenBudgetPerHour: 10000,
     });
   });
+
+  function makeUsage(overrides: { pulseIndex?: number; createdAt?: number; inputTokens?: number; outputTokens?: number } = {}) {
+    return {
+      simulationId: "sim-test",
+      agentId: "goulart",
+      model: "mock-model",
+      inputTokens: 10,
+      outputTokens: 20,
+      latencyMs: 100,
+      callType: "cognition" as const,
+      pulseIndex: 0,
+      createdAt: Date.now(),
+      ...overrides,
+    };
+  }
 
   it("should allow calls when budget is fresh", () => {
     const dec = budget.canCall({
@@ -217,17 +232,7 @@ describe("LLMBudgetTracker", () => {
     // rate windows — previously cleanup() pruned them instantly because it
     // compared sim-time stamps against Date.now().
     for (let i = 0; i < 10; i++) {
-      budget.recordUsage({
-        simulationId: "sim-test",
-        agentId: "goulart",
-        model: "mock-model",
-        inputTokens: 10,
-        outputTokens: 20,
-        latencyMs: 100,
-        callType: "cognition",
-        pulseIndex: i,
-        createdAt: (i + 1) * 3000,
-      });
+      budget.recordUsage(makeUsage({ pulseIndex: i, createdAt: (i + 1) * 3000 }));
     }
 
     const dec = budget.canCall({
@@ -240,17 +245,7 @@ describe("LLMBudgetTracker", () => {
   });
 
   it("accumulates sim-clock tokens in the per-hour window (#147)", () => {
-    budget.recordUsage({
-      simulationId: "sim-test",
-      agentId: "goulart",
-      model: "mock-model",
-      inputTokens: 5000,
-      outputTokens: 5000,
-      latencyMs: 100,
-      callType: "cognition",
-      pulseIndex: 1,
-      createdAt: 3000,
-    });
+    budget.recordUsage(makeUsage({ pulseIndex: 1, createdAt: 3000, inputTokens: 5000, outputTokens: 5000 }));
 
     const dec = budget.canCall({
       simulationId: "sim-test",
@@ -262,7 +257,33 @@ describe("LLMBudgetTracker", () => {
     expect(dec.reason).toContain("Token budget exhausted");
   });
 
-  it("should get complete status", () => {    budget.recordUsage({
+  it("expires records outside the wall-clock windows (#147)", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      for (let i = 0; i < 10; i++) {
+        budget.recordUsage(makeUsage({ pulseIndex: i }));
+      }
+      expect(budget.canCall({
+        simulationId: "sim-test",
+        agentId: "goulart",
+        priority: "high",
+      }).allowed).toBe(false);
+
+      // Past the 1-minute call window, the old calls no longer count.
+      vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+      expect(budget.canCall({
+        simulationId: "sim-test",
+        agentId: "goulart",
+        priority: "high",
+      }).allowed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should get complete status", () => {
+    budget.recordUsage({
       simulationId: "sim-test",
       agentId: "goulart",
       model: "mock-model",

--- a/packages/server/src/llm/llm-budget.ts
+++ b/packages/server/src/llm/llm-budget.ts
@@ -164,8 +164,15 @@ export class LLMBudgetTracker {
   }
 
   recordUsage(usage: LLMUsage): void {
-    const { simulationId, agentId, inputTokens, outputTokens, createdAt } = usage;
-    const timestamp = createdAt || Date.now();
+    const { simulationId, agentId, inputTokens, outputTokens } = usage;
+    // Rate windows are wall-clock sliding windows, so stamp them with
+    // Date.now() taken here — never with usage.createdAt, which carries the
+    // pulse-relative sim clock (~10^3-10^6). Storing sim-time stamps made
+    // cleanup()'s wall-clock filter prune every record on the next call,
+    // silently disabling both rate limits (#147). createdAt stays on the sim
+    // clock for deterministic replay attribution and never feeds anything
+    // the replay fingerprint covers.
+    const timestamp = Date.now();
 
     // Simulation level calls
     if (!this.calls.has(simulationId)) {


### PR DESCRIPTION
Closes #147.

## Bug
`LLMBudgetTracker.recordUsage` stored `usage.createdAt` as the rate-window timestamp, but production callers stamp `createdAt` with the pulse-relative sim clock (~10^3-10^6). `cleanup()` prunes against `Date.now()` (~1.7e12), so every record was dropped on the next call — both rate limits never tripped.

## Fix (issue option 2)
- `recordUsage` now stamps windows with `Date.now()` taken inside the tracker; `LLMUsage.createdAt` stays on the sim clock for deterministic replay attribution and never feeds anything the replay fingerprint covers.
- `buildConfiguredSimulation` resets the sim's windows on every build, so reruns and re-attaches sharing one process (CLI, back-to-back eval runs, restart tests) don't inherit another run's usage. Limits are kept.
- Tests: shared `makeUsage` helper, 2 regression tests (sim-clock calls and tokens trip the windows), 1 expiry test (records drop out past the window, via fake timers).

## Verification
- `llm-budget` 9/9 (new tests failed pre-fix); `sweep-temperature` unchanged and green (6/6, incl. pinned-seed replay).
- `agent-runtime` (12) + `goal-layer-llm` (10) green; `tsc` clean in server + eval; `audit-tests --check` and `docs-lint --check` PASS.
- Full server suite: 717 pass; 91 failures are pre-existing environmental (missing better-sqlite3 native binding — verified identical on clean tree).
- Adversarial review (3 axes) done; findings addressed except the open point below.

## Open discussion — rate limits now really bite
Heads-up: this is a behavior flip, not just a bugfix. Defaults are 20 calls/min per simulation, and every pulse records 1 call per agent (plus retries, plus goal calls); mock counts like real. A 4-agent sim at 3s pulses does about 80 calls/min wall-clock, so most late-window calls would now be blocked as `no_op` plus `llm_budget_exceeded` where previously nothing ever blocked. Options: (a) raise the defaults, (b) scope windows per-agent instead of per-simulation, (c) accept current blocking as the intended backpressure. Team call — not changing defaults in this PR without agreement.
