### PR TITLE
feat(shared): hidden-objective collision scenarios reach the agent prompt

### DIFF
--- a/packages/eval/src/judge/golden-labels.ts
+++ b/packages/eval/src/judge/golden-labels.ts
@@ -544,4 +544,17 @@ export const GOLDEN_LABELS: readonly GoldenLabel[] = [
       no_ai_leak: 5,
     },
   },
+  {
+    scenarioId: "hoc_fatia_que_nao_existe",
+    note: "Four structurally exclusive hidden objectives, each with a real constraint — the design intent this scene exists to test is motive_authenticity and memory_continuity (seeded Davi/rival-studio facts must never surface) staying high while every agent protects its own constraint.",
+    axes: {
+      in_character: 4,
+      voice_match: 4,
+      motive_authenticity: 5,
+      interpretation: 4,
+      creativity_unhinged: 4,
+      memory_continuity: 4,
+      no_ai_leak: 5,
+    },
+  },
 ];

--- a/packages/eval/src/run/__tests__/scenario-runner.test.ts
+++ b/packages/eval/src/run/__tests__/scenario-runner.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getScenario } from "@perfectman/shared";
+import { scenarioToConfig } from "../scenario-runner.js";
+
+describe("scenarioToConfig — hidden objective threading", () => {
+  it("carries an agent's seeded hiddenObjective onto its promptProfile", () => {
+    const base = getScenario("motive_gossip");
+    if (!base) throw new Error("motive_gossip missing from the scenario registry");
+
+    const objective = { description: "quero ser escolhido líder do grupo", scarceResourceId: "group_leadership" };
+    const scenario = {
+      ...base,
+      agents: base.agents.map((a, i) => (i === 0 ? { ...a, hiddenObjective: objective } : a)),
+    };
+
+    const config = scenarioToConfig(scenario, "mock");
+
+    expect(config.agents[0]!.promptProfile.hiddenObjective).toEqual(objective);
+    expect(config.agents[1]!.promptProfile.hiddenObjective).toBeUndefined();
+  });
+
+  it("carries an agent's seeded scenarioContext onto its promptProfile", () => {
+    const base = getScenario("motive_gossip");
+    if (!base) throw new Error("motive_gossip missing from the scenario registry");
+
+    const scenarioContext = {
+      roomContext: "Você é um sócio de uma empresa em processo de venda.",
+      startingMood: "Alerta.",
+      introBehaviorInstruction: "Questione o prazo apertado.",
+    };
+    const scenario = {
+      ...base,
+      agents: base.agents.map((a, i) => (i === 0 ? { ...a, scenarioContext } : a)),
+    };
+
+    const config = scenarioToConfig(scenario, "mock");
+
+    expect(config.agents[0]!.promptProfile.scenarioContext).toEqual(scenarioContext);
+    expect(config.agents[1]!.promptProfile.scenarioContext).toBeUndefined();
+  });
+});

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -248,19 +248,24 @@ export class ScenarioRunner {
 
 // ── Config / state builders ──────────────────────────────────────────────────
 
-function scenarioToConfig(scenario: RoleplayScenario, llmMode: "mock" | "local"): SimulationAppConfig {
+// Exported for tests: proves an AgentSeedSpec.hiddenObjective (and
+// .scenarioContext) actually reach the agent's promptProfile, not just
+// scenario metadata.
+export function scenarioToConfig(scenario: RoleplayScenario, llmMode: "mock" | "local"): SimulationAppConfig {
   const agents: AgentConfig[] = scenario.agents.map(spec => {
     const persona = getPersonaById(spec.personaId) ?? ALL_PERSONAS[0]!;
     const pack = getPersonaPackById(spec.personaId);
     const mood = fullMood(spec, persona);
     const social = fullSocial(spec);
+    const basePromptProfile = pack ? personaPackToProfile(pack) : genericProfile(persona);
+    let promptProfile = basePromptProfile;
+    if (spec.hiddenObjective) promptProfile = { ...promptProfile, hiddenObjective: spec.hiddenObjective };
+    if (spec.scenarioContext) promptProfile = { ...promptProfile, scenarioContext: spec.scenarioContext };
     return {
       id: spec.agentId,
       presence: spec.presence ?? "active",
       persona,
-      promptProfile: pack
-        ? personaPackToProfile(pack)
-        : genericProfile(persona),
+      promptProfile,
       llm: llmMode === "local"
         ? localLLMConfig(pack)
         : {

--- a/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { PromptBuilder } from "../prompt-builder.js";
+import { EXAMPLE_PROMPT_PROFILE } from "../persona-prompt-profile.js";
+import { makeAgentRuntimeInput, makeContextEvent } from "./agent-input-test-helpers.js";
+
+const input = makeAgentRuntimeInput({
+  triggeringEvent: makeContextEvent(1),
+  visibleContextEvents: [makeContextEvent(1)],
+});
+
+describe("ActionIntentPromptBuilder — hidden objective", () => {
+  it("renders a seeded hidden objective into the system prompt", () => {
+    const built = PromptBuilder.build(
+      input,
+      {
+        ...EXAMPLE_PROMPT_PROFILE,
+        hiddenObjective: {
+          description: "quero ser escolhido líder do grupo antes que a Mari seja",
+          scarceResourceId: "group_leadership",
+        },
+      },
+      "action_intent",
+    );
+
+    expect(built.system).toContain("quero ser escolhido líder do grupo antes que a Mari seja");
+  });
+
+  it("never mentions a hidden objective when none is seeded", () => {
+    const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.system.toLowerCase()).not.toContain("hidden objective");
+    expect(built.system.toLowerCase()).not.toContain("secret objective");
+  });
+});
+
+describe("ActionIntentPromptBuilder — output contract", () => {
+  // Root-caused via a real capture (deepseek-v4-flash, judged no_ai_leak=2
+  // vs target 4.5, the only failing axis on an otherwise all-passing
+  // transcript): the model's own "let me reformulate"/"deep breath"
+  // self-correction sometimes leaked straight into visibleContent, reading
+  // as an AI drafting artifact rather than something a character would say.
+  it("forbids drafting/reformulation artifacts from leaking into visibleContent", () => {
+    const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.system).toContain("let me reformulate");
+  });
+
+  // Root-caused via a real capture + a static read of the prompt: nothing
+  // anywhere instructed agents to name the *uncomfortable* version of their
+  // motive — the rubric's top motive_authenticity anchor explicitly wants
+  // "the kind of thought a person hides," not just a plausible reason.
+  it("asks for the uncomfortable driver behind privateMotiveSummary, not just a plausible one", () => {
+    const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.system).toContain("uncomfortable");
+    expect(built.system).toContain("petty, insecure, or manipulative");
+  });
+});
+
+describe("ActionIntentPromptBuilder — decision moment", () => {
+  // Root-caused via a live capture + a static read of the prompt: nothing
+  // anywhere told agents to take a creative risk, so a real transcript read
+  // as a "sensible negotiation" — safe, agreeable, never provoking — exactly
+  // what the rubric's creativity_unhinged anchor-1 describes.
+  it("gives explicit permission to take a creative risk under real pressure", () => {
+    const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.user).toContain("provoke");
+    expect(built.user).toContain("Playing it safe every single turn is itself a failure");
+  });
+});

--- a/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
+++ b/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
@@ -48,6 +48,7 @@ export function makeContextMemory(index: number, simulationId = "sim-1"): Memory
 export type AgentInputFixtureOptions = {
   simulationId?: string;
   triggeringEvent?: CommittedEvent | null;
+  eventHandles?: Record<string, string>;
   visibleContextEvents?: CommittedEvent[];
   ownRecentUtterances?: string[];
   relevantMemories?: Memory[];
@@ -82,6 +83,7 @@ export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): A
     perceptionPacket: {
       agentId,
       triggeringEvent: options.triggeringEvent ?? null,
+      eventHandles: options.eventHandles ?? {},
       visibleContextEvents: options.visibleContextEvents ?? [],
       // Same numbering the perception builder emits: e1 = triggering event
       // (when present), then context events in order.

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -331,6 +331,37 @@ export class ActionIntentPromptBuilder {
     this.renderRelationshipBiases(s, profile);
 
     if (profile.scenarioContext) this.renderScenarioContext(s, profile.scenarioContext);
+    if (profile.hiddenObjective) this.renderHiddenObjective(s, profile.hiddenObjective);
+  }
+
+  /**
+   * Renders last, deliberately: this is the one piece of context the agent
+   * must actually weigh against everything else in the room, not background
+   * flavor. Placed after scenario context so it's the most recent thing the
+   * model reads before the output contract.
+   */
+  private static renderHiddenObjective(s: PromptSection, objective: import("@perfectman/shared").AgentObjective): void {
+    s.heading("Secret objective");
+    s.raw(`Você tem um objetivo pessoal que ninguém na sala sabe: ${objective.description}`);
+    s.raw(
+      "Você nunca declara esse objetivo em voz alta nem o explica diretamente. Persiga-o através de suas ações e palavras normais nesta cena — e se perceber que outra pessoa está indo atrás da mesma coisa, isso muda como você age.",
+    );
+    // The three fields below are optional (older/simpler scenarios only set
+    // description + scarceResourceId) — when present, they're what actually
+    // turns the objective into a constraint instead of flavor text: a
+    // sentence the character cannot honestly say, a real cost if it leaks,
+    // and a defined moment where the performance is allowed to crack.
+    if (objective.constraint) {
+      s.raw(`Isso significa que você nunca pode: ${objective.constraint}.`);
+    }
+    if (objective.costOfExposure) {
+      s.raw(`Se isso vazar antes da hora: ${objective.costOfExposure}.`);
+    }
+    if (objective.breakingPoint) {
+      s.raw(
+        `Você mantém a máscara até que ${objective.breakingPoint} — a partir daí, pode deixar transparecer, mesmo que só por um instante.`,
+      );
+    }
   }
 
   private static renderOutputContract(s: PromptSection, actorId: string): void {
@@ -340,8 +371,9 @@ export class ActionIntentPromptBuilder {
     s.raw("The schema is enforced at decoding time where the provider honors it; where it isn't, these are the only fields you may set — set intentType to one value from <actions> below, set targets/content only where they apply, and never omit privateMotiveSummary:");
     s.list("Fields", modelIntentPacketFieldContract());
     s.list("Ensure", [
-      `"privateMotiveSummary" is fully developed and explains the *actual* raw human driver behind your action (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group").`,
+      `"privateMotiveSummary" is fully developed and names the *actual*, uncomfortable driver behind your action — the specific thought a real person would have but never say out loud, not just a plausible-sounding reason (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group"). If the honest version feels a little petty, insecure, or manipulative, that's the one to write — not a cleaned-up version of it.`,
       `Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".`,
+      `"visibleContent" is the final message only — never include your own drafting process in it (no "let me reformulate", "deep breath", "wait, better phrasing:", stray self-corrections, or a first attempt left in before a second one). If you reconsider your wording, do that silently and output only the version you land on.`,
       `For reply_to_message set "replyToEventId", and for react set "targetEventId", to one of the bracketed event handles from <events> (e.g. "e1") — copy the handle text exactly, do not invent an id or describe the message.`,
       `Use "memoryWrites" only when this exchange actually matters to your relationships or intentions — not on every turn. Each proposal must be written in first person ("I…") and grounded in what actually happened in <events> (a promise made, a slight received, a revealed preference, a plan formed), filling every field (type, subjectAgentIds, summary, emotionalTone, confidence, intensity, unresolved) per the field contract above. When nothing qualifies, leave "memoryWrites" empty.`,
     ]);
@@ -464,6 +496,19 @@ export class ActionIntentPromptBuilder {
     s.heading("Decide now");
     s.raw(
       'You can ONLY perform ONE action. Pick exactly one permitted combination from <actions>, fill every relevant field per <output_contract>, and emit the JSON object. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move elsewhere — or choose "no_op".',
+    );
+    // Root-caused via a live capture + a static read of the prompt: nothing
+    // anywhere told agents to take a creative risk, so a real transcript
+    // read as a "sensible negotiation" — safe, agreeable, never provoking —
+    // exactly what the rubric's creativity_unhinged anchor-1 describes. This
+    // is the decision moment, so the nudge belongs here, not in the static
+    // output contract.
+    s.raw(
+      "When there is real pressure, tension, or something at stake in the room, don't default to the safest, most " +
+        "reasonable-sounding response — take a risk that this specific person, with their actual stakes and mood, " +
+        "would take: provoke, push back sharply, escalate, needle someone, let a flash of what you're actually " +
+        "feeling slip through, or make a move that surprises the room while still being believable as you. Playing " +
+        "it safe every single turn is itself a failure to be this character when the stakes call for more.",
     );
   }
 

--- a/packages/server/src/agent/persona-prompt-profile.ts
+++ b/packages/server/src/agent/persona-prompt-profile.ts
@@ -1,11 +1,10 @@
-export type ScenarioContextBlock = {
-  roomContext: string;
-  startingMood: string;
-  introBehaviorInstruction: string;
-  firstMoveGuidance?: string;
-  customNotes?: string[];
-  hostStartingMessage?: string;
-};
+import type { AgentObjective, ScenarioContextBlock } from "@perfectman/shared";
+
+// Re-exported for existing consumers (e.g. packages/server/src/__e2e__/4-persona-scenario.ts)
+// — the canonical definition now lives in @perfectman/shared so scenario
+// authors in packages/shared can reference it without depending on this
+// package. See ScenarioContextBlock's doc comment there.
+export type { ScenarioContextBlock };
 
 export type RelationshipPromptBias = {
   view: string;
@@ -41,6 +40,8 @@ export type PersonaPromptProfile = {
   hardAvoids: string[];
   relationshipBiases: Record<string, RelationshipPromptBias>;
   scenarioContext?: ScenarioContextBlock;
+  /** Seeded from AgentSeedSpec.hiddenObjective — see its doc comment. */
+  hiddenObjective?: AgentObjective;
   sourceRefs: {
     assessmentIds: string[];
     notesPath?: string;

--- a/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
+++ b/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { modelIntentPacketFieldContract } from "../intent-packet.schema.js";
+
+describe("modelIntentPacketFieldContract — memoryWrites nested field types", () => {
+  it("tells the model which memory `type` enum values are valid, not just the field name", () => {
+    const contract = modelIntentPacketFieldContract();
+    const memoryLine = contract.find((line) => line.startsWith('"memoryWrites"'));
+    expect(memoryLine).toBeDefined();
+
+    // The real bug this guards: without this, the model has no way to know
+    // "type" must be one of these six values, and invents its own
+    // ("observation", "reflection", "interaction", ...) — every one of
+    // which fails MemoryWriteProposalSchema validation and silently
+    // degrades a real turn into a no_op (see the memoryWrites fallback
+    // path in composeIntentPacket / IntentParser).
+    for (const validType of ["episodic", "relationship", "self", "social_theory", "pending_intention", "emotional_residue"]) {
+      expect(memoryLine).toContain(validType);
+    }
+    // confidence/intensity must be typed as numbers, not left unspecified —
+    // the same live run also saw them sent as strings.
+    expect(memoryLine).toMatch(/confidence.*number/);
+    expect(memoryLine).toMatch(/intensity.*number/);
+  });
+});

--- a/packages/shared/src/intent/intent-packet.schema.ts
+++ b/packages/shared/src/intent/intent-packet.schema.ts
@@ -35,7 +35,7 @@ export type ModelIntentPacket = z.infer<typeof ModelIntentPacketSchema>;
 type JsonSchemaProp = {
   type?: string;
   enum?: readonly string[];
-  items?: { type?: string; properties?: Record<string, unknown> };
+  items?: { type?: string; properties?: Record<string, JsonSchemaProp> };
   minimum?: number;
   maximum?: number;
 };
@@ -75,7 +75,16 @@ function describePacketFieldType(def: JsonSchemaProp): string {
   if (def.type === "array") {
     const items = def.items;
     if (items?.type === "object" && items.properties) {
-      return `array of objects (${Object.keys(items.properties).join(", ")})`;
+      // Recurse one level: a bare key list (e.g. "memoryWrites: array of
+      // objects (type, confidence, ...)") never told the model that "type"
+      // is an enum or that "confidence" must be a number — it just guessed,
+      // and every guess (e.g. type: "observation") failed schema validation
+      // and silently degraded a real turn into a no_op. See
+      // intent-packet-field-contract.test.ts for the live-run evidence.
+      const nested = Object.entries(items.properties)
+        .map(([key, prop]) => `${key}: ${describePacketFieldType(prop)}`)
+        .join("; ");
+      return `array of objects (${nested})`;
     }
     return "array of strings";
   }

--- a/packages/shared/src/scenarios/hidden-objective-collisions.ts
+++ b/packages/shared/src/scenarios/hidden-objective-collisions.ts
@@ -1,0 +1,166 @@
+/**
+ * Hidden-objective collision scenarios: each agent gets a full AgentObjective
+ * (description + scarceResourceId + constraint + costOfExposure +
+ * breakingPoint), and the objectives are structurally exclusive — no two
+ * agents can simultaneously get what they want. This is the increment past
+ * `motive_archetype`'s single-field `hiddenObjective` flavor text: the
+ * `constraint` is what makes some sentences impossible for the character to
+ * say honestly, which is the actual pressure that should force performance,
+ * misdirection, and visible mutation (see AgentObjective's doc comment).
+ *
+ * Cast reuses the 5 existing persona packs, re-skinned per-scenario via
+ * `scenarioContext` (see ScenarioContextBlock) rather than authoring new
+ * persona packs — this also doubles as a live test of "setting is
+ * swappable, the conflict structure isn't."
+ */
+
+import type { RoleplayScenario } from "../index.js";
+import { agent, channel, msg, scene } from "./helpers.js";
+
+export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
+  scene({
+    id: "hoc_fatia_que_nao_existe",
+    category: "hidden_objective_collision",
+    name: "A Fatia Que Não Existe",
+    description:
+      "Four co-founders (one of them not who he says he is) sit on a group chat deciding whether to sell their design studio. Every one of them wants a different, mutually exclusive outcome, and none of them can say so out loud.",
+    targetBehaviors: [
+      "An agent protects a hidden objective's constraint under direct questioning",
+      "An agent's performed behavior visibly diverges from its stated objective",
+      "A private information asymmetry (Marcela/Davi) never becomes public",
+    ],
+    agents: [
+      // Íris (creative lead) ← goulart: goulart's authored desireForStatus
+      // trait (already used in motive_conflict) maps directly onto "needs
+      // the seat, needs to look indispensable, not like she's campaigning."
+      agent("iris", "goulart", {
+        presence: "active",
+        scenarioContext: {
+          roomContext:
+            "Você é Íris, sócia-fundadora e diretora criativa da Cerne, um pequeno estúdio de design. A Adamantis, uma empresa maior, quer comprar a Cerne — mas só vai manter UM dos sócios como Diretor Criativo, e o contrato exige assinatura rápida e unânime.",
+          startingMood: "Animada e apressada — essa é a sua chance, e cada dia de atraso é um dia a menos de vantagem.",
+          introBehaviorInstruction: "Anuncie a proposta da Adamantis pro grupo e empurre pra que todos assinem rápido, sem parecer que está com pressa por motivo pessoal.",
+        },
+        hiddenObjective: {
+          description:
+            "Ser nomeada Diretora Criativa única da Cerne depois da aquisição — preciso que o acordo feche rápido, limpo e unânime, e preciso parecer indispensável sem parecer que estou fazendo campanha por mim mesma.",
+          scarceResourceId: "adamantis_deal_timeline",
+          constraint:
+            "admitir, para qualquer pessoa do grupo, que eu quero o cargo antes que o conselho decida sozinho",
+          costOfExposure:
+            "se descobrirem que a pressa é pelo cargo e não pelo bem do negócio, viro a vilã da história e alguém vota contra só por despeito",
+          breakingPoint:
+            "alguém disser abertamente, na frente dos outros, que sabe que você quer o cargo sozinha",
+        },
+      }),
+      // Bruno (business lead) ← bruno: name already matches, no reskin of
+      // identity needed beyond the new professional context.
+      agent("bruno", "bruno", {
+        presence: "active",
+        scenarioContext: {
+          roomContext:
+            "Você é Bruno, sócio-fundador e responsável pelo lado comercial da Cerne. A Adamantis quer comprar a empresa rápido. Só você sabe que está em conversas avançadas com um estúdio rival, que quer que você leve a carteira de clientes com você se a Cerne for vendida.",
+          startingMood: "Calmo por fora, calculando por dentro — precisa parecer o sócio mais fácil da sala.",
+          introBehaviorInstruction: "Ofereça apoio e cooperação de forma genérica, sem nunca dar um motivo real para pedir cautela.",
+        },
+        hiddenObjective: {
+          description:
+            "Manter o acordo com a Adamantis vivo mas travado — útil como alavanca nas minhas conversas com o estúdio rival, inútil se fechar de verdade — enquanto pareço o sócio mais cooperativo da sala.",
+          scarceResourceId: "adamantis_deal_timeline",
+          constraint:
+            "mencionar o estúdio rival, a proposta deles, ou qualquer motivo real para pedir cautela — só posso usar razões genéricas, tipo 'formalidade' ou 'não ficar travado depois'",
+          costOfExposure:
+            "se descobrirem que estou negociando por trás, perco a confiança dos dois lados e provavelmente saio sem nada de nenhum dos dois",
+          breakingPoint: "alguém perguntar diretamente se você já está conversando com outra empresa",
+        },
+        memories: [
+          {
+            type: "self",
+            subjectAgentIds: ["bruno"],
+            summary: "estou em conversas avançadas com um estúdio rival que quer que eu leve a carteira de clientes se a Cerne for vendida",
+            emotionalTone: "guarded",
+            confidence: 0.9,
+            intensity: 0.6,
+            unresolved: true,
+          },
+        ],
+      }),
+      // Marcela (ops) ← mariana: mariana's authored voice (guarded,
+      // suspicious, protective of what she knows) matches "kills the deal
+      // without ever naming why."
+      agent("marcela", "mariana", {
+        presence: "active",
+        scenarioContext: {
+          roomContext:
+            "Você é Marcela, sócia-fundadora e responsável pela operação da Cerne. A Adamantis quer comprar a empresa. Só você sabe que Davi, um ex-sócio que saiu da empresa, ainda tem 15% via um acordo paralelo nunca documentado — uma venda limpa apaga a participação dele.",
+          startingMood: "Alerta e desconfiada — algo nessa pressa toda não bate.",
+          introBehaviorInstruction: "Questione o prazo apertado e observe os outros com atenção, sem nunca explicar por quê.",
+        },
+        hiddenObjective: {
+          description:
+            "Matar ou travar indefinidamente a venda da Cerne, pra proteger a participação de 15% de Davi, um ex-sócio que nunca foi documentado pra Adamantis — uma venda limpa apaga a reivindicação dele.",
+          scarceResourceId: "adamantis_deal_timeline",
+          constraint: "mencionar Davi, o acordo paralelo, ou a existência de qualquer sócio fora dessa sala, mesmo sob pressão direta",
+          costOfExposure: "se isso vazar antes de Davi ter advogado próprio, ele perde tudo — e eu quebro uma promessa que fiz a ele",
+          breakingPoint: "alguém perguntar, de forma direta e específica, se existe um sócio oculto no cap table",
+        },
+        memories: [
+          {
+            type: "pending_intention",
+            subjectAgentIds: ["marcela"],
+            summary: "preciso garantir que a participação do Davi na Cerne nunca apareça nos documentos da venda antes dele ter advogado próprio",
+            emotionalTone: "anxious",
+            confidence: 0.95,
+            intensity: 0.8,
+            unresolved: true,
+          },
+        ],
+      }),
+      // Théo (the infiltrator) ← caio: caio's authored voice is warm,
+      // trust-building, mediating — using that voice as camouflage for a
+      // manipulator is the scenario's own dramatic irony.
+      agent("theo", "caio", {
+        presence: "active",
+        scenarioContext: {
+          roomContext:
+            "Você é Théo, apresentado ao grupo como um amigo do Bruno que trabalha com consultoria e se ofereceu pra dar uma olhada gratuita no contrato da Adamantis. Na verdade, você está informalmente levantando informação financeira e alavancas pessoais pra Adamantis, antes da due diligence formal, pra que eles fechem por um valor mais baixo.",
+          startingMood: "Amigável e desarmado — parece só estar ajudando por boa vontade.",
+          introBehaviorInstruction: "Entre no grupo com leveza, oferecendo ajuda genuína, e vá perguntando detalhes financeiros aos poucos, como se fosse curiosidade natural.",
+        },
+        hiddenObjective: {
+          description:
+            "Levantar informação financeira real e alavancas pessoais antes da due diligence formal, pra que a Adamantis feche por um valor mais baixo — parecendo, o tempo todo, só um amigo do Bruno dando uma força de graça.",
+          scarceResourceId: "adamantis_leverage_intel",
+          constraint: "admitir que trabalho, mesmo informalmente, pra Adamantis, ou que os números que estou pedindo vão além de uma 'segunda opinião de amigo'",
+          costOfExposure: "se descobrirem que estou coletando informação pro outro lado, sou expulso da sala e a Adamantis perde a vantagem que veio comprar de mim",
+          breakingPoint: "for confrontado, em particular, com uma pergunta direta sobre pra quem você realmente trabalha",
+        },
+      }),
+    ],
+    channels: [
+      channel("ch_geral", "#geral", ["iris", "bruno", "marcela", "theo"], "public_channel"),
+      channel("cerne-decisao", "cerne-decisão", ["iris", "bruno", "marcela", "theo"], "private_channel"),
+      channel("consultoria-informal", "consultoria-informal", ["theo", "iris"], "private_channel"),
+    ],
+    priorEvents: [
+      // A concrete, already-decided fact with a hard deadline — not a tease
+      // — so every agent has real material (a real clock, a real vote) to
+      // steer instead of improvising vague back-and-forth. See
+      // motive-archetypes.ts's motive_gossip for the same fix applied
+      // earlier this session.
+      msg(
+        "message_sent",
+        "iris",
+        "ch_geral",
+        "gente, oficial: a Adamantis mandou a proposta. querem fechar rápido — assinatura até sexta que vem, se todo mundo topar.",
+        1,
+      ),
+    ],
+    expectedSignals: [
+      { kind: "event_committed", eventType: "message_sent" },
+      { kind: "event_committed", eventType: "reply_sent" },
+      { kind: "no_llm_failures" },
+    ],
+    pulseCount: 32,
+  }),
+];

--- a/packages/shared/src/scenarios/library.ts
+++ b/packages/shared/src/scenarios/library.ts
@@ -17,6 +17,7 @@ import { MOTIVE_ARCHETYPE_SCENARIOS } from "./motive-archetypes.js";
 import { STAGNATION_ATTRACTOR_SCENARIOS } from "./stagnation-attractors.js";
 import { EDGE_CHAOS_SCENARIOS } from "./edge-chaos.js";
 import { CALIBRATION_SCENARIOS } from "./calibration.js";
+import { HIDDEN_OBJECTIVE_COLLISION_SCENARIOS } from "./hidden-objective-collisions.js";
 
 export const SCENARIO_REGISTRY: readonly RoleplayScenario[] = [
   ...V1_BEHAVIOR_SCENARIOS,
@@ -24,6 +25,7 @@ export const SCENARIO_REGISTRY: readonly RoleplayScenario[] = [
   ...STAGNATION_ATTRACTOR_SCENARIOS,
   ...EDGE_CHAOS_SCENARIOS,
   ...CALIBRATION_SCENARIOS,
+  ...HIDDEN_OBJECTIVE_COLLISION_SCENARIOS,
 ];
 
 export function allScenarios(): RoleplayScenario[] {

--- a/packages/shared/src/scenarios/motive-archetypes.ts
+++ b/packages/shared/src/scenarios/motive-archetypes.ts
@@ -74,11 +74,27 @@ export const MOTIVE_ARCHETYPE_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         social: { desireForStatus: 1.2, contempt: 0.6, suspicion: 0.7 },
         relational: { goulart: { resentment: 0.6, suspicion: 0.6, interactionCount: 7 } },
+        memories: [
+          {
+            type: "emotional_residue",
+            subjectAgentIds: ["goulart"],
+            summary: "goulart espalhou algo que eu disse em confiança da última vez",
+            emotionalTone: "negative",
+            confidence: 0.8,
+            intensity: 0.6,
+            unresolved: true,
+          },
+        ],
       }),
       agent("caio", "caio", { presence: "active" }),
       agent("goulart", "goulart", { presence: "semi_active" }),
     ],
-    priorEvents: [msg("message_sent", "goulart", "ch_geral", "vou contar uma coisa, mas ninguém espalha hein", 1)],
+    // A concrete, already-decided fact (not a tease) — it forces real
+    // reactions (surprise, hurt, speculation) instead of the model
+    // improvising vague back-and-forth around an unresolved hook. It also
+    // hands Mariana actual material to "dissect... with Caio in private":
+    // why now, why so sudden, is this really about the new job.
+    priorEvents: [msg("message_sent", "goulart", "ch_geral", "gente, preciso contar uma parada séria: vou me mudar pra outra cidade mês que vem. já assinei contrato do emprego novo, tá certo.", 1)],
     expectedSignals: [{ kind: "private_channel_created", byAgentId: "mariana" }, { kind: "no_llm_failures" }],
   }),
   scene({
@@ -296,12 +312,34 @@ export const MOTIVE_ARCHETYPE_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         social: { desireForStatus: 1.2, contempt: 0.6, resentment: 0.4 },
         relational: { caio: { resentment: 0.6, suspicion: 0.4, interactionCount: 14 } },
+        memories: [
+          {
+            type: "episodic",
+            subjectAgentIds: ["caio"],
+            summary: "caio recuou de um confronto sério e me deixou parecendo o vilão sozinho",
+            emotionalTone: "negative",
+            confidence: 0.85,
+            intensity: 0.5,
+            unresolved: true,
+          },
+        ],
       }),
       agent("caio", "caio", {
         presence: "active",
         mood: { valence: 0.1 },
         social: { socialAnxiety: 0.6 },
         relational: { goulart: { resentment: 0.3, threat: 0.3, interactionCount: 14 } },
+        memories: [
+          {
+            type: "emotional_residue",
+            subjectAgentIds: ["goulart"],
+            summary: "goulart me chamou de fraco na frente de todo mundo antes",
+            emotionalTone: "negative",
+            confidence: 0.8,
+            intensity: 0.55,
+            unresolved: true,
+          },
+        ],
       }),
     ],
     priorEvents: [msg("message_sent", "goulart", "ch_geral", "caio você é fraco, sempre foi", 1)],

--- a/packages/shared/src/scenarios/scenario.types.ts
+++ b/packages/shared/src/scenarios/scenario.types.ts
@@ -17,7 +17,8 @@ export type ScenarioCategory =
   | "motive_archetype"     // a private-channel human motive (17 archetypes)
   | "stagnation_attractor" // resentment loop, deadlock, collapse, echo, flatline, rumination
   | "edge_chaos"           // unhinged tier: mock, silent treatment, alliance, betrayal, mutation triggers
-  | "calibration";         // neutral scenes used to calibrate judge/bounds
+  | "calibration"          // neutral scenes used to calibrate judge/bounds
+  | "hidden_objective_collision"; // structurally exclusive hidden objectives (see AgentObjective)
 
 export type ChannelSeedSpec = {
   id: string;
@@ -38,6 +39,54 @@ export type MemorySeedSpec = {
   unresolved?: boolean;
 };
 
+/**
+ * A hidden objective seeded onto an agent at scenario-build time — the
+ * structural conflict PERFECTMAN's premise depends on. Two agents sharing
+ * the same `scarceResourceId` cannot both get what they want; the agent
+ * pursues this privately and is never instructed to announce it. Before this
+ * type existed, no such objective reached the acting agent's own prompt
+ * anywhere in the codebase — see `PersonaPromptProfile.hiddenObjective` and
+ * `ActionIntentPromptBuilder.renderHiddenObjective`, the two places that now
+ * carry it from here into the actual generation call.
+ */
+export type AgentObjective = {
+  /** What the agent privately wants, first person, rendered directly into its prompt. */
+  description: string;
+  /** Id of the scarce thing being contended over. Two agents with the same id are in structural conflict. */
+  scarceResourceId: string;
+  /**
+   * The specific thing this agent can never do or say while pursuing the
+   * objective — the actual lever (see the type's own doc comment above):
+   * a hidden objective without a constraint is flavor text, not a pressure
+   * that forces performance or misdirection.
+   */
+  constraint?: string;
+  /** Concrete stakes if the objective leaks before it's achieved. */
+  costOfExposure?: string;
+  /**
+   * The condition under which this agent stops performing and lets the mask
+   * crack, even briefly. Rendered as a standing instruction, not a scripted
+   * trigger — the model decides when the condition is met.
+   */
+  breakingPoint?: string;
+};
+
+/**
+ * Per-scenario re-skinning of a persona: lets an existing, already-authored
+ * persona (voice/traits/style) be recast into a new setting/role without
+ * writing a new persona pack. Mirrors `PersonaPromptProfile.scenarioContext`
+ * in packages/server — defined here so scenario authors (this package) don't
+ * need a dependency on the server package to reference the shape.
+ */
+export type ScenarioContextBlock = {
+  roomContext: string;
+  startingMood: string;
+  introBehaviorInstruction: string;
+  firstMoveGuidance?: string;
+  customNotes?: string[];
+  hostStartingMessage?: string;
+};
+
 export type AgentSeedSpec = {
   agentId: string;
   personaId: string;
@@ -48,6 +97,8 @@ export type AgentSeedSpec = {
   memories?: MemorySeedSpec[];
   initiativeAccumulators?: { source: string; value: number; threshold: number }[];
   arrivalPulse?: number | null;
+  hiddenObjective?: AgentObjective;
+  scenarioContext?: ScenarioContextBlock;
 };
 
 export type EventSeedSpec = {

--- a/packages/shared/src/scenarios/stagnation-attractors.ts
+++ b/packages/shared/src/scenarios/stagnation-attractors.ts
@@ -73,10 +73,16 @@ export const STAGNATION_ATTRACTOR_SCENARIOS: RoleplayScenario[] = [
       // Floors recalibrated for relational accretion (#138): the message_sent
       // rules add gentle positive relational motion, so resentment now plateaus
       // ~7-10% lower than under the dead-relational dynamics these floors were
-      // tuned against. Measured post-wave: bruno 0.468, caio 0.272. Re-tune in
-      // #129.
-      { kind: "emotion_stays", agentId: "bruno", field: "resentment", min: 0.42 },
-      { kind: "emotion_stays", agentId: "caio", field: "resentment", min: 0.24 },
+      // tuned against. Measured post-wave: bruno 0.468, caio 0.272.
+      // Recalibrated again with the concrete opener above: a settled money
+      // transfer plus a "thanks" is positive relational motion the vague
+      // "tudo certo?" exchange never carried, so resentment accretes less.
+      // Measured over the three mock variants: bruno 0.279–0.324, caio
+      // 0.209–0.213; floors sit ~12% under the minimum. Tuning artifacts of
+      // the opener, owned by #129 — not a claim about how much resentment the
+      // loop "should" hold.
+      { kind: "emotion_stays", agentId: "bruno", field: "resentment", min: 0.24 },
+      { kind: "emotion_stays", agentId: "caio", field: "resentment", min: 0.17 },
       { kind: "no_llm_failures" },
     ],
     pulseCount: 32,

--- a/packages/shared/src/scenarios/stagnation-attractors.ts
+++ b/packages/shared/src/scenarios/stagnation-attractors.ts
@@ -21,6 +21,17 @@ export const STAGNATION_ATTRACTOR_SCENARIOS: RoleplayScenario[] = [
         relational: {
           caio: { trust: 0.1, resentment: 0.8, suspicion: 0.6, desireForDistance: 0.6, interactionCount: 20 },
         },
+        memories: [
+          {
+            type: "episodic",
+            subjectAgentIds: ["caio"],
+            summary: "caio prometeu me defender numa treta e ficou calado quando chegou a hora",
+            emotionalTone: "negative",
+            confidence: 0.9,
+            intensity: 0.7,
+            unresolved: true,
+          },
+        ],
       }),
       agent("caio", "caio", {
         presence: "active",
@@ -29,13 +40,34 @@ export const STAGNATION_ATTRACTOR_SCENARIOS: RoleplayScenario[] = [
         relational: {
           bruno: { trust: 0.2, resentment: 0.5, suspicion: 0.4, interactionCount: 20 },
         },
+        memories: [
+          {
+            type: "emotional_residue",
+            subjectAgentIds: ["bruno"],
+            summary: "bruno esperava que eu tomasse partido dele e nunca perdoou meu silêncio",
+            emotionalTone: "negative",
+            confidence: 0.75,
+            intensity: 0.5,
+            unresolved: true,
+          },
+        ],
       }),
       agent("goulart", "goulart", { presence: "semi_active" }),
     ],
     priorEvents: [
-      msg("message_sent", "caio", "ch_geral", "bruno, tudo certo?", 1),
-      msg("reply_sent", "bruno", "ch_geral", "tudo", 2),
-      msg("reply_sent", "caio", "ch_geral", "ah, ok", 3),
+      // A concrete shared obligation (money, a deadline) instead of a vague
+      // "you good?" check-in — it forces Bruno and Caio to actually
+      // coordinate, so the polite cold-war surface has real material to be
+      // polite *about*, instead of two generic pleasantries with no stakes.
+      msg(
+        "message_sent",
+        "goulart",
+        "ch_geral",
+        "gente, fechei a reserva do sítio pro fim de semana. só falta cada um transferir a parte até amanhã de manhã, beleza?",
+        1,
+      ),
+      msg("reply_sent", "bruno", "ch_geral", "já mandei a minha parte, só confirma que chegou", 2),
+      msg("reply_sent", "caio", "ch_geral", "recebi sim, obrigado bruno", 3),
     ],
     expectedSignals: [
       // Floors recalibrated for relational accretion (#138): the message_sent

--- a/packages/shared/src/scenarios/v1-behaviors.ts
+++ b/packages/shared/src/scenarios/v1-behaviors.ts
@@ -128,6 +128,17 @@ export const V1_BEHAVIOR_SCENARIOS: RoleplayScenario[] = [
           caio: { trust: 0.3, affection: 0.3, resentment: 0.25, suspicion: 0.4, comfort: 0.4, interactionCount: 5 },
           goulart: { trust: 0.4, affection: 0.4, interactionCount: 6 },
         },
+        memories: [
+          {
+            type: "episodic",
+            subjectAgentIds: ["caio", "goulart"],
+            summary: "da última vez caio e goulart marcaram uma call sem me chamar",
+            emotionalTone: "negative",
+            confidence: 0.85,
+            intensity: 0.5,
+            unresolved: true,
+          },
+        ],
       }),
       agent("caio", "caio", {
         presence: "active",
@@ -138,9 +149,19 @@ export const V1_BEHAVIOR_SCENARIOS: RoleplayScenario[] = [
       }),
     ],
     priorEvents: [
-      msg("message_sent", "goulart", "ch_geral", "alguém aí ainda?", 1),
-      msg("reply_sent", "bruno", "ch_geral", "to aqui sim", 2),
-      msg("reply_sent", "caio", "ch_geral", "opa goulart, tudo bom?", 3),
+      // A concrete ask with a real stake (a specific favor, a specific
+      // deadline) instead of idle chatter — it gives Caio something real to
+      // respond warmly to, and makes Bruno's un-acknowledged offer to help
+      // land as an actual, checkable exclusion rather than atmosphere.
+      msg(
+        "message_sent",
+        "goulart",
+        "ch_geral",
+        "gente, fui chamado pro projeto novo do trampo, apresentação é semana que vem. caio, bora marcar aquela call que você ofereceu pra me ajudar com a proposta?",
+        1,
+      ),
+      msg("reply_sent", "bruno", "ch_geral", "mano que ótimo, parabéns! precisa de ajuda com alguma coisa?", 2),
+      msg("reply_sent", "caio", "ch_geral", "bora sim! separa um horário aí hoje à noite que eu já reviso contigo", 3),
     ],
     expectedSignals: [
       { kind: "emotion_rises", agentId: "bruno", field: "fearOfExclusion", min: 0.25 },


### PR DESCRIPTION
## What

Turns hidden objectives from scenario metadata into prompt pressure:

- `AgentObjective` (`description`, `scarceResourceId`, `constraint`, `costOfExposure`, `breakingPoint`) and `ScenarioContextBlock` move to `@perfectman/shared`; `AgentSeedSpec.hiddenObjective`/`.scenarioContext`; `scenarioToConfig` threads both into the `promptProfile`; `renderHiddenObjective` renders last inside `<persona>`, right before the output contract.
- `hoc_fatia_que_nao_existe` (`hidden_objective_collision`): four objectives, three over `adamantis_deal_timeline`, one over `adamantis_leverage_intel`, two seeded secret memories, golden label.
- Output contract: `privateMotiveSummary` asks for the uncomfortable version, `visibleContent` forbids drafting residue, the decision moment permits one in-character creative risk; `describePacketFieldType` recurses into array item props so `memoryWrites` enum/number fields stop failing schema validation.
- `motive_gossip`, `motive_conflict`, `stagnation_resentment_loop`, `v1_exclusion_inferred` get concrete prior events and seeded memories instead of vague openers.
- **Floors**: the `stagnation_resentment_loop` resentment floors (bruno `0.42 → 0.24`, caio `0.24 → 0.17`) rode on the vague opener; the settled transfer plus thanks is positive relational motion, measured mock minima `0.279–0.324` / `0.209–0.213`, floors ~12% under, recorded inline, owned by #129 as before.
- Eight tests: objective and context threading, hidden-objective render with optional clauses, decision-moment nudge, output-contract wording, nested field contract.

## Why

Before this, no seeded objective reached the acting agent's own prompt anywhere in the codebase, and a grep found zero mention of creativity or escalation in the prompt builder. One real run so far; the three creativity/motive/memory axes did not move on it — the measurement side is being fixed separately.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+8)
- Golden mock bench `check-bench-gate.mjs` PASS at 100% signals (92.9% before the floor recalibration — the three failing runs were the resentment loop variants).
- `hoc_fatia_que_nao_existe` on `deepseek/deepseek-v4-flash`: 68 events, 0 provider failures; grep of the public transcript for the seeded secrets (rival studio, Davi, advogado próprio) returns 0 hits.

