### PR TITLE
fix(simulation): split repetition-guard blocks out of no_op_recorded

### DIFF
--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -57,6 +57,9 @@ export type BenchReport = {
   promptTemplateVersions: string[];
   signalsByKind: Record<string, import("../run/signal-checker.js").SignalsByKindEntry>;
   calibration: ReturnType<typeof calibrateJudge>;
+  /** Retries that fixed a guard violation on the first attempt — not free,
+   *  but not a terminal `llm_failure` either (see `llm_retry_recovered`). */
+  recoveredFallbacks: number;
   perScenario: Array<{
     id: string;
     name: string;
@@ -66,6 +69,7 @@ export type BenchReport = {
     probeTotal: number;
     axisScores: AxisScores;
     fallbackCount: number;
+    recoveredFallbacks: number;
     latencyMs: number;
     promptVersions: string[];
     judgeSalvaged?: boolean;
@@ -155,6 +159,7 @@ export async function runBench(opts: {
     promptTemplateVersions: [],
     signalsByKind: {},
     calibration: calibrateJudge(new Map(), []),
+    recoveredFallbacks: 0,
     perScenario: [],
   };
 
@@ -174,6 +179,7 @@ export async function runBench(opts: {
     try {
       const artifact: ScenarioRunArtifact = await ScenarioRunner.run(scenario, { llmMode: mode });
       report.scenariosRun++;
+      report.recoveredFallbacks += artifact.recoveredFallbacks ?? 0;
       artifact.promptVersions.forEach((v) => allPromptVersions.add(v));
       artifact.templateVersions.forEach((v) => allTemplateVersions.add(v));
 
@@ -237,6 +243,7 @@ export async function runBench(opts: {
         probeTotal: artifact.probeResults.length,
         axisScores,
         fallbackCount: artifact.fallbackCount,
+        recoveredFallbacks: artifact.recoveredFallbacks ?? 0,
         latencyMs: artifact.latencyMs,
         promptVersions: artifact.promptVersions,
         judgeSalvaged: judgeResult.salvaged,
@@ -254,6 +261,7 @@ export async function runBench(opts: {
         probeTotal: 0,
         axisScores: {},
         fallbackCount: 0,
+        recoveredFallbacks: 0,
         latencyMs: 0,
         promptVersions: [],
         failed: err instanceof Error ? err.message : String(err),
@@ -301,6 +309,7 @@ export async function runBench(opts: {
 function printReport(report: BenchReport): void {
   console.log(`\n=== Perfectman Roleplay Bench (${report.mode}) ===`);
   console.log(`scenarios: ${report.scenariosRun} run, ${report.scenariosFailed} failed`);
+  console.log(`recovered fallbacks (retry fixed a guard violation): ${report.recoveredFallbacks}`);
   console.log(`signal pass rate: ${(report.signalPassRate * 100).toFixed(1)}%`);
   console.log(`probe pass rate: ${(report.probePassRate * 100).toFixed(1)}%`);
   const byKind = Object.entries(report.signalsByKind).sort((a, b) => a[1].passRate - b[1].passRate);

--- a/packages/eval/src/cli/sweep-repetition.ts
+++ b/packages/eval/src/cli/sweep-repetition.ts
@@ -42,12 +42,18 @@ type Cell = {
   narrativeCohesionMean: number;
 };
 
+/**
+ * Guard blocks are their own event type now, so this is a plain count rather
+ * than a motive-string match. The marker match is kept as a fallback so runs
+ * recorded before the split still measure correctly.
+ */
 function countGuardBlocks(events: { type: string; payload: Record<string, unknown> }[]): number {
   return events.filter(
     e =>
-      e.type === "no_op_recorded" &&
-      typeof e.payload["privateMotiveSummary"] === "string" &&
-      (e.payload["privateMotiveSummary"] as string).includes(REPETITION_GUARD_MARKER),
+      e.type === "repetition_blocked" ||
+      (e.type === "no_op_recorded" &&
+        typeof e.payload["privateMotiveSummary"] === "string" &&
+        (e.payload["privateMotiveSummary"] as string).includes(REPETITION_GUARD_MARKER)),
   ).length;
 }
 

--- a/packages/eval/src/cli/sweep-temperature.ts
+++ b/packages/eval/src/cli/sweep-temperature.ts
@@ -92,6 +92,9 @@ export function countGuardBlocks(
   events: readonly { type: string; payload: Record<string, unknown> }[],
 ): number {
   return events.filter(e => {
+    // Guard blocks carry their own event type now; the marker match stays so
+    // runs recorded before the split still measure correctly.
+    if (e.type === "repetition_blocked") return true;
     if (e.type !== "no_op_recorded") return false;
     const motive = e.payload["privateMotiveSummary"];
     return typeof motive === "string" && motive.includes(REPETITION_GUARD_MARKER);

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -163,6 +163,10 @@ export function ruleJudge(
  * is intentionally NOT here: it is the mechanical echo of one
  * `channel_created` decision (N invites from a single create), so counting
  * it would inflate one choice across two buckets.
+ *
+ * `repetition_blocked` is likewise absent on purpose: the guard firing is the
+ * generator failing, not the agent choosing, and counting it as a choice let a
+ * degenerate run score as behaviorally diverse.
  */
 const CHOICE_EVENT_TYPES = new Set([
   "message_sent",

--- a/packages/eval/src/probes/adapter.ts
+++ b/packages/eval/src/probes/adapter.ts
@@ -42,6 +42,8 @@ function kindFor(type: CommittedEvent["type"]): BehavioralEventKind {
       return "react";
     case "no_op_recorded":
       return "silence";
+    case "repetition_blocked":
+      return "blocked_repeat";
     case "channel_created":
       return "private_channel";
     case "memory_written":

--- a/packages/eval/src/probes/types.ts
+++ b/packages/eval/src/probes/types.ts
@@ -6,7 +6,8 @@ export type BehavioralEventKind =
   | "post"          // message_sent
   | "reply"         // reply_sent
   | "react"         // reaction_sent
-  | "silence"       // no_op_recorded
+  | "silence"       // no_op_recorded — a chosen social act
+  | "blocked_repeat" // repetition_blocked — the generator degenerating, never silence
   | "private_channel" // channel_created
   | "memory"        // memory_written
   | "join"          // agent_invited

--- a/packages/eval/src/render/html.ts
+++ b/packages/eval/src/render/html.ts
@@ -117,6 +117,16 @@ function transcriptHtml(evidence: ScenarioEvidence): string {
             `</div>`,
         );
         break;
+      // Rendered distinctly from a no_op on purpose: labelling a blocked
+      // near-duplicate "escolhe o silêncio" told the reader an agent chose
+      // something when the generator had simply repeated itself.
+      case "repetition_blocked":
+        parts.push(
+          `<div class="msg blocked" ${agentAttr}><span class="who" style="color:${color}">${name}</span>` +
+            `<span class="tag">repetição bloqueada</span>` +
+            `</div>`,
+        );
+        break;
       case "channel_created":
         parts.push(
           `<div class="msg system">🔒 <b>${name}</b> abre um canal privado${t.channelId ? ` (${esc(t.channelId)})` : ""} — longe da sala</div>`,
@@ -224,20 +234,21 @@ function chapter(evidence: ScenarioEvidence, narration?: Narration, idPrefix = "
 }
 
 /** Aggregates per-persona stats across all scenes (for the focus select). */
-function personaStats(evidence: ScenarioEvidence[]): Record<string, { msgs: number; noops: number; reacts: number; scenes: number }> {
-  const stats: Record<string, { msgs: number; noops: number; reacts: number; scenes: number }> = {};
+function personaStats(evidence: ScenarioEvidence[]): Record<string, { msgs: number; noops: number; blocked: number; reacts: number; scenes: number }> {
+  const stats: Record<string, { msgs: number; noops: number; blocked: number; reacts: number; scenes: number }> = {};
   const seen = new Set<string>();
   for (const e of evidence) {
     for (const t of e.transcript) {
-      stats[t.agent] ??= { msgs: 0, noops: 0, reacts: 0, scenes: 0 };
+      stats[t.agent] ??= { msgs: 0, noops: 0, blocked: 0, reacts: 0, scenes: 0 };
       if (t.type === "message_sent" || t.type === "reply_sent") stats[t.agent]!.msgs++;
       if (t.type === "no_op_recorded") stats[t.agent]!.noops++;
+      if (t.type === "repetition_blocked") stats[t.agent]!.blocked++;
       if (t.type === "reaction_sent") stats[t.agent]!.reacts++;
     }
     for (const agent of Object.keys(e.finalStates)) {
       if (!seen.has(e.scenarioId + agent)) {
         seen.add(e.scenarioId + agent);
-        stats[agent] ??= { msgs: 0, noops: 0, reacts: 0, scenes: 0 };
+        stats[agent] ??= { msgs: 0, noops: 0, blocked: 0, reacts: 0, scenes: 0 };
         stats[agent]!.scenes++;
       }
     }
@@ -307,7 +318,8 @@ export function renderHtmlPage(data: HtmlPageData): string {
     .sort()
     .map(a => {
       const s = stats[a]!;
-      return `<option value="${esc(a)}">${esc(agentName(a))} — ${s.msgs} msg · ${s.noops} silêncios · ${s.scenes} cenas</option>`;
+      const blockedNote = s.blocked > 0 ? ` · ${s.blocked} bloqueios` : "";
+      return `<option value="${esc(a)}">${esc(agentName(a))} — ${s.msgs} msg · ${s.noops} silêncios${blockedNote} · ${s.scenes} cenas</option>`;
     })
     .join("");
 

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -50,6 +50,11 @@ export type ScenarioRunArtifact = {
   llmCalls: Map<string, number>;
   fallbackCount: number;
   operatorFailures: number;
+  /** Retries that fixed a guard violation on the first attempt — not a
+   *  terminal failure, but not free either (see `llm_retry_recovered` in
+   *  operator.types.ts). Optional so untyped test fixtures built before this
+   *  field existed keep working. */
+  recoveredFallbacks?: number;
   probeResults: ProbeResult[];
   signalResults: SignalOutcome[];
   passedSignals: number;
@@ -205,6 +210,9 @@ export class ScenarioRunner {
 
     const failures = events.filter(e => e.type === "llm_failure").length;
     const fallbackCount = failures;
+    const recoveredFallbacks = gateway instanceof MockDeliveryGateway
+      ? gateway.operatorEvents.filter(e => e.type === "llm_retry_recovered").length
+      : 0;
     const behavioral = eventsToBehavioral(events);
     const probeResults = runAllProbes({
       events: behavioral,
@@ -224,6 +232,7 @@ export class ScenarioRunner {
       llmCalls: new Map(scenario.agents.map(a => [a.agentId, tracking?.callsFor(a.agentId) ?? 0])),
       fallbackCount,
       operatorFailures: failures,
+      recoveredFallbacks,
       probeResults,
       signalResults,
       passedSignals,

--- a/packages/eval/src/test/bench.test.ts
+++ b/packages/eval/src/test/bench.test.ts
@@ -12,6 +12,7 @@ vi.mock("../run/scenario-runner.js", () => ({
       llmCalls: new Map(),
       fallbackCount: 0,
       operatorFailures: 0,
+      recoveredFallbacks: 2,
       probeResults: [],
       signalResults: [],
       passedSignals: 0,
@@ -38,6 +39,17 @@ describe("runBench", () => {
     const written = JSON.parse(readFileSync(outPath, "utf8"));
     expect(written.promptVersions).toEqual(["abc123"]);
     expect(written.promptTemplateVersions).toEqual(["action-intent-hybrid-v1"]);
+  });
+
+  it("counts recovered fallbacks (retry fixed a guard violation) into the report, not just terminal failures", async () => {
+    const outPath = join(mkdtempSync(join(tmpdir(), "bench-report-")), "report.json");
+
+    const report = await runBench({ mode: "mock", limit: 1, out: outPath });
+
+    expect(report.recoveredFallbacks).toBe(2);
+    expect(report.perScenario[0]?.recoveredFallbacks).toBe(2);
+    const written = JSON.parse(readFileSync(outPath, "utf8"));
+    expect(written.recoveredFallbacks).toBe(2);
   });
 });
 

--- a/packages/eval/src/test/sweep-temperature.test.ts
+++ b/packages/eval/src/test/sweep-temperature.test.ts
@@ -38,7 +38,7 @@ describe("temperature sweep: repetition-guard marker", () => {
     const artifact = await ScenarioRunner.run(scenario, { llmMode: "mock" });
 
     const noOpMotives = artifact.events
-      .filter(e => e.type === "no_op_recorded")
+      .filter(e => e.type === "no_op_recorded" || e.type === "repetition_blocked")
       .map(e => e.payload["privateMotiveSummary"])
       .filter((m): m is string => typeof m === "string");
 

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -191,6 +191,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     const mainOutputTokens = providerResult.usage.outputTokens;
     const retryUsages: { inputTokens: number; outputTokens: number; latencyMs: number; promptVersion: string }[] = [];
     const retryTrimEvents: OperatorEvent[] = [];
+    const retryRecoveryEvents: OperatorEvent[] = [];
 
     const isRepeat = (candidateIntent: typeof intent): boolean =>
       (candidateIntent.intentType === "send_message" || candidateIntent.intentType === "reply_to_message") &&
@@ -198,6 +199,15 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
       isNearRepeat(candidateIntent.visibleContent, input.perceptionPacket.ownRecentUtterances, threshold);
 
     if (!fallbackApplied && (isRepeat(intent) || parseResult.unresolvedTarget)) {
+      // What the *first* attempt got wrong. A retry that fixes it clears every
+      // in-band signal (`fallbackApplied` goes back to false, no llm_failure is
+      // pushed), so without capturing it here the failed attempt vanishes and
+      // the offline counters report a clean run.
+      const firstAttemptViolations = [
+        isRepeat(intent) ? "near_duplicate" : null,
+        parseResult.unresolvedTarget ? "unresolved_target" : null,
+      ].filter((v): v is string => v !== null);
+
       for (let attempt = 0; attempt < maxRetries; attempt++) {
         // The correction notes re-inflate the (already-capped) base prompt, so
         // the retry prompt is re-assembled and re-trimmed against the same cap
@@ -257,6 +267,18 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
             parseResult = retryParse;
             intent = retryParse.intent;
             fallbackApplied = false;
+            retryRecoveryEvents.push({
+              type: "llm_retry_recovered",
+              simulationId,
+              agentId,
+              pulseIndex: ctx.pulseIndex,
+              detail: `Agent ${agentId} recovered on retry ${retriesAttempted} after ${firstAttemptViolations.join(" + ")}.`,
+              createdAt: Date.now(),
+              data: {
+                violations: firstAttemptViolations,
+                retriesAttempted,
+              },
+            });
             break;
           }
           // Adopt the latest attempt even when it still violates a guard, so
@@ -388,6 +410,7 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     const operatorEvents: OperatorEvent[] = [];
     if (trimEvent) operatorEvents.push(trimEvent);
     operatorEvents.push(...retryTrimEvents);
+    operatorEvents.push(...retryRecoveryEvents);
     operatorEvents.push({
       type: "pulse_metrics",
       simulationId,

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -11,6 +11,7 @@ import type {
   AvailableAction,
 } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
+import { REPETITION_GUARD_MARKER } from "../../agent/repetition-guard.js";
 
 const SIM_ID = "sim_test";
 const AGENT_ID = "agent_1";
@@ -122,6 +123,51 @@ describe("IntentResolver", () => {
     membership: [],
     settings: SETTINGS,
     actionEmotions: ACTION_EMOTIONS,
+  });
+
+  describe("repetition_blocked is not no_op_recorded", () => {
+    it("commits repetition_blocked when the guard authored the no_op motive", async () => {
+      const intent = makeIntent({
+        intentType: "no_op",
+        channelTarget: CHANNEL_ID,
+        privateMotiveSummary:
+          `${REPETITION_GUARD_MARKER}: near-duplicate of a message you already sent, even after a retry — blocked structurally.`,
+      });
+      const result = await resolver.resolve(intent, ctx());
+
+      const types = result.committedEvents.map(e => e.type);
+      expect(types).toContain("repetition_blocked");
+      // The whole point of the split: a degenerate generator must never be
+      // counted as an agent choosing silence.
+      expect(types).not.toContain("no_op_recorded");
+    });
+
+    it("still commits no_op_recorded when the agent genuinely chose silence", async () => {
+      const intent = makeIntent({
+        intentType: "no_op",
+        channelTarget: CHANNEL_ID,
+        privateMotiveSummary: "nothing worth saying right now; let them come to me.",
+      });
+      const result = await resolver.resolve(intent, ctx());
+
+      const types = result.committedEvents.map(e => e.type);
+      expect(types).toContain("no_op_recorded");
+      expect(types).not.toContain("repetition_blocked");
+    });
+
+    it("keeps repetition_blocked hidden from agents, like the no_op it replaced", async () => {
+      const intent = makeIntent({
+        intentType: "no_op",
+        channelTarget: CHANNEL_ID,
+        privateMotiveSummary: `${REPETITION_GUARD_MARKER}: near-duplicate, blocked structurally.`,
+      });
+      const result = await resolver.resolve(intent, ctx());
+      const blocked = result.committedEvents.find(e => e.type === "repetition_blocked")!;
+
+      expect(blocked.visibility.visibleToAgents).toEqual([]);
+      expect(blocked.visibility.visibleToSpectators).toBe(false);
+      expect(blocked.visibility.visibleToOperators).toBe(true);
+    });
   });
 
   it("commits a valid send_message intent", async () => {

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -445,6 +445,7 @@ describe("PulseScheduler", () => {
     async function runAndReadState(
       intent: ActionIntent,
       outcome: import("@perfectman/shared").ResolvedIntentOutcome,
+      fallbackApplied = false,
     ): Promise<AgentState | null> {
       const sched = buildScheduler(() => ({
         ...makeCannedStep(),
@@ -455,7 +456,7 @@ describe("PulseScheduler", () => {
         intent,
         llmUsage: null,
         latencyMs: 10,
-        fallbackApplied: false,
+        fallbackApplied,
         operatorEvents: [],
       });
       vi.spyOn(intentResolver, "resolve").mockResolvedValue({
@@ -478,6 +479,30 @@ describe("PulseScheduler", () => {
       const state = await runAndReadState(makeIntent("no_op"), "committed");
       expect(state?.lastActionAt).toBeNull();
     });
+
+    // A no_op with fallbackApplied:true means IntentParser substituted it
+    // because the agent's real intent attempt failed (repetition guard,
+    // malformed/truncated JSON, an unresolved target, a provider error on
+    // retry) — categorically different from a genuine "I choose silence"
+    // no_op (fallbackApplied:false). Root-caused via a live capture where
+    // repetition-guard blocks AND separately "No JSON object found in
+    // response" fallbacks (a real deepseek-v4-flash failure mode observed
+    // live) both denied an agent justActed relief, saturating her
+    // cold_start_bootstrap accumulator and forcing needsLLM on her alone
+    // for the rest of the run — see pulse-scheduler.ts's comment.
+    for (const failureMotive of [
+      "Repetition guard: near-duplicate of a message you already sent, even after a retry — blocked structurally.",
+      "Fallback applied: No JSON object found in response",
+    ]) {
+      it(`stamps lastActionAt for a fallback no_op (${failureMotive.split(":")[0]}) — the agent attempted a real act, unlike a genuine silence choice`, async () => {
+        const state = await runAndReadState(
+          makeIntent("no_op", { privateMotiveSummary: failureMotive }),
+          "committed",
+          true,
+        );
+        expect(state?.lastActionAt).toBe(SETTINGS.pulseIntervalMs);
+      });
+    }
 
     it("does not stamp lastActionAt for a committed write_memory (memory-only)", async () => {
       const state = await runAndReadState(makeIntent("write_memory"), "committed");

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -17,6 +17,7 @@ import type {
 import { createId } from "@perfectman/shared";
 import { validateIntentPure } from "@perfectman/engine";
 import { memoryWrittenPayload } from "./memory-written-payload.js";
+import { REPETITION_GUARD_MARKER } from "../agent/repetition-guard.js";
 import type { RateLimitGate } from "./rate-limit-gate.js";
 import type { ChannelRegistry } from "./channel-registry.js";
 
@@ -357,6 +358,21 @@ function buildChannelCreatedEvent(
   return [createEvent, ...inviteEvents];
 }
 
+/**
+ * A no_op that exists only because the repetition guard blocked a degenerate
+ * message is not the same fact as an agent choosing to stay quiet, and the two
+ * must not share an event type — see the `repetition_blocked` note in
+ * event.types.ts. The guard marks its own fallback motive with a documented
+ * prefix (repetition-guard.ts), which is the signal this reads.
+ */
+function isRepetitionBlockedIntent(intent: ActionIntent): boolean {
+  return (
+    intent.intentType === "no_op" &&
+    typeof intent.privateMotiveSummary === "string" &&
+    intent.privateMotiveSummary.startsWith(REPETITION_GUARD_MARKER)
+  );
+}
+
 function buildNoOpEvent(
   intent: ActionIntent,
   ctx: ResolveContext,
@@ -365,7 +381,7 @@ function buildNoOpEvent(
     simulationId: ctx.simulationId,
     channelId: ctx.channelId,
     actorId: intent.actorId,
-    type: "no_op_recorded",
+    type: isRepetitionBlockedIntent(intent) ? "repetition_blocked" : "no_op_recorded",
     payload: {
       intentType: intent.intentType,
       privateMotiveSummary: intent.privateMotiveSummary,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -351,7 +351,23 @@ export class PulseScheduler {
             : resolved.outcome === "fallback_committed"
               ? intent.fallbackIfBlocked
               : undefined;
-        if (committedActType && OUTWARD_SOCIAL_ACT_TYPES.has(committedActType)) {
+        // A no_op with `runtimeOutput.fallbackApplied` is not a genuine "I
+        // choose silence" decision — the agent's real intent attempt failed
+        // (repetition guard, malformed/truncated JSON, an unresolved target,
+        // a provider retry) and IntentParser substituted it. Without this,
+        // the agent never gets justActed relief, her decay-exempt
+        // cold_start_bootstrap accumulator saturates and never comes back
+        // down, and scoreAttention's cooldown-blind cadence score then forces
+        // needsLLM every subsequent pulse forever — a real production
+        // lockup, root-caused via two separate live captures (a repetition
+        // guard block, then independently a "No JSON object found in
+        // response" parse failure) that both monopolized every pulse after
+        // the affected agent's first blocked turn. `fallbackApplied` is the
+        // general signal IntentParser already computes for exactly this
+        // distinction — prefer it over pattern-matching specific fallback
+        // reasons.
+        const attemptedRealAct = resolved.outcome === "committed" && runtimeOutput.fallbackApplied;
+        if ((committedActType && OUTWARD_SOCIAL_ACT_TYPES.has(committedActType)) || attemptedRealAct) {
           stepResult.updatedAgentState.lastActionAt = now;
         }
       }

--- a/packages/shared/src/event/event.types.ts
+++ b/packages/shared/src/event/event.types.ts
@@ -12,6 +12,15 @@ export type EventType =
   | "intent_blocked"
   | "memory_written"
   | "no_op_recorded"
+  /**
+   * A turn the repetition guard blocked structurally — the model produced a
+   * near-duplicate of something the agent already said and could not fix it on
+   * retry. Deliberately NOT `no_op_recorded`: a no-op is a social act ("silence
+   * is a social signal"), while this is the generator degenerating. Folding the
+   * two together made both unmeasurable — offline runs showed 72-98% "silence"
+   * that was really the guard firing, and probes read it as chosen lurking.
+   */
+  | "repetition_blocked"
   | "private_motive_summary"
   | "operator_warning"
   | "llm_failure"

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -13,9 +13,17 @@ import type { AttractorState } from "../constants/stagnation.js";
  * `rate_limit_hit` was removed — the one type declared with no producer
  * anywhere in packages/server/src (RateLimitGate computes block state but
  * never emits an operator event for it).
+ *
+ * `llm_retry_recovered` exists because a first attempt that violated a guard
+ * and was fixed by a retry used to emit nothing at all: `llm_failure` covers
+ * only the terminal case, so every offline fallback count was reported as 0
+ * against transcripts full of `Fallback applied` lines. Recovery is not free —
+ * it costs a wire call and it means the model got it wrong once — so it is
+ * recorded rather than swallowed.
  */
 export const OPERATOR_EVENT_TYPES = [
   "llm_failure",
+  "llm_retry_recovered",
   "llm_budget_exceeded",
   "intent_blocked",
   "intent_delayed",


### PR DESCRIPTION
## What

Turns a repetition-guard block into its own committed fact instead of a `no_op_recorded`:

- `repetition_blocked` event type; `IntentResolver.buildNoOpEvent` emits it when the motive carries `REPETITION_GUARD_MARKER`, `no_op_recorded` stays for chosen silence.
- `llm_retry_recovered` operator event from `ActionIntentStep` when the retry fixed `near_duplicate`/`unresolved_target`; surfaced as `ScenarioRunArtifact.recoveredFallbacks` and `BenchReport.recoveredFallbacks`.
- `PulseScheduler` stamps `lastActionAt` for a fallback no_op too (`runtimeOutput.fallbackApplied`): without relief `cold_start_bootstrap` saturates and the agent forces `needsLLM` every following pulse — two live captures, one guard block and one `No JSON object found` parse failure, both monopolized the room.
- Probes map the type to `blocked_repeat`, never `silence`; `render/html.ts` labels it `repetição bloqueada`; `sweep-repetition`/`sweep-temperature` count both shapes so older recordings still measure.
- Five tests: resolver emits `repetition_blocked`, genuine no_op unchanged, fallback no_op stamps `lastActionAt` (guard and parse-failure), bench folds recovered fallbacks into the report.

## Why

A guard block narrated as chosen silence, a degenerate run scoring as behaviorally diverse, and an agent that never got relief after a blocked turn all came from the same conflation.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+5)
- `hoc_fatia_que_nao_existe` on `deepseek/deepseek-v4-flash`: the two parse-failure no_ops in the capture now stamp `lastActionAt` (they were previously invisible as `0 fallbacks`). The stamp alone did not end that run's monopoly — `needsLLM` has other owners; tracked separately.
