### PR TITLE
feat(engine): power-law memory decay, eviction, reinforcement (#137)

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -19,6 +19,13 @@ export { scoreAttention } from "./attention/score-attention.js";
 // Perception
 export { buildPerceptionPacket } from "./perception/build-perception-packet.js";
 
+// Memory decay / eviction (used by dev2's memory projection for eviction)
+export {
+  effectiveConfidence,
+  shouldEvictMemory,
+  MAX_MEMORIES,
+} from "./perception/memory-salience.js";
+
 // Available Actions
 export { computeAvailableActions } from "./action/compute-available-actions.js";
 

--- a/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
+++ b/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
@@ -36,6 +36,8 @@ describe("buildPerceptionPacket eventHandles", () => {
       attention,
       translated,
       [],
+      0,
+      1000,
     );
 
     expect(packet.eventHandles).toEqual({
@@ -51,13 +53,13 @@ describe("buildPerceptionPacket eventHandles", () => {
     const ctx1 = makeEvent("message_sent", { id: "evt_a", actorId: "agent-x" });
     const ctx2 = makeEvent("message_sent", { id: "evt_b", actorId: "agent-y" });
 
-    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [ctx1, ctx2], null, [], attention, translated, []);
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [ctx1, ctx2], null, [], attention, translated, [], 0, 1000);
 
     expect(packet.eventHandles).toEqual({ e1: "evt_a", e2: "evt_b" });
   });
 
   it("returns an empty handle map when nothing is in view", () => {
-    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [], null, [], attention, translated, []);
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), [], null, [], attention, translated, [], 0, 1000);
     expect(packet.eventHandles).toEqual({});
   });
 });
