### PR TITLE
docs: restructure README and add a Perfectman visual identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,90 @@
-# Perfectman
+<h1 align="center"><img src="docs/assets/logo.svg" alt="" width="72" height="72" align="absmiddle">&nbsp;Perfectman</h1>
 
-AI personas that hang out in a socket chat server like people do: noticing unevenly, replying late, lurking, masking, forming private alliances, misreading silence — and creating real, emergent social drama nobody scripted.
+<p align="center"><strong>AI personas that reply because something got to them — not because it's their turn.</strong></p>
 
-> <!-- TODO before sharing publicly: replace this with a spectator-view transcript or short GIF of an actual emergent moment (exclusion, grudge, private alliance) captured from a real run. See docs/README.md "V1 Target Behaviors" for what to look for. -->
-> **Status:** early, pre-1.0 experiment. The core event-oriented runtime and social presence engine work end-to-end; the interesting behaviors (exclusion, masking, grudges, biased memory) are what we're actively tuning for. Expect rough edges.
+<div align="center">
+
+[![PR Gate](https://img.shields.io/github/actions/workflow/status/caiotheodoro/perfectman/pr-gate.yml?branch=main&style=flat-square&label=PR%20gate&labelColor=0D1117&color=7C6BF0)](https://github.com/caiotheodoro/perfectman/actions/workflows/pr-gate.yml)
+[![Benchmark](https://img.shields.io/github/actions/workflow/status/caiotheodoro/perfectman/benchmark.yml?branch=main&style=flat-square&label=benchmark&labelColor=0D1117&color=E8A33D)](https://github.com/caiotheodoro/perfectman/actions/workflows/benchmark.yml)
+[![Node](https://img.shields.io/badge/Node-22%2B-7C6BF0?style=flat-square&labelColor=0D1117)](https://nodejs.org)
+[![License](https://img.shields.io/badge/license-MIT-7C6BF0?style=flat-square&labelColor=0D1117)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/caiotheodoro/perfectman?style=flat-square&labelColor=0D1117&color=E8A33D)](https://github.com/caiotheodoro/perfectman/stargazers)
+
+[What this is](#what-this-is) · [Quickstart](#quickstart) · [Run it free](#running-with-a-real-model-for-free) · [Benchmarks](#benchmarks) · [Architecture](#architecture) · [Open questions](#status--open-questions)
+
+**[Install and run →](#quickstart)**
+
+</div>
+
+<p align="center">
+  <picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/hero-dark.svg"><img src="docs/assets/hero-light.svg" alt="Four connected personas with ties of uneven strength, one amber private alliance between two of them, and a fifth persona drawn as a dashed outline sitting apart with no connection at all" width="820"></picture>
+</p>
+
+Most "AI agent chat" demos are round-robin with extra steps. Each agent replies
+because the scheduler said so, everyone gets equal airtime, nobody is ever left
+out, and nothing is ever awkward. That is not what a group chat is.
+
+**Perfectman agents act because something got to them.** An event has to be
+visible, catch attention, get interpreted, produce motivation and emotion, and
+build enough pressure to overcome inhibition before anything is said at all. The
+result is a chat where someone lurks for twenty minutes, replies late in a way
+that changes what the reply means, starts a private channel out of jealousy, or
+works out they were excluded from something purely because nobody mentioned it.
+
+Nobody scripts those moments. They fall out of the model.
+
+### Highlights
+
+- 🧠 **Pressure, not turn-taking** — a ten-stage pipeline decides whether to speak at all. Silence is a first-class outcome, not a missing reply.
+- 🚪 **Exclusion is inferred** — an agent works out it wasn't invited from public silence. Nobody tells it.
+- 🤫 **Private alliances** — agents open private channels from curiosity, gossip, jealousy, secrecy, or repair.
+- 🩹 **Memory is biased on purpose** — episodic and relationship memory drift emotionally. It is not a perfect log, because people aren't.
+- 📊 **Measured, not vibes** — 123 deterministic scenarios, [benchmarked offline](#benchmarks) with no API key, gated at 100% behavioral signals in CI.
+
+> [!NOTE]
+> **Status:** early, pre-1.0 experiment. The event-oriented runtime and social
+> presence engine work end to end; the interesting behaviors (exclusion,
+> masking, grudges, biased memory) are what we're actively tuning for. Expect
+> rough edges.
+
+## Table of contents
+
+- [What this is](#what-this-is)
+- [Quickstart](#quickstart)
+- [Running with a real model, for free](#running-with-a-real-model-for-free)
+- [Bring your own personas](#bring-your-own-personas)
+- [Benchmarks](#benchmarks)
+- [Architecture](#architecture)
+- [Status / open questions](#status--open-questions)
+- [Releases](#releases)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## What this is
 
-Most "AI agent chat" demos are agents replying because it's their turn. Perfectman agents act because something caught their attention, produced motivation and emotion, and built up enough pressure to overcome inhibition:
+Every action an agent takes has to survive this pipeline:
 
 ```text
-event -> visibility -> attention -> interpretation -> motivation -> emotion -> pressure -> inhibition -> intent -> resolver -> committed event
+event → visibility → attention → interpretation → motivation
+      → emotion → pressure → inhibition → intent → resolver → committed event
 ```
 
-Concretely, that pipeline is what lets an agent:
+Any stage can stop it. That is the whole point — most of what makes a group chat
+feel human is the messages that *don't* get sent.
 
-- Notice a mention and reply, or notice a message and deliberately not reply.
-- Create or enter a private channel out of curiosity, gossip, jealousy, secrecy, or repair.
-- Infer exclusion from public silence — nobody told it, it just wasn't invited.
-- Reply late in a way that changes what the reply means.
-- Store a biased, emotionally-colored memory instead of a perfect log.
+Concretely, the pipeline is what lets an agent:
 
-A rule-based spectator layer turns the committed event log into a narrative recap of the hidden social shifts, without leaking backend metrics into the story.
+| Behavior | What it looks like |
+|---|---|
+| **Selective attention** | notice a mention and reply — or notice a message and deliberately not reply |
+| **Private alliance** | create or enter a private channel out of curiosity, gossip, jealousy, secrecy, or repair |
+| **Inferred exclusion** | work out it wasn't invited from public silence, without being told |
+| **Meaningful lateness** | reply late in a way that changes what the reply means |
+| **Biased memory** | store an emotionally-colored memory instead of a perfect log |
+
+A rule-based spectator layer turns the committed event log into a narrative
+recap of the hidden social shifts — without leaking backend metrics into the
+story.
 
 ## Quickstart
 
@@ -45,17 +108,19 @@ Run it:
 pnpm --filter @perfectman/server simulation
 ```
 
-This uses `providerType: "mock"` by default — no API key or model needed to see the runtime work.
+This uses `providerType: "mock"` by default — **no API key or model needed** to
+see the runtime work.
 
-### Running with a real model, for free
+## Running with a real model, for free
 
-You don't need a paid API key. Free local options:
+You don't need a paid API key.
 
-**Native Ollama** (recommended on macOS / Apple Silicon):
+<details>
+<summary><strong>Native Ollama</strong> — recommended on macOS / Apple Silicon</summary>
 
 Docker Desktop has no GPU passthrough on macOS, and the Docker CPU path is
 dramatically slower (~1.2–1.5 tok/s vs ~40 tok/s native with Metal). Install
-Ollama directly instead — it's free and exposes the same API:
+Ollama directly instead:
 
 ```bash
 brew install ollama        # or download from https://ollama.com
@@ -64,32 +129,38 @@ ollama serve               # API on :11434
 ```
 
 Then point `config/index.json` at `examples/simulations/qwen3-local.example.json`.
+</details>
 
-**Local Qwen3 via Docker** (Linux machines with an NVIDIA GPU):
+<details>
+<summary><strong>Local Qwen3 via Docker</strong> — Linux with an NVIDIA GPU</summary>
 
 ```bash
 pnpm qwen:dev              # pulls qwen3:1.7b, portable CPU-safe default
 # or: pnpm qwen:dev:8b for the 8B model
 ```
 
-On a machine with an NVIDIA driver, opt into GPU passthrough with the
-override file:
+On a machine with an NVIDIA driver, opt into GPU passthrough:
 
 ```bash
 docker compose -f docker/qwen3/qwen3.compose.yml \
                -f docker/qwen3/qwen3.gpu.compose.yml up -d
 ```
+</details>
 
-**FreeLLMAPI** (unified proxy for aggregating free-tier provider keys):
+<details>
+<summary><strong>FreeLLMAPI</strong> — unified proxy aggregating free-tier provider keys</summary>
 
 ```bash
 cp .env.example .env   # set FREELLMAPI_ENCRYPTION_KEY
-pnpm freellm:dev        # API on :3001, dashboard on :5173
+pnpm freellm:dev       # API on :3001, dashboard on :5173
 ```
 
-Add provider keys and create a unified key via the dashboard, then set `FREELLMAPI_KEY` in `.env`.
+Add provider keys and create a unified key via the dashboard, then set
+`FREELLMAPI_KEY` in `.env`.
+</details>
 
-**Simulation in Docker** (no local Node/pnpm toolchain needed):
+<details>
+<summary><strong>Simulation in Docker</strong> — no local Node/pnpm toolchain needed</summary>
 
 ```bash
 mkdir -p config
@@ -97,7 +168,9 @@ cp examples/simulations/mock.inline-personas.example.json config/index.json
 docker compose -f docker/app/app.compose.yml up --build
 ```
 
-It combines with the auxiliary containers — putting the app file first keeps every relative path anchored to `docker/app/`. With Ollama running as an in-project service, point your config's provider `baseURL` at `http://qwen3:11434/v1` (container DNS), not localhost:
+Putting the app file first keeps every relative path anchored to `docker/app/`.
+With Ollama running as an in-project service, point your config's provider
+`baseURL` at `http://qwen3:11434/v1` (container DNS), not localhost:
 
 ```bash
 docker compose -f docker/app/app.compose.yml \
@@ -106,35 +179,115 @@ docker compose -f docker/app/app.compose.yml \
                -f docker/qwen3/qwen3.compose.yml logs -f simulation
 ```
 
-Published images are built for each tagged release and pushed to GHCR (`ghcr.io/caiotheodoro/perfectman:<tag>`) — see [Releases](#releases) below.
-
-This builds a multi-stage image of the runtime itself and runs the same CLI as `pnpm --filter @perfectman/server simulation`. With the mock example it needs no API keys or model — personas converse on stdout. To use a real provider, point your mounted `config/index.json` at it and hand keys to the container with an extra read-only mount of the same `.env` the CLI reads natively:
+To use a real provider, hand keys to the container with a read-only mount of the
+same `.env` the CLI reads natively:
 
 ```bash
 docker compose -f docker/app/app.compose.yml run --rm \
   -v "$PWD/.env:/app/.env:ro" simulation
 ```
+</details>
 
-### Bring your own personas
+## Bring your own personas
 
-See [`docs/personas/README.md`](docs/personas/README.md) for the plug-and-play persona interview/compile workflow. Real, person-specific persona files live under `config/` and `docs/personas/`, both gitignored — nothing personal gets committed.
+See [`docs/personas/README.md`](docs/personas/README.md) for the plug-and-play
+persona interview/compile workflow. Real, person-specific persona files live
+under `config/` and `docs/personas/` — both gitignored, so nothing personal gets
+committed.
+
+## Benchmarks
+
+The behavioral claims above are measured, not asserted. The full suite runs
+**fully offline** — mock provider, rule judge, no API key, no model server:
+
+```bash
+pnpm --filter @perfectman/eval bench --mode mock --judge rule --out out/bench.json
+node scripts/ci/check-bench-gate.mjs out/bench.json
+```
+
+**Scenario coverage** — 123 scenario runs across five behavioral categories,
+every one of them deterministic:
+
+| Category | Runs | Signal pass rate |
+|---|---:|---:|
+| `motive_archetype` | 51 | 100% |
+| `v1_behavior` | 27 | 100% |
+| `stagnation_attractor` | 18 | 100% |
+| `calibration` | 15 | 100% |
+| `edge_chaos` | 12 | 100% |
+| **Total** | **123** | **100%** |
+
+**Behavioral signals** — 276 assertions that the social engine actually did the
+thing, not that it produced plausible text:
+
+| Signal | Passed | Rate |
+|---|---:|---:|
+| `no_llm_failures` | 123 / 123 | 100% |
+| `event_committed` | 75 / 75 | 100% |
+| `private_channel_created` | 48 / 48 | 100% |
+| `emotion_rises` | 15 / 15 | 100% |
+| `emotion_stays` | 15 / 15 | 100% |
+
+Zero scenario runs failed. **Runtime probes** average **91.0%** — the weakest are
+`content-repetition` (21.1%) and `memory-write` (70.7%), both tracked as trend
+signals rather than gates.
+
+### What is and isn't gated
+
+| Layer | Result | Gated in CI? |
+|---|---|---|
+| **Behavioral signals** | 100% | ✅ yes — the merge bar |
+| **Runtime probes** | 91.0% | ⚠️ tracked, not gated |
+| **Judge axis scores** | 6 of 8 targets met | ❌ advisory only |
+
+> [!IMPORTANT]
+> Judge axis scores are **deliberately not gated**, because the rule judge has
+> not passed its calibration bar: Cohen's κ against the golden-labeled set is
+> **0.219 against a 0.7 target** (n=39). Until that lands, axis numbers are a
+> trend signal, not evidence. `in_character` (2.99 / 4.0) and `voice_match`
+> (1.16 / 3.8) are the two axes currently below target, and voice_match is
+> where the judge disagrees with the golden labels most.
+
+This is the honest read: **the deterministic parts of the social engine hold at
+100%, and the qualitative scoring of them is not yet trustworthy.** Improving
+judge calibration is [open work](#status--open-questions).
+
+Separately, the unit and hygiene suite covers **1,426 tests across 126 files** and
+passes clean on Node 22:
+
+```bash
+pnpm lint       # typecheck, all four packages
+pnpm test:all   # unit tests + hygiene gates
+```
 
 ## Architecture
 
-The full design lives in [`docs/README.md`](docs/README.md) — start there for the canonical architecture, the emotion model, social presence engine, and open design questions. Short version:
+The full design lives in [`docs/README.md`](docs/README.md) — start there for the
+canonical architecture, the emotion model, the social presence engine, and open
+design questions. Short version:
 
-- **Event-oriented runtime** (`packages/server`): canonical append-only event log, command handlers, intent resolver, per-audience projections (delivery, spectator, operator, engine snapshot), pluggable transports (Socket.IO, Discord, stdout, mock).
-- **Social presence engine** (`packages/engine`): pure, I/O-free attention/motivation/emotion/pressure/inhibition model — the behavioral core.
-- **Agent mind** (`packages/server/src/agent`): persona identity, writing style, relationship beliefs, and the LLM-backed runtime that turns perception into an action intent.
-- **Continuity system**: episodic + relationship memory, emotional drift, rumination — memory is biased and emotional on purpose, not a perfect log.
+| Layer | Responsibility |
+|---|---|
+| **Event-oriented runtime** (`packages/server`) | append-only event log, command handlers, intent resolver, per-audience projections (delivery, spectator, operator, engine snapshot), pluggable transports (Socket.IO, Discord, stdout, mock) |
+| **Social presence engine** (`packages/engine`) | pure, I/O-free attention/motivation/emotion/pressure/inhibition model — the behavioral core |
+| **Agent mind** (`packages/server/src/agent`) | persona identity, writing style, relationship beliefs, and the LLM-backed runtime turning perception into intent |
+| **Evaluation harness** (`packages/eval`) | scenario registry, rule and LLM judges, probes, calibration, narration |
+| **Continuity system** | episodic + relationship memory, emotional drift, rumination — biased and emotional on purpose |
 
 ## Status / open questions
 
-This is an active experiment, not a finished product. See [`docs/README.md`](docs/README.md#current-open-questions) for what's genuinely undecided — private-channel spectator visibility, how much scoring machinery should exist, which symbolic actions are worth keeping. If one of those interests you, that's a good place to start.
+This is an active experiment, not a finished product. See
+[`docs/README.md`](docs/README.md#current-open-questions) for what's genuinely
+undecided — private-channel spectator visibility, how much scoring machinery
+should exist, which symbolic actions are worth keeping, and closing the judge
+calibration gap above. If one of those interests you, that's a good place to
+start.
 
 ## Releases
 
-Every tagged release (`v*`) publishes a container image of the runtime to GitHub Container Registry via `docker-release.yml`: `ghcr.io/caiotheodoro/perfectman` gets the exact tag (`v0.1.0` → image tag `0.1.0`, plus `latest` for non-prerelease). Consumers without a Node toolchain can run the simulation directly:
+Every tagged release (`v*`) publishes a runtime container image to GHCR via
+`docker-release.yml`: `ghcr.io/caiotheodoro/perfectman` gets the exact tag
+(`v0.1.0` → image tag `0.1.0`, plus `latest` for non-prerelease).
 
 ```bash
 docker pull ghcr.io/caiotheodoro/perfectman:latest
@@ -144,7 +297,18 @@ Use a tagged image instead of `latest` anywhere reproducibility matters.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Issues tagged `good first issue` are scoped entry points that don't require reading the full architecture doc first.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Issues tagged `good first issue` are
+scoped entry points that don't require reading the full architecture doc first.
+
+## Star history
+
+<a href="https://star-history.com/#caiotheodoro/perfectman&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=caiotheodoro/perfectman&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=caiotheodoro/perfectman&type=Date" />
+    <img alt="Star history chart for caiotheodoro/perfectman" src="https://api.star-history.com/svg?repos=caiotheodoro/perfectman&type=Date" width="600" />
+  </picture>
+</a>
 
 ## License
 

--- a/docs/assets/hero-dark.svg
+++ b/docs/assets/hero-dark.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" width="880" height="420" role="img" aria-label="Four connected personas with ties of uneven strength, one amber private alliance between two of them, and a fifth persona drawn as a dashed outline sitting apart with no connection at all">
+  <rect width="880" height="420" fill="#0D1117"/>
+  <g fill="none" stroke-linecap="round">
+    <!-- ties of uneven weight: attention is not evenly distributed -->
+    <path d="M235 145 L425 110" stroke="#7C6BF0" stroke-width="17"/>
+    <path d="M235 145 L400 300" stroke="#7C6BF0" stroke-width="12"/>
+    <path d="M425 110 L615 180" stroke="#7C6BF0" stroke-width="9"/>
+    <path d="M425 110 L400 300" stroke="#7C6BF0" stroke-width="5" opacity="0.55"/>
+    <!-- private alliance nobody else can see -->
+    <path d="M615 180 L400 300" stroke="#E8A33D" stroke-width="14"/>
+    <!-- the tie that never formed: inferred exclusion from silence -->
+    <path d="M745 322 L648 246" stroke="#4E5566" stroke-width="7" stroke-dasharray="2 20"/>
+  </g>
+  <g fill="#7C6BF0">
+    <circle cx="235" cy="145" r="36"/>
+    <circle cx="425" cy="110" r="36"/>
+    <circle cx="615" cy="180" r="36"/>
+    <circle cx="400" cy="300" r="36"/>
+  </g>
+  <!-- excluded: present, unconnected, still watching -->
+  <circle cx="790" cy="345" r="32" fill="none" stroke="#4E5566" stroke-width="7" stroke-dasharray="16 13"/>
+</svg>

--- a/docs/assets/hero-light.svg
+++ b/docs/assets/hero-light.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" width="880" height="420" role="img" aria-label="Four connected personas with ties of uneven strength, one amber private alliance between two of them, and a fifth persona drawn as a dashed outline sitting apart with no connection at all">
+  <rect width="880" height="420" fill="#FFFFFF"/>
+  <g fill="none" stroke-linecap="round">
+    <!-- ties of uneven weight: attention is not evenly distributed -->
+    <path d="M235 145 L425 110" stroke="#7C6BF0" stroke-width="17"/>
+    <path d="M235 145 L400 300" stroke="#7C6BF0" stroke-width="12"/>
+    <path d="M425 110 L615 180" stroke="#7C6BF0" stroke-width="9"/>
+    <path d="M425 110 L400 300" stroke="#7C6BF0" stroke-width="5" opacity="0.55"/>
+    <!-- private alliance nobody else can see -->
+    <path d="M615 180 L400 300" stroke="#E8A33D" stroke-width="14"/>
+    <!-- the tie that never formed: inferred exclusion from silence -->
+    <path d="M745 322 L648 246" stroke="#B4BAC6" stroke-width="7" stroke-dasharray="2 20"/>
+  </g>
+  <g fill="#7C6BF0">
+    <circle cx="235" cy="145" r="36"/>
+    <circle cx="425" cy="110" r="36"/>
+    <circle cx="615" cy="180" r="36"/>
+    <circle cx="400" cy="300" r="36"/>
+  </g>
+  <!-- excluded: present, unconnected, still watching -->
+  <circle cx="790" cy="345" r="32" fill="none" stroke="#B4BAC6" stroke-width="7" stroke-dasharray="16 13"/>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" role="img" aria-label="Perfectman logo: two personas joined by a private tie, with a third drawn as a dashed outline, present but not included">
+  <path d="M26 31 L70 31" fill="none" stroke="#E8A33D" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="26" cy="31" r="15" fill="#7C6BF0"/>
+  <circle cx="70" cy="31" r="15" fill="#7C6BF0"/>
+  <circle cx="48" cy="65" r="13" fill="none" stroke="#6B7288" stroke-width="6" stroke-dasharray="6 4.2"/>
+</svg>


### PR DESCRIPTION
## What

Restructures the README around the pattern used by high-traffic CLI project
READMEs (lazygit, bat, fzf), and gives Perfectman its first visual identity.

## Above the fold

Centered hero — logo, tagline, badges, section nav, one **Install and run →**
CTA, then the hero image.

New tagline: **"AI personas that reply because something got to them — not
because it's their turn."** The real differentiator here is that agents act from
accumulated social pressure rather than round-robin scheduling, so the opening
leads with that rather than with the pipeline diagram. The `TODO before sharing
publicly` HTML comment is replaced with a real status callout.

## Structure

- Highlights + table of contents.
- Behavior list and architecture layers converted to tables.
- The four "run it with a real model, for free" paths folded into `<details>`
  blocks — that was four screens of setup sitting between a reader and the
  architecture. Content unchanged, just collapsed.

## New assets

| File | Size | Content |
|---|---:|---|
| `docs/assets/logo.svg` | ~600 B | two personas joined by a private tie, a third as a dashed outline — present, not included |
| `docs/assets/hero-dark.svg` | ~1.2 KB | four personas with ties of uneven weight, one amber private alliance, one sitting apart with no connection |
| `docs/assets/hero-light.svg` | ~1.2 KB | light variant |

Theme-aware via `<picture>`, hand-authored, ~3 KB total. They're drawn to state
the thesis — uneven attention, private alliances, inferred exclusion — rather
than decorate.

## New Benchmarks section

Reports a real local run of the offline harness on this branch:

```
pnpm --filter @perfectman/eval bench --mode mock --judge rule
```

**123 scenario runs, 0 failed, 100% signal pass rate** across 276 behavioral
assertions; probe average 91.0%. Unit suite separately verified at **1,426 tests
across 126 files, all passing** on Node 22, with `pnpm lint` clean.

It also states plainly what is **not** gated: judge axis scores are advisory
because the rule judge hasn't passed calibration — **κ 0.219 against a 0.7
target** (n=39), with `in_character` (2.99/4.0) and `voice_match` (1.16/3.8)
below target. Publishing the 100% without that context would have been the
misleading half of the truth, and `check-bench-gate.mjs` already documents the
distinction — the README now matches it.

## Note for anyone reproducing locally

Use **Node 22**, as CI does. On Node 25 the suite reports ~68 spurious failures
(`Cannot read private member #state from an object whose class did not declare
it`) that are entirely a runtime artifact — main is green on 22.

## Scope

Docs and assets only — no source or test files touched.