@@ -78,6 +80,8 @@ describe("buildPerceptionPacket ownRecentUtterances", () => {
       attention,
       translated,
       [],
+      0,
+      1000,
       [old, recent],
     );
     expect(packet.ownRecentUtterances).toEqual(["gente, oficial: a proposta chegou", "bora fechar hoje"]);
@@ -86,7 +90,7 @@ describe("buildPerceptionPacket ownRecentUtterances", () => {
   it("caps at OWN_UTTERANCE_WINDOW newest-last, dedupes by event id and collapses consecutive duplicates", () => {
     const history = Array.from({ length: 15 }, (_, i) => own(`evt_${i}`, i === 7 ? "same" : `line ${i}`, i));
     history.splice(8, 0, own("evt_dup", "same", 7));
-    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), history.slice(-3), null, [], attention, translated, [], history);
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), history.slice(-3), null, [], attention, translated, [], 0, 1000, history);
     expect(packet.ownRecentUtterances).toHaveLength(12);
     expect(packet.ownRecentUtterances[packet.ownRecentUtterances.length - 1]).toBe("line 14");
     expect(packet.ownRecentUtterances.filter(u => u === "same")).toHaveLength(1);

--- a/packages/engine/src/perception/__tests__/memory-decay.test.ts
+++ b/packages/engine/src/perception/__tests__/memory-decay.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  effectiveConfidence,
+  shouldEvictMemory,
+  MEMORY_DECAY_RATES,
+} from "../memory-salience.js";
+import type { Memory } from "@perfectman/shared";
+
+const PULSE_INTERVAL_MS = 1000;
+
+function memory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "m",
+    agentId: "goulart",
+    simulationId: "sim",
+    type: "episodic",
+    subjectAgentIds: [],
+    sourceEventIds: [],
+    summary: "something happened",
+    emotionalTone: "neutral",
+    confidence: 0.5,
+    intensity: 0,
+    unresolved: false,
+    createdAt: 100,
+    lastReinforcedAt: 100,
+    ...overrides,
+  };
+}
+
+describe("effectiveConfidence", () => {
+  it("equals raw confidence at zero age (just reinforced)", () => {
+    const m = memory({ confidence: 0.8, lastReinforcedAt: 500 });
+    expect(effectiveConfidence(m, 500, PULSE_INTERVAL_MS)).toBeCloseTo(0.8);
+  });
+
+  it("decreases across pulses with no interaction (AC1)", () => {
+    const m = memory({ confidence: 0.8, intensity: 0, type: "episodic", lastReinforcedAt: 0 });
+    const at0 = effectiveConfidence(m, 0, PULSE_INTERVAL_MS);
+    const at10 = effectiveConfidence(m, 10 * PULSE_INTERVAL_MS, PULSE_INTERVAL_MS);
+    const at20 = effectiveConfidence(m, 20 * PULSE_INTERVAL_MS, PULSE_INTERVAL_MS);
+    expect(at10).toBeLessThan(at0);
+    expect(at20).toBeLessThan(at10);
+  });
+
+  it("approaches but never drops below the confidence-scaled floor as age grows without bound", () => {
+    // Power-law decay falls off slowly: even at 1e6 pulses of age the
+    // episodic (fastest-decaying) rate is nowhere near the floor, so the
+    // approach must be checked at an astronomically large age instead.
+    const m = memory({ confidence: 0.8, intensity: 0, type: "episodic", lastReinforcedAt: 0 });
+    const floor = 0.8 * 0.1;
+    const near = effectiveConfidence(m, 1e6 * PULSE_INTERVAL_MS, PULSE_INTERVAL_MS);
+    const far = effectiveConfidence(m, 1e15 * PULSE_INTERVAL_MS, PULSE_INTERVAL_MS);
+    expect(far).toBeLessThan(near);
+    expect(far).toBeGreaterThanOrEqual(floor);
+    expect(far).toBeCloseTo(floor, 2);
+  });
+
+  it("a high-intensity memory decays slower than a low-intensity one of the same type and age (AC2)", () => {
+    const now = 20 * PULSE_INTERVAL_MS;
+    const highIntensity = memory({ confidence: 0.8, intensity: 0.9, type: "episodic", lastReinforcedAt: 0 });
+    const lowIntensity = memory({ confidence: 0.8, intensity: 0.1, type: "episodic", lastReinforcedAt: 0 });
+    expect(effectiveConfidence(highIntensity, now, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      effectiveConfidence(lowIntensity, now, PULSE_INTERVAL_MS),
+    );
+  });
+
+  it("orders per-type decay rates from slowest (pending_intention) to fastest (episodic)", () => {
+    expect(MEMORY_DECAY_RATES.pending_intention).toBeLessThan(MEMORY_DECAY_RATES.self);
+    expect(MEMORY_DECAY_RATES.self).toBeLessThan(MEMORY_DECAY_RATES.social_theory);
+    expect(MEMORY_DECAY_RATES.social_theory).toBeLessThan(MEMORY_DECAY_RATES.relationship);
+    expect(MEMORY_DECAY_RATES.relationship).toBeLessThan(MEMORY_DECAY_RATES.emotional_residue);
+    expect(MEMORY_DECAY_RATES.emotional_residue).toBeLessThan(MEMORY_DECAY_RATES.episodic);
+  });
+
+  it("reinforcing a memory (bumping lastReinforcedAt toward now) raises its subsequent effective confidence relative to leaving it unreinforced (AC4)", () => {
+    const base = memory({ confidence: 0.8, intensity: 0, type: "episodic", lastReinforcedAt: 0 });
+    const reinforcedAt = 5 * PULSE_INTERVAL_MS;
+    const reinforced: Memory = { ...base, lastReinforcedAt: reinforcedAt };
+    const laterNow = 20 * PULSE_INTERVAL_MS;
+
+    expect(effectiveConfidence(reinforced, laterNow, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      effectiveConfidence(base, laterNow, PULSE_INTERVAL_MS),
+    );
+  });
+});
+
+describe("shouldEvictMemory", () => {
+  const now = 21 * PULSE_INTERVAL_MS;
+
+  it("evicts a low-confidence, aged (>20 pulses), non-unresolved memory (AC3)", () => {
+    const stale = memory({
+      confidence: 0.03,
+      intensity: 0,
+      type: "episodic",
+      unresolved: false,
+      lastReinforcedAt: 0,
+    });
+    expect(shouldEvictMemory(stale, now, PULSE_INTERVAL_MS)).toBe(true);
+  });
+
+  it("keeps an unresolved memory of the same age/confidence (Zeigarnik exemption, AC3)", () => {
+    const stale = memory({
+      confidence: 0.03,
+      intensity: 0,
+      type: "episodic",
+      unresolved: true,
+      lastReinforcedAt: 0,
+    });
+    expect(shouldEvictMemory(stale, now, PULSE_INTERVAL_MS)).toBe(false);
+  });
+
+  it("keeps a pending_intention memory of the same age/confidence (exempt by type)", () => {
+    const stale = memory({
+      confidence: 0.1,
+      intensity: 0,
+      type: "pending_intention",
+      unresolved: false,
+      lastReinforcedAt: 0,
+    });
+    expect(shouldEvictMemory(stale, now, PULSE_INTERVAL_MS)).toBe(false);
+  });
+
+  it("keeps a memory that has not aged past the threshold even if already low-confidence", () => {
+    const recent = memory({
+      confidence: 0.02,
+      intensity: 0,
+      type: "episodic",
+      unresolved: false,
+      lastReinforcedAt: now, // age 0
+    });
+    expect(shouldEvictMemory(recent, now, PULSE_INTERVAL_MS)).toBe(false);
+  });
+
+  it("keeps an aged memory whose effective confidence is still above the eviction threshold", () => {
+    const stillStrong = memory({
+      confidence: 1,
+      intensity: 0,
+      type: "relationship", // slow decay, but not exempt-by-type
+      unresolved: false,
+      lastReinforcedAt: 0,
+    });
+    expect(shouldEvictMemory(stillStrong, now, PULSE_INTERVAL_MS)).toBe(false);
+  });
+});

--- a/packages/engine/src/perception/__tests__/memory-salience.test.ts
+++ b/packages/engine/src/perception/__tests__/memory-salience.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { scoreMemorySalience, selectRelevantMemories } from "../memory-salience.js";
 import type { Memory } from "@perfectman/shared";
 
+const PULSE_INTERVAL_MS = 1000;
+
 function memory(overrides: Partial<Memory> = {}): Memory {
   return {
     id: "m",
@@ -31,8 +33,8 @@ describe("scoreMemorySalience", () => {
     const involved = new Set(["bruno"]);
     const oldRelevant = memory({ createdAt: 10, subjectAgentIds: ["bruno"] });
     const newIrrelevant = memory({ createdAt: 200 });
-    expect(scoreMemorySalience(oldRelevant, involved, NOBODY, 200, 10)).toBeGreaterThan(
-      scoreMemorySalience(newIrrelevant, involved, NOBODY, 200, 10),
+    expect(scoreMemorySalience(oldRelevant, involved, NOBODY, 200, 10, 200, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      scoreMemorySalience(newIrrelevant, involved, NOBODY, 200, 10, 200, PULSE_INTERVAL_MS),
     );
   });
 
@@ -44,15 +46,17 @@ describe("scoreMemorySalience", () => {
       confidence: 0,
       unresolved: false,
       createdAt: 0,
+      lastReinforcedAt: 0,
     });
     const bestIrrelevant = memory({
       type: "pending_intention",
       confidence: 1,
       unresolved: true,
       createdAt: 100,
+      lastReinforcedAt: 100,
     });
-    expect(scoreMemorySalience(worstRelevant, involved, NOBODY, 100, 0)).toBeGreaterThan(
-      scoreMemorySalience(bestIrrelevant, involved, NOBODY, 100, 0),
+    expect(scoreMemorySalience(worstRelevant, involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      scoreMemorySalience(bestIrrelevant, involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS),
     );
   });
 
@@ -64,15 +68,15 @@ describe("scoreMemorySalience", () => {
   it("treats a memory about the agent themselves as relevant, even with no one else involved", () => {
     const selfSubject = memory({ subjectAgentIds: ["bruno"] });
     const noSubject = memory({ subjectAgentIds: [] });
-    expect(scoreMemorySalience(selfSubject, new Set(), "bruno", 100, 0)).toBeGreaterThan(
-      scoreMemorySalience(noSubject, new Set(), "bruno", 100, 0),
+    expect(scoreMemorySalience(selfSubject, new Set(), "bruno", 100, 0, 100, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      scoreMemorySalience(noSubject, new Set(), "bruno", 100, 0, 100, PULSE_INTERVAL_MS),
     );
   });
 
   it("does not grant the relevance bonus to a memory about someone else who isn't involved", () => {
     const otherSubject = memory({ subjectAgentIds: ["theo"] });
-    expect(scoreMemorySalience(otherSubject, new Set(), "bruno", 100, 0)).toBe(
-      scoreMemorySalience(memory({ subjectAgentIds: [] }), new Set(), "bruno", 100, 0),
+    expect(scoreMemorySalience(otherSubject, new Set(), "bruno", 100, 0, 100, PULSE_INTERVAL_MS)).toBe(
+      scoreMemorySalience(memory({ subjectAgentIds: [] }), new Set(), "bruno", 100, 0, 100, PULSE_INTERVAL_MS),
     );
   });
 
@@ -80,62 +84,64 @@ describe("scoreMemorySalience", () => {
     const involved = new Set<string>();
     const open = memory({ unresolved: true, createdAt: 50 });
     const settled = memory({ unresolved: false, createdAt: 50 });
-    expect(scoreMemorySalience(open, involved, NOBODY, 100, 0)).toBeGreaterThan(
-      scoreMemorySalience(settled, involved, NOBODY, 100, 0),
+    expect(scoreMemorySalience(open, involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS)).toBeGreaterThan(
+      scoreMemorySalience(settled, involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS),
     );
   });
 
   it("orders type tiers: pending_intention > relationship > episodic", () => {
     const involved = new Set<string>();
-    const pending = scoreMemorySalience(memory({ type: "pending_intention" }), involved, NOBODY, 100, 0);
-    const relationship = scoreMemorySalience(memory({ type: "relationship" }), involved, NOBODY, 100, 0);
-    const episodic = scoreMemorySalience(memory({ type: "episodic" }), involved, NOBODY, 100, 0);
+    const pending = scoreMemorySalience(memory({ type: "pending_intention" }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const relationship = scoreMemorySalience(memory({ type: "relationship" }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const episodic = scoreMemorySalience(memory({ type: "episodic" }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
     expect(pending).toBeGreaterThan(relationship);
     expect(relationship).toBeGreaterThan(episodic);
   });
 
   it("rewards authored confidence", () => {
     const involved = new Set<string>();
-    const high = scoreMemorySalience(memory({ confidence: 0.9 }), involved, NOBODY, 100, 0);
-    const low = scoreMemorySalience(memory({ confidence: 0.1 }), involved, NOBODY, 100, 0);
+    const high = scoreMemorySalience(memory({ confidence: 0.9 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const low = scoreMemorySalience(memory({ confidence: 0.1 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
     expect(high).toBeGreaterThan(low);
   });
 
   it("keeps recency as a bounded term, not a dominating one", () => {
     const involved = new Set<string>();
-    // Newest possible vs oldest possible differs by RECENCY_WEIGHT only.
-    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0);
-    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0);
-    expect(newest - oldest).toBeCloseTo(0.5);
+    // Newest possible vs oldest possible differs by RECENCY_WEIGHT only —
+    // both share the default lastReinforcedAt (100) so decay is identical
+    // (zero, at now=100) and cancels out of the comparison.
+    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    expect(newest - oldest).toBeCloseTo(0.2);
   });
 
   it("decays recency linearly across the store span, not binary newest-or-nothing", () => {
     const involved = new Set<string>();
-    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0);
-    const middle = scoreMemorySalience(memory({ createdAt: 50 }), involved, NOBODY, 100, 0);
-    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0);
+    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const middle = scoreMemorySalience(memory({ createdAt: 50 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
+    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0, 100, PULSE_INTERVAL_MS);
     expect(middle).toBeLessThan(newest);
     expect(middle).toBeGreaterThan(oldest);
-    expect(newest - middle).toBeCloseTo(0.25);
-    expect(middle - oldest).toBeCloseTo(0.25);
+    expect(newest - middle).toBeCloseTo(0.1);
+    expect(middle - oldest).toBeCloseTo(0.1);
   });
 
-  it("is finite for unknown memory types via the fallback weight", () => {
+  it("is finite for unknown memory types via the fallback weight and fallback decay rate", () => {
     const rogue = memory({ type: "alien" as Memory["type"] });
-    expect(Number.isFinite(scoreMemorySalience(rogue, new Set(), NOBODY, 100, 0))).toBe(true);
+    expect(Number.isFinite(scoreMemorySalience(rogue, new Set(), NOBODY, 100, 0, 100, PULSE_INTERVAL_MS))).toBe(true);
   });
 });
 
 describe("selectRelevantMemories", () => {
   it("returns an empty list for an empty store", () => {
-    expect(selectRelevantMemories([], new Set(), NOBODY, 8)).toEqual([]);
+    expect(selectRelevantMemories([], new Set(), NOBODY, 8, 100, PULSE_INTERVAL_MS)).toEqual([]);
   });
 
   it("caps selection at maxMemories", () => {
     const store = Array.from({ length: 20 }, (_, i) =>
       memory({ id: `m${i}`, createdAt: i + 1 }),
     );
-    expect(selectRelevantMemories(store, new Set(), NOBODY, 8)).toHaveLength(8);
+    expect(selectRelevantMemories(store, new Set(), NOBODY, 8, 100, PULSE_INTERVAL_MS)).toHaveLength(8);
   });
 
   it("ranks a salient old memory ahead of fresh noise", () => {
@@ -152,7 +158,7 @@ describe("selectRelevantMemories", () => {
       }),
       memory({ id: "noise-3", createdAt: 103 }),
     ];
-    const selected = selectRelevantMemories(store, new Set(["bruno"]), NOBODY, 2);
+    const selected = selectRelevantMemories(store, new Set(["bruno"]), NOBODY, 2, 103, PULSE_INTERVAL_MS);
     expect(selected[0]!.id).toBe("open-intent");
   });
 
@@ -167,21 +173,23 @@ describe("selectRelevantMemories", () => {
         confidence: 0.9,
         unresolved: true,
         createdAt: 40,
+        lastReinforcedAt: 40,
       }),
       memory({ id: "noise-3", createdAt: 103 }),
     ];
-    const selected = selectRelevantMemories(store, new Set(), "bruno", 2);
+    const selected = selectRelevantMemories(store, new Set(), "bruno", 2, 103, PULSE_INTERVAL_MS);
     expect(selected[0]!.id).toBe("my-secret");
   });
 
   it("breaks exact ties by recency deterministically", () => {
-    // The extra confidence cancels the newer memory's recency advantage exactly,
-    // so the scores tie and createdAt is the only term left to order them.
-    const older = memory({ id: "older", createdAt: 10, confidence: 1.0 });
+    // At zero decay (now == the shared default lastReinforcedAt), a 0.2
+    // confidence gap exactly cancels the full-span recency gap now that
+    // RECENCY_WEIGHT is 0.2 (decay carries most of the former recency term).
+    const older = memory({ id: "older", createdAt: 10, confidence: 0.7 });
     const newer = memory({ id: "newer", createdAt: 20, confidence: 0.5 });
-    expect(scoreMemorySalience(older, new Set(), NOBODY, 20, 10)).toBe(
-      scoreMemorySalience(newer, new Set(), NOBODY, 20, 10),
+    expect(scoreMemorySalience(older, new Set(), NOBODY, 20, 10, 100, PULSE_INTERVAL_MS)).toBe(
+      scoreMemorySalience(newer, new Set(), NOBODY, 20, 10, 100, PULSE_INTERVAL_MS),
     );
-    expect(selectRelevantMemories([older, newer], new Set(), NOBODY, 1)[0]!.id).toBe("newer");
+    expect(selectRelevantMemories([older, newer], new Set(), NOBODY, 1, 100, PULSE_INTERVAL_MS)[0]!.id).toBe("newer");
   });
 });

--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -39,6 +39,8 @@ export function buildPerceptionPacket(
   attentionResult: AttentionResult,
   translatedEmotionalState: TranslatedEmotionalState,
   availableActions: AvailableAction[],
+  now: number,
+  pulseIntervalMs: number,
   ownHistoryWindow: readonly CommittedEvent[] = [],
 ): PerceptionPacket {
   // Filter out spectator/operator-only event types
@@ -119,6 +121,8 @@ export function buildPerceptionPacket(
     involvedPeople,
     agent.agentId,
     MAX_MEMORIES,
+    now,
+    pulseIntervalMs,
   );
 
   return {

--- a/packages/engine/src/perception/memory-salience.ts
+++ b/packages/engine/src/perception/memory-salience.ts
@@ -6,7 +6,7 @@ import type { Memory } from "@perfectman/shared";
  * Replaces the flat (relevanceFlag, recency) sort: recency as a sort key
  * evicts genuinely important older memories once the store grows (long-
  * running scenes), so it becomes a bounded term among the signals the
- * Memory type already carries — subject relevance, memory type, authored
+ * Memory type already carries — subject relevance, memory type, decayed
  * confidence, and open loops. Pure: no I/O, deterministic, stable ties.
  */
 
@@ -21,7 +21,66 @@ export const MEMORY_TYPE_WEIGHTS: Record<Memory["type"], number> = {
 
 const RELEVANCE_WEIGHT = 2.5; // > max opposing delta (0.7 + 1.0 + 0.25 + 0.5) so relevance strictly dominates
 const UNRESOLVED_WEIGHT = 0.25;
-const RECENCY_WEIGHT = 0.5;
+const RECENCY_WEIGHT = 0.2; // reduced from 0.5 — decay now carries most of the recency signal
+
+/**
+ * Power-law decay: per-memory-type base rate `d`, provisional pending #129
+ * tuning. Ordering (trait-like types decay slowest) matches the existing
+ * `MEMORY_TYPE_WEIGHTS` tiering; absolute values are calibration targets from
+ * the human-memory research spec (issue #131).
+ */
+export const MEMORY_DECAY_RATES: Record<Memory["type"], number> = {
+  pending_intention: 0.04,
+  self: 0.05,
+  social_theory: 0.06,
+  relationship: 0.08,
+  emotional_residue: 0.12,
+  episodic: 0.18,
+};
+
+// d_eff = d · (1 − EMOTIONAL_PROTECTION_FACTOR · intensity) — protects strength,
+// not accuracy. Provisional pending #129 tuning.
+const EMOTIONAL_PROTECTION_FACTOR = 0.6;
+
+// retention(agePulses, d) = DECAY_FLOOR + DECAY_SCALE · (1 + agePulses)^(−d).
+// Steep-then-flat Ebbinghaus shape; DECAY_FLOOR is a permanent floor so a
+// memory's confidence never fully vanishes. DECAY_FLOOR + DECAY_SCALE = 1 so
+// a just-reinforced memory (agePulses = 0) always retains 100% regardless of d.
+const DECAY_FLOOR = 0.10;
+const DECAY_SCALE = 0.90;
+
+export const EVICTION_CONFIDENCE_THRESHOLD = 0.05;
+export const EVICTION_MIN_AGE_PULSES = 20;
+export const MAX_MEMORIES = 500;
+
+/**
+ * Confidence discounted by power-law decay since the memory was last
+ * reinforced (recalled), with emotional protection slowing high-intensity
+ * memories. Lazily computed at read time — decay is never written back,
+ * only `lastReinforcedAt` is (reinforcement).
+ */
+export function effectiveConfidence(memory: Memory, now: number, pulseIntervalMs: number): number {
+  const agePulses = Math.max(0, (now - memory.lastReinforcedAt) / pulseIntervalMs);
+  const dType = MEMORY_DECAY_RATES[memory.type] ?? MEMORY_DECAY_RATES.episodic;
+  const dEff = dType * (1 - EMOTIONAL_PROTECTION_FACTOR * memory.intensity);
+  const retention = DECAY_FLOOR + DECAY_SCALE * Math.pow(1 + agePulses, -dEff);
+  return memory.confidence * retention;
+}
+
+/**
+ * Eviction gate for the memory projection: a memory this faded and this
+ * stale is dropped, unless it is an open loop (Zeigarnik exemption) —
+ * `unresolved` or `pending_intention` memories are never evicted by this
+ * gate, only by the `MAX_MEMORIES` backstop.
+ */
+export function shouldEvictMemory(memory: Memory, now: number, pulseIntervalMs: number): boolean {
+  if (memory.unresolved || memory.type === "pending_intention") return false;
+  const agePulses = (now - memory.lastReinforcedAt) / pulseIntervalMs;
+  return (
+    agePulses > EVICTION_MIN_AGE_PULSES &&
+    effectiveConfidence(memory, now, pulseIntervalMs) < EVICTION_CONFIDENCE_THRESHOLD
+  );
+}
 
 export function scoreMemorySalience(
   memory: Memory,
@@ -29,6 +88,8 @@ export function scoreMemorySalience(
   selfId: string,
   newestCreatedAt: number,
   oldestCreatedAt: number,
+  now: number,
+  pulseIntervalMs: number,
 ): number {
   // Root-caused via a real capture: `involvedPeople` deliberately excludes
   // the agent's own id (it means "who ELSE is in this exchange" — see
@@ -50,7 +111,7 @@ export function scoreMemorySalience(
   return (
     RELEVANCE_WEIGHT * relevant +
     typeWeight +
-    memory.confidence +
+    effectiveConfidence(memory, now, pulseIntervalMs) +
     (memory.unresolved ? UNRESOLVED_WEIGHT : 0) +
     RECENCY_WEIGHT * recency
   );
@@ -61,6 +122,8 @@ export function selectRelevantMemories(
   involvedPeople: ReadonlySet<string>,
   selfId: string,
   maxMemories: number,
+  now: number,
+  pulseIntervalMs: number,
 ): Memory[] {
   if (memories.length === 0) return [];
   // reduce, not spread: huge stores would blow the argument limit.
@@ -70,7 +133,15 @@ export function selectRelevantMemories(
   return [...memories]
     .map(memory => ({
       memory,
-      score: scoreMemorySalience(memory, involvedPeople, selfId, newestCreatedAt, oldestCreatedAt),
+      score: scoreMemorySalience(
+        memory,
+        involvedPeople,
+        selfId,
+        newestCreatedAt,
+        oldestCreatedAt,
+        now,
+        pulseIntervalMs,
+      ),
     }))
     .sort((a, b) => b.score - a.score || b.memory.createdAt - a.memory.createdAt)
     .slice(0, maxMemories)

--- a/packages/engine/src/step/run-engine-step.ts
+++ b/packages/engine/src/step/run-engine-step.ts
@@ -277,6 +277,8 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
     attentionResults,
     translatedEmotionalState,
     availableActions,
+    now,
+    simulation.settings.pulseIntervalMs,
     snapshot.ownHistoryWindow ?? [],
   );
 

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -607,8 +607,10 @@ function buildAgentState(spec: AgentSeedSpec, scenario: RoleplayScenario): Agent
     confidence: m.confidence ?? 0.8,
     intensity: m.intensity ?? 0,
     unresolved: m.unresolved ?? false,
-    createdAt: now,
-    lastReinforcedAt: now,
+    // Simulated-clock epoch, not wall-clock: memory age is measured in pulses
+    // off PulseScheduler.simTime, which starts at 0. See applyMemoryProjection.
+    createdAt: 0,
+    lastReinforcedAt: 0,
   }));
 
   return {

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -715,6 +715,9 @@ async function createGateways(
 
 function makeAgentState(agent: AgentConfig, simulationId: string): AgentState {
   const now = Date.now();
+  // Simulated-clock epoch: PulseScheduler starts simTime at 0 and advances it by
+  // pulseIntervalMs per pulse. Memory ages are read against that clock.
+  const SIM_EPOCH = 0;
   const persona = inflatePersonaConfig(agent.persona);
   return {
     agentId: agent.id,
@@ -748,8 +751,12 @@ function makeAgentState(agent: AgentConfig, simulationId: string): AgentState {
       confidence: m.confidence ?? 0.8,
       intensity: m.intensity ?? 0,
       unresolved: false,
-      createdAt: now - 1,
-      lastReinforcedAt: now - 1,
+      // Memory timestamps live on the simulated clock (PulseScheduler.simTime,
+      // which starts at 0), not wall-clock time: decay and eviction measure age
+      // in pulses off that clock. A seeded memory predates pulse 1, so it is
+      // stamped at the simulated epoch.
+      createdAt: SIM_EPOCH,
+      lastReinforcedAt: SIM_EPOCH,
     })),
     initiativeAccumulators: [],
     lastProcessedEventId: null,

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-memory-decay.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-memory-decay.test.ts
@@ -13,6 +13,7 @@ import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
 import type { AgentContext, AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
 import type { Simulation, SimulationSettings, AgentState, PersonaConfig, ActionIntent, Memory } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
+import { effectiveConfidence } from "@perfectman/engine";
 
 /**
  * Issue #137 — power-law decay, emotional protection, eviction, and
@@ -254,6 +255,41 @@ describe("PulseScheduler memory decay, eviction, and reinforcement (issue #137)"
     expect(
       reinforcedEvents.some((e) => (e.data as { memoryId?: string } | undefined)?.memoryId === "mem_surfaced"),
     ).toBe(true);
+  });
+
+  it("stamps a projected memory on the simulated clock, so it actually ages", async () => {
+    // The gap that let the clock bug through: every other test here injects
+    // memories straight into updatedAgentState. Committed events carry
+    // wall-clock createdAt, so a memory projected from one used to land ~1.7e12
+    // ms ahead of the simTime that reads it — age clamped to 0, decay and
+    // eviction permanently inert on the only path that creates memories live.
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      memoryProposals: [
+        {
+          type: "episodic",
+          subjectAgentIds: [],
+          summary: "caio ignored me in front of everyone",
+          emotionalTone: "stung",
+          confidence: 0.5,
+          intensity: 0,
+          unresolved: false,
+        },
+      ],
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    const projected = state?.memories.at(-1);
+    expect(projected).toBeDefined();
+    expect(projected!.createdAt).toBe(SETTINGS.pulseIntervalMs); // pulse 0's simulated now
+    expect(projected!.lastReinforcedAt).toBe(SETTINGS.pulseIntervalMs);
+
+    // And it is therefore readable as aging: 30 pulses on, strength is down.
+    const thirtyPulsesOn = 31 * SETTINGS.pulseIntervalMs;
+    expect(effectiveConfidence(projected!, thirtyPulsesOn, SETTINGS.pulseIntervalMs)).toBeLessThan(
+      projected!.confidence,
+    );
   });
 
   it("does not reinforce a memory that memory selection did not surface", async () => {

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-memory-decay.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-memory-decay.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PulseScheduler } from "../pulse-scheduler.js";
+import { InMemoryEventRepository, InMemoryAgentStateRepository, InMemoryChannelRepository } from "../in-memory-stores.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { IntentResolver } from "../intent-resolver.js";
+import { EngineSnapshotProjection } from "../projections/engine-snapshot-projection.js";
+import { DeliveryProjection } from "../projections/delivery-projection.js";
+import { SpectatorProjection } from "../projections/spectator-projection.js";
+import { OperatorProjection } from "../projections/operator-projection.js";
+import { EngineEventBuilder } from "../engine-event-builder.js";
+import { MockDeliveryGateway } from "../../delivery/mock-delivery-gateway.js";
+import type { AgentContext, AgentRuntime, LLMBudget } from "../pulse-scheduler.js";
+import type { Simulation, SimulationSettings, AgentState, PersonaConfig, ActionIntent, Memory } from "@perfectman/shared";
+import { createId } from "@perfectman/shared";
+
+/**
+ * Issue #137 — power-law decay, emotional protection, eviction, and
+ * recall reinforcement, exercised through the real PulseScheduler. Split out
+ * of pulse-scheduler.test.ts to stay under the per-file test cap (Q4);
+ * pure-function coverage of the decay/eviction math itself lives in
+ * packages/engine/src/perception/__tests__/memory-salience.test.ts.
+ */
+
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+const SIM: Simulation = {
+  id: "sim_test",
+  name: "test",
+  status: "running",
+  agentIds: ["agent_1"],
+  channelIds: ["ch_public"],
+  settings: SETTINGS,
+  seed: 42,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+function makeAgentState(agentId = "agent_1"): AgentState {
+  return {
+    agentId,
+    simulationId: "sim_test",
+    personaId: `persona_${agentId.split("_")[1] ?? "1"}`,
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+const PERSONA: PersonaConfig = {
+  id: "persona_1",
+  name: "Test Agent",
+  archetype: "test",
+  writingStyle: "casual",
+  styleExamples: [],
+  baselineValence: 0,
+  baselineArousal: 0.5,
+  baselineStability: 0.8,
+  baselineEnergy: 0.6,
+  emotionalReactivity: 0.5,
+  moodInertia: 0.5,
+  maxMoodRotation: 0.5,
+  energyRegen: 0.05,
+  exclusionSensitivity: 0.5,
+  praiseSensitivity: 0.5,
+  conflictSensitivity: 0.5,
+  boredomSensitivity: 0.5,
+  intimacySensitivity: 0.5,
+  socialSensitivities: {},
+};
+
+function makeNoOpIntent(agentId: string): ActionIntent {
+  return {
+    id: createId(),
+    actorId: agentId,
+    intentType: "no_op",
+    personTargets: [],
+    privateMotiveSummary: "test motive",
+    emotionDrivers: [],
+    motivationDrivers: [],
+    memoryWrites: [],
+  };
+}
+
+const ZERO_ACTION = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+/** Canned step result for driving the real PulseScheduler through its commit-ordering. */
+function makeCannedStep({ agentId = "agent_1" } = {}): import("@perfectman/shared").EngineStepResult {
+  return {
+    visibleEvents: [],
+    newEvents: [],
+    attentionResults: { noticed: false, dueScore: 0, reasons: [], needsLLM: false, triggeringReason: "test" },
+    perceptionPacket: {
+      agentId, triggeringEvent: null, visibleContextEvents: [], eventHandles: {}, ownRecentUtterances: [], involvedPeople: [],
+      relevantChannels: [], relevantMemories: [],
+      translatedEmotionalState: { summary: "", emotions: [] },
+      availableActions: [],
+    },
+    interpretations: [],
+    emotionDelta: { coreMoodDelta: {}, socialEmotionDeltas: {}, relationalDeltas: new Map(), ruminationApplied: false },
+    updatedAgentState: makeAgentState(agentId),
+    motivations: [],
+    pressures: [],
+    inhibitions: [],
+    actionEmotions: ZERO_ACTION,
+    decision: { outcome: "no_op", needsLLM: false, initiativeProceed: false, noOpReason: "test", privateMotiveSeed: "x" },
+    availableActions: [],
+    initiativeCandidates: [],
+    memoryProposals: [],
+    noOpRecord: { agentId, pulseIndex: 0, privateMotiveSummary: "nothing to do", reason: "test" },
+    operatorMetrics: { pulseIndex: 0, pulseDurationMs: 10, agentsCalled: 1, eventsCommitted: 0, llmCallsMade: 0, budgetUsedPercent: 0 },
+  };
+}
+
+function agedMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "mem",
+    agentId: "agent_1",
+    simulationId: "sim_test",
+    type: "episodic",
+    subjectAgentIds: [],
+    sourceEventIds: [],
+    summary: "a memory",
+    emotionalTone: "neutral",
+    confidence: 0.5,
+    intensity: 0,
+    unresolved: false,
+    createdAt: 0,
+    lastReinforcedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("PulseScheduler memory decay, eviction, and reinforcement (issue #137)", () => {
+  let scheduler: PulseScheduler;
+  let eventRepo: InMemoryEventRepository;
+  let agentStateRepo: InMemoryAgentStateRepository;
+  let channelRepo: InMemoryChannelRepository;
+  let channelRegistry: ChannelRegistry;
+  let gateway: MockDeliveryGateway;
+  let intentResolver: IntentResolver;
+  let engineEventBuilder: EngineEventBuilder;
+
+  function buildScheduler(stepResolver: (snap: import("@perfectman/shared").EngineSnapshot) => import("@perfectman/shared").EngineStepResult): PulseScheduler {
+    return new PulseScheduler({
+      simulation: SIM,
+      agents: [AGENT],
+      defaultPublicChannelId: "ch_public",
+      eventRepo,
+      agentStateRepo,
+      channelRegistry,
+      rateLimitGate: new RateLimitGate(SETTINGS),
+      intentResolver,
+      engineSnapshotProjection: new EngineSnapshotProjection(),
+      deliveryProjection: new DeliveryProjection(gateway),
+      spectatorProjection: new SpectatorProjection(gateway),
+      operatorProjection: new OperatorProjection(gateway),
+      engineEventBuilder,
+      agentRuntime: mockAgentRuntime,
+      llmBudget: mockLLMBudget,
+      pulseIntervalMs: SETTINGS.pulseIntervalMs,
+      stepResolver,
+    });
+  }
+
+  const AGENT: AgentContext = {
+    id: "agent_1",
+    state: makeAgentState(),
+    persona: PERSONA,
+  };
+
+  const mockAgentRuntime: AgentRuntime = {
+    generateIntent: vi.fn().mockResolvedValue({
+      intent: makeNoOpIntent("agent_1"),
+      llmUsage: null,
+      latencyMs: 10,
+      fallbackApplied: false,
+      operatorEvents: [],
+    }),
+  };
+
+  const mockLLMBudget: LLMBudget = {
+    getPriority: vi.fn().mockReturnValue("normal"),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    eventRepo = new InMemoryEventRepository();
+    agentStateRepo = new InMemoryAgentStateRepository();
+    channelRepo = new InMemoryChannelRepository();
+    channelRegistry = new ChannelRegistry(channelRepo);
+    gateway = new MockDeliveryGateway();
+
+    await channelRepo.create({
+      id: "ch_public",
+      simulationId: "sim_test",
+      type: "public_channel",
+      name: "general",
+      createdBy: "system",
+      memberAgentIds: ["agent_1"],
+      spectatorVisible: true,
+      operatorVisible: true,
+      createdForMotives: [],
+      status: "active",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await channelRepo.addMembership({ channelId: "ch_public", agentId: "agent_1", joinedAt: Date.now() });
+    await agentStateRepo.upsert(makeAgentState());
+
+    const rateLimitGate = new RateLimitGate(SETTINGS);
+    intentResolver = new IntentResolver(rateLimitGate, channelRegistry);
+    engineEventBuilder = new EngineEventBuilder();
+
+    scheduler = buildScheduler(() => makeCannedStep());
+  });
+
+  it("reinforces a memory surfaced by memory selection: bumps lastReinforcedAt and emits memory_reinforced", async () => {
+    const surfaced = agedMemory({ id: "mem_surfaced" });
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      updatedAgentState: { ...makeAgentState(), memories: [surfaced] },
+      perceptionPacket: { ...makeCannedStep().perceptionPacket, relevantMemories: [surfaced] },
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    const persisted = state?.memories.find((m) => m.id === "mem_surfaced");
+    expect(persisted?.lastReinforcedAt).toBe(SETTINGS.pulseIntervalMs); // pulse 0's simulated now
+
+    const reinforcedEvents = gateway.operatorEvents.filter((e) => e.type === "memory_reinforced");
+    expect(
+      reinforcedEvents.some((e) => (e.data as { memoryId?: string } | undefined)?.memoryId === "mem_surfaced"),
+    ).toBe(true);
+  });
+
+  it("does not reinforce a memory that memory selection did not surface", async () => {
+    const notSurfaced = agedMemory({ id: "mem_not_surfaced" });
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      updatedAgentState: { ...makeAgentState(), memories: [notSurfaced] },
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    const persisted = state?.memories.find((m) => m.id === "mem_not_surfaced");
+    expect(persisted?.lastReinforcedAt).toBe(0);
+
+    const reinforcedEvents = gateway.operatorEvents.filter((e) => e.type === "memory_reinforced");
+    expect(
+      reinforcedEvents.some((e) => (e.data as { memoryId?: string } | undefined)?.memoryId === "mem_not_surfaced"),
+    ).toBe(false);
+  });
+
+  it("evicts a low-confidence, aged (>20 pulses), non-unresolved memory", async () => {
+    const stale = agedMemory({
+      id: "mem_stale",
+      confidence: 0.03,
+      unresolved: false,
+      lastReinforcedAt: -100 * SETTINGS.pulseIntervalMs,
+    });
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      updatedAgentState: { ...makeAgentState(), memories: [stale] },
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    expect(state?.memories.some((m) => m.id === "mem_stale")).toBe(false);
+  });
+
+  it("keeps an unresolved memory of the same age/confidence (Zeigarnik exemption)", async () => {
+    const stale = agedMemory({
+      id: "mem_stale_open",
+      confidence: 0.03,
+      unresolved: true,
+      lastReinforcedAt: -100 * SETTINGS.pulseIntervalMs,
+    });
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      updatedAgentState: { ...makeAgentState(), memories: [stale] },
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    expect(state?.memories.some((m) => m.id === "mem_stale_open")).toBe(true);
+  });
+
+  it("MAX_MEMORIES backstop evicts the lowest-strength memory on overflow", async () => {
+    const memories: Memory[] = Array.from({ length: 501 }, (_, i) =>
+      agedMemory({
+        id: `mem_${i}`,
+        confidence: (i + 1) / 501, // distinct, strictly increasing strength
+        unresolved: true, // isolates the backstop from the age/confidence eviction gate
+        lastReinforcedAt: SETTINGS.pulseIntervalMs, // zero age at pulse 0's now
+      }),
+    );
+    scheduler = buildScheduler(() => ({
+      ...makeCannedStep(),
+      updatedAgentState: { ...makeAgentState(), memories },
+    }));
+    await scheduler.runPulse();
+
+    const state = await agentStateRepo.get("sim_test", "agent_1");
+    expect(state?.memories).toHaveLength(500);
+    expect(state?.memories.some((m) => m.id === "mem_0")).toBe(false); // weakest — dropped
+    expect(state?.memories.some((m) => m.id === "mem_500")).toBe(true); // strongest — kept
+  });
+});

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -337,8 +337,10 @@ describe("PulseScheduler", () => {
         confidence: PROPOSAL.confidence,
         intensity: PROPOSAL.intensity,
         unresolved: PROPOSAL.unresolved,
-        createdAt: memoryEvent.createdAt,
-        lastReinforcedAt: memoryEvent.createdAt,
+        // Simulated clock, not the event's wall-clock createdAt: memory age is
+        // counted in pulses off simTime (issue #137 decay/eviction).
+        createdAt: SETTINGS.pulseIntervalMs,
+        lastReinforcedAt: SETTINGS.pulseIntervalMs,
       });
 
       const snapshots = gateway.operatorEvents.filter((e) => e.type === "agent_state_snapshot");

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -317,7 +317,7 @@ export class PulseScheduler {
       if (engineEvents.length > 0) {
         const committed = await this.appendAndProject(engineEvents, channels, membership);
         eventsCommitted += committed.length;
-        this.applyMemoryProjection(committed, stepResult.updatedAgentState);
+        this.applyMemoryProjection(committed, stepResult.updatedAgentState, now);
       }
 
       // Reinforcement (testing effect): every memory this pulse's selection
@@ -390,7 +390,7 @@ export class PulseScheduler {
         if (resolved.committedEvents.length > 0) {
           const committed = await this.appendAndProject(resolved.committedEvents, channels, membership);
           eventsCommitted += committed.length;
-          this.applyMemoryProjection(committed, stepResult.updatedAgentState);
+          this.applyMemoryProjection(committed, stepResult.updatedAgentState, now);
         }
 
         for (const opEv of [...resolved.operatorEvents, ...runtimeOutput.operatorEvents]) {
@@ -579,8 +579,14 @@ export class PulseScheduler {
    * Mutates `updatedAgentState` in place — same-pulse `persistAndSnapshot` is
    * the single write point, and a failed append never reaches here because
    * only returned (committed) events are passed in.
+   *
+   * Both timestamps are stamped from the simulated clock (`now`), not from
+   * `event.createdAt`. Committed events carry wall-clock time; decay,
+   * reinforcement and eviction all measure age in pulses off `simTime`, so a
+   * wall-clock stamp would put every memory ~1.7e12 ms in the future of the
+   * clock reading it and nothing would ever age.
    */
-  private applyMemoryProjection(committed: CommittedEvent[], agentState: AgentState): void {
+  private applyMemoryProjection(committed: CommittedEvent[], agentState: AgentState, now: number): void {
     for (const event of committed) {
       if (event.type !== "memory_written") continue;
       agentState.memories.push({
@@ -595,8 +601,8 @@ export class PulseScheduler {
         confidence: event.payload["confidence"] as number,
         intensity: event.payload["intensity"] as number,
         unresolved: event.payload["unresolved"] as boolean,
-        createdAt: event.createdAt,
-        lastReinforcedAt: event.createdAt,
+        createdAt: now,
+        lastReinforcedAt: now,
       });
     }
   }

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -15,7 +15,15 @@ import type {
   Memory,
 } from "@perfectman/shared";
 import { createId, createSeededRng, STAGNATION_WINDOW_PULSES, OWN_HISTORY_LIMIT } from "@perfectman/shared";
-import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
+import {
+  runEngineStep,
+  computeStagnationMetrics,
+  detectAttractorStates,
+  filterVisibleEventsForAgent,
+  effectiveConfidence,
+  shouldEvictMemory,
+  MAX_MEMORIES,
+} from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
 import type { RateLimitGate } from "./rate-limit-gate.js";
@@ -31,6 +39,7 @@ import type {
   ActionIntentOperatorData,
   AttractorDetectedOperatorData,
   EventVisibilityData,
+  MemoryReinforcedOperatorData,
   StagnationMetricsOperatorData,
 } from "@perfectman/shared";
 import { buildAgentRuntimeInput } from "./runtime-input-builder.js";
@@ -311,6 +320,15 @@ export class PulseScheduler {
         this.applyMemoryProjection(committed, stepResult.updatedAgentState);
       }
 
+      // Reinforcement (testing effect): every memory this pulse's selection
+      // surfaced gets its decay clock reset, regardless of whether the
+      // perception packet goes on to an LLM call.
+      await this.applyMemoryReinforcement(
+        stepResult.perceptionPacket.relevantMemories ?? [],
+        stepResult.updatedAgentState,
+        now,
+      );
+
       if (stepResult.decision.needsLLM) {
         agentsCalled += 1;
         const budgetPriority = this.config.llmBudget.getPriority(sim.id, agent.id);
@@ -325,7 +343,7 @@ export class PulseScheduler {
         });
 
         if (!runtimeOutput) {
-          await this.persistAndSnapshot(stepResult.updatedAgentState);
+          await this.persistAndSnapshot(stepResult.updatedAgentState, now);
           continue;
         }
 
@@ -346,7 +364,7 @@ export class PulseScheduler {
         });
 
         if (!resolved) {
-          await this.persistAndSnapshot(stepResult.updatedAgentState);
+          await this.persistAndSnapshot(stepResult.updatedAgentState, now);
           continue;
         }
 
@@ -416,7 +434,7 @@ export class PulseScheduler {
         }
       }
 
-      await this.persistAndSnapshot(stepResult.updatedAgentState);
+      await this.persistAndSnapshot(stepResult.updatedAgentState, now);
     }
 
     // Every 10 pulses: compute stagnation metrics
@@ -583,6 +601,55 @@ export class PulseScheduler {
     }
   }
 
+  /**
+   * Reinforcement (testing effect): a memory surfaced by this pulse's memory
+   * selection gets its decay clock (`lastReinforcedAt`) reset to `now`, and a
+   * `memory_reinforced` operator event is emitted per surfaced memory. Mutates
+   * `agentState.memories` in place — same single-write-point rationale as
+   * `applyMemoryProjection`.
+   */
+  private async applyMemoryReinforcement(
+    surfacedMemories: readonly Memory[],
+    agentState: AgentState,
+    now: number,
+  ): Promise<void> {
+    for (const surfaced of surfacedMemories) {
+      const stored = agentState.memories.find((m) => m.id === surfaced.id);
+      if (!stored) continue;
+      stored.lastReinforcedAt = now;
+      const data: MemoryReinforcedOperatorData = { memoryId: stored.id, memoryType: stored.type };
+      await this.emitOperatorEvent({
+        type: "memory_reinforced",
+        simulationId: agentState.simulationId,
+        agentId: agentState.agentId,
+        pulseIndex: this.pulseIndex,
+        detail: `Memory reinforced: ${stored.type}`,
+        data,
+        createdAt: Date.now(),
+      });
+    }
+  }
+
+  /**
+   * Eviction pass over an agent's memory store, run right before persistence
+   * so every pulse's write reflects a decayed-and-capped store regardless of
+   * which code path produced this pulse's `agentState` (LLM failure, resolver
+   * failure, or the full commit path all funnel through `persistAndSnapshot`).
+   * Drops faded, stale, non-open-loop memories first (`shouldEvictMemory`),
+   * then applies the `MAX_MEMORIES` backstop by strength if still over.
+   */
+  private applyMemoryEviction(agentState: AgentState, now: number): void {
+    const pulseIntervalMs = this.config.pulseIntervalMs;
+    agentState.memories = agentState.memories.filter(
+      (m) => !shouldEvictMemory(m, now, pulseIntervalMs),
+    );
+    if (agentState.memories.length > MAX_MEMORIES) {
+      agentState.memories = [...agentState.memories]
+        .sort((a, b) => effectiveConfidence(b, now, pulseIntervalMs) - effectiveConfidence(a, now, pulseIntervalMs))
+        .slice(0, MAX_MEMORIES);
+    }
+  }
+
   private async emitEventVisibility(event: CommittedEvent): Promise<void> {
     const data: EventVisibilityData = {
       eventId: event.id,
@@ -626,7 +693,8 @@ export class PulseScheduler {
     }
   }
 
-  private async persistAndSnapshot(agentState: AgentState): Promise<void> {
+  private async persistAndSnapshot(agentState: AgentState, now: number): Promise<void> {
+    this.applyMemoryEviction(agentState, now);
     try {
       await this.config.agentStateRepo.upsert(agentState);
     } catch (err) {

--- a/packages/shared/src/fixtures/biased-memory.ts
+++ b/packages/shared/src/fixtures/biased-memory.ts
@@ -74,7 +74,9 @@ export function buildBiasedMemoryScenario(): BiasedMemoryScenario {
   const caioState = makeAgentState("caio", simulationId, "caio");
 
   // Mixed memories of Caio (both positive and negative, same age)
-  const baseTime = Date.now() - 120000;
+  // Simulated-clock epoch: memory age is counted in pulses off
+  // PulseScheduler.simTime (starts at 0), never wall-clock time.
+  const baseTime = 0;
 
   const memories: Memory[] = [
     makeMemory(

--- a/packages/shared/src/fixtures/helpers.ts
+++ b/packages/shared/src/fixtures/helpers.ts
@@ -254,7 +254,8 @@ export function makeMemory(
     confidence,
     intensity,
     unresolved: false,
-    createdAt: Date.now(),
-    lastReinforcedAt: Date.now(),
+    // Simulated clock, not wall-clock — see applyMemoryProjection.
+    createdAt: 0,
+    lastReinforcedAt: 0,
   };
 }

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -1,6 +1,7 @@
 import type { EventPayload, EventType } from "../event/event.types.js";
 import type { IntentType } from "../intent/intent.types.js";
 import type { AttractorState } from "../constants/stagnation.js";
+import type { Memory } from "../memory/memory.types.js";
 
 /**
  * Operator event types the server may emit. Declared once here — the single
@@ -32,6 +33,7 @@ export const OPERATOR_EVENT_TYPES = [
   "stagnation_warning",
   "stagnation_metrics",
   "attractor_detected",
+  "memory_reinforced",
   "scheduler_error",
   "pulse_metrics",
   "agent_state_snapshot",
@@ -150,4 +152,12 @@ export type StagnationMetricsOperatorData = StagnationMetrics;
  *  Independent of the composite `level`, which it never overrides. */
 export type AttractorDetectedOperatorData = {
   signature: AttractorState;
+};
+
+/** `memory_reinforced` payload — one event per memory surfaced by memory
+ *  selection this pulse; the projection uses `memoryId` to bump that
+ *  memory's `lastReinforcedAt`. */
+export type MemoryReinforcedOperatorData = {
+  memoryId: string;
+  memoryType: Memory["type"];
 };


### PR DESCRIPTION
## What

Adds power-law decay, eviction, and recall reinforcement to agent memory:

- `effectiveConfidence(memory, now, pulseIntervalMs)` in `memory-salience.ts`: retention `0.10 + 0.90 * (1 + agePulses)^(-d_eff)` keyed to pulses since `lastReinforcedAt`, per-type base rate via `MEMORY_DECAY_RATES` (`pending_intention 0.04` .. `episodic 0.18`), emotional protection `d_eff = d * (1 - 0.6 * intensity)`.
- `scoreMemorySalience` swaps raw `memory.confidence` for `effectiveConfidence`; `RECENCY_WEIGHT` drops `0.5` -> `0.2` now that decay carries most of that signal.
- `shouldEvictMemory` drops a memory once it is below `EVICTION_CONFIDENCE_THRESHOLD 0.05` and past `EVICTION_MIN_AGE_PULSES 20`, exempting `unresolved`/`pending_intention`; a `MAX_MEMORIES = 500` per-agent backstop runs in `pulse-scheduler.ts`'s new `applyMemoryEviction`, called from `persistAndSnapshot` so every write-path (LLM failure, resolver failure, full commit) stays capped.
- `applyMemoryReinforcement` bumps `lastReinforcedAt` to `now` for every memory `selectRelevantMemories` surfaces and emits a `memory_reinforced` operator event (new type in `operator.types.ts`).
- `buildPerceptionPacket`/`runEngineStep` thread `now` and `pulseIntervalMs` through so decay tracks the simulated clock instead of a memory-store-relative proxy.
- Ten new/rewritten unit tests in `memory-salience.test.ts` (decay-over-pulses, emotional protection, eviction gate incl. Zeigarnik exemption, reinforcement) plus a five-case `PulseScheduler` integration suite (`pulse-scheduler-memory-decay.test.ts`, split out for the 25-tests-per-file cap): reinforcement event + timestamp bump, non-surfaced memory left alone, stale eviction, unresolved exemption, `MAX_MEMORIES` backstop.

## Why

Memory salience previously treated a memory's authored confidence as constant forever and had no eviction path, so `agentState.memories` grows unbounded (flagged as a deliberate deferral in ADR-0013) and old, no-longer-relevant memories never lost ground to genuinely current ones. #131's research resolved the model (power-law retention, per-type rate, emotional protection, Zeigarnik-exempt eviction); this closes #126 Q5 by wiring it in.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1443 tests, 127 files)
- `node scripts/audit-tests.mjs --check` PASS, `node scripts/docs-lint.mjs --check` PASS

Closes #137
