### PR TITLE
fix(engine): count self-subject memories as relevant in salience

### DIFF
--- a/packages/engine/src/perception/__tests__/memory-salience.test.ts
+++ b/packages/engine/src/perception/__tests__/memory-salience.test.ts
@@ -21,13 +21,18 @@ function memory(overrides: Partial<Memory> = {}): Memory {
   };
 }
 
+// A placeholder self id that never matches any fixture's subjectAgentIds,
+// so existing tests keep testing what they always tested unless a test
+// explicitly cares about self-relevance.
+const NOBODY = "nobody-self-id";
+
 describe("scoreMemorySalience", () => {
   it("weights subject relevance above recency (old relevant beats new irrelevant)", () => {
     const involved = new Set(["bruno"]);
     const oldRelevant = memory({ createdAt: 10, subjectAgentIds: ["bruno"] });
     const newIrrelevant = memory({ createdAt: 200 });
-    expect(scoreMemorySalience(oldRelevant, involved, 200, 10)).toBeGreaterThan(
-      scoreMemorySalience(newIrrelevant, involved, 200, 10),
+    expect(scoreMemorySalience(oldRelevant, involved, NOBODY, 200, 10)).toBeGreaterThan(
+      scoreMemorySalience(newIrrelevant, involved, NOBODY, 200, 10),
     );
   });
 
@@ -46,8 +51,28 @@ describe("scoreMemorySalience", () => {
       unresolved: true,
       createdAt: 100,
     });
-    expect(scoreMemorySalience(worstRelevant, involved, 100, 0)).toBeGreaterThan(
-      scoreMemorySalience(bestIrrelevant, involved, 100, 0),
+    expect(scoreMemorySalience(worstRelevant, involved, NOBODY, 100, 0)).toBeGreaterThan(
+      scoreMemorySalience(bestIrrelevant, involved, NOBODY, 100, 0),
+    );
+  });
+
+  // Root-caused via a real capture: `involvedPeople` deliberately excludes
+  // the agent's own id (it means "who else is here", not "am I here") — so
+  // a self-subject memory (subjectAgentIds: [my own id], the exact shape
+  // used for "my own secret/plan") could never earn the relevance bonus
+  // before this fix, no matter how central it was to the agent's behavior.
+  it("treats a memory about the agent themselves as relevant, even with no one else involved", () => {
+    const selfSubject = memory({ subjectAgentIds: ["bruno"] });
+    const noSubject = memory({ subjectAgentIds: [] });
+    expect(scoreMemorySalience(selfSubject, new Set(), "bruno", 100, 0)).toBeGreaterThan(
+      scoreMemorySalience(noSubject, new Set(), "bruno", 100, 0),
+    );
+  });
+
+  it("does not grant the relevance bonus to a memory about someone else who isn't involved", () => {
+    const otherSubject = memory({ subjectAgentIds: ["theo"] });
+    expect(scoreMemorySalience(otherSubject, new Set(), "bruno", 100, 0)).toBe(
+      scoreMemorySalience(memory({ subjectAgentIds: [] }), new Set(), "bruno", 100, 0),
     );
   });
 
@@ -55,40 +80,40 @@ describe("scoreMemorySalience", () => {
     const involved = new Set<string>();
     const open = memory({ unresolved: true, createdAt: 50 });
     const settled = memory({ unresolved: false, createdAt: 50 });
-    expect(scoreMemorySalience(open, involved, 100, 0)).toBeGreaterThan(
-      scoreMemorySalience(settled, involved, 100, 0),
+    expect(scoreMemorySalience(open, involved, NOBODY, 100, 0)).toBeGreaterThan(
+      scoreMemorySalience(settled, involved, NOBODY, 100, 0),
     );
   });
 
   it("orders type tiers: pending_intention > relationship > episodic", () => {
     const involved = new Set<string>();
-    const pending = scoreMemorySalience(memory({ type: "pending_intention" }), involved, 100, 0);
-    const relationship = scoreMemorySalience(memory({ type: "relationship" }), involved, 100, 0);
-    const episodic = scoreMemorySalience(memory({ type: "episodic" }), involved, 100, 0);
+    const pending = scoreMemorySalience(memory({ type: "pending_intention" }), involved, NOBODY, 100, 0);
+    const relationship = scoreMemorySalience(memory({ type: "relationship" }), involved, NOBODY, 100, 0);
+    const episodic = scoreMemorySalience(memory({ type: "episodic" }), involved, NOBODY, 100, 0);
     expect(pending).toBeGreaterThan(relationship);
     expect(relationship).toBeGreaterThan(episodic);
   });
 
   it("rewards authored confidence", () => {
     const involved = new Set<string>();
-    const high = scoreMemorySalience(memory({ confidence: 0.9 }), involved, 100, 0);
-    const low = scoreMemorySalience(memory({ confidence: 0.1 }), involved, 100, 0);
+    const high = scoreMemorySalience(memory({ confidence: 0.9 }), involved, NOBODY, 100, 0);
+    const low = scoreMemorySalience(memory({ confidence: 0.1 }), involved, NOBODY, 100, 0);
     expect(high).toBeGreaterThan(low);
   });
 
   it("keeps recency as a bounded term, not a dominating one", () => {
     const involved = new Set<string>();
     // Newest possible vs oldest possible differs by RECENCY_WEIGHT only.
-    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, 100, 0);
-    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, 100, 0);
+    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0);
+    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0);
     expect(newest - oldest).toBeCloseTo(0.5);
   });
 
   it("decays recency linearly across the store span, not binary newest-or-nothing", () => {
     const involved = new Set<string>();
-    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, 100, 0);
-    const middle = scoreMemorySalience(memory({ createdAt: 50 }), involved, 100, 0);
-    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, 100, 0);
+    const newest = scoreMemorySalience(memory({ createdAt: 100 }), involved, NOBODY, 100, 0);
+    const middle = scoreMemorySalience(memory({ createdAt: 50 }), involved, NOBODY, 100, 0);
+    const oldest = scoreMemorySalience(memory({ createdAt: 0 }), involved, NOBODY, 100, 0);
     expect(middle).toBeLessThan(newest);
     expect(middle).toBeGreaterThan(oldest);
     expect(newest - middle).toBeCloseTo(0.25);
@@ -97,20 +122,20 @@ describe("scoreMemorySalience", () => {
 
   it("is finite for unknown memory types via the fallback weight", () => {
     const rogue = memory({ type: "alien" as Memory["type"] });
-    expect(Number.isFinite(scoreMemorySalience(rogue, new Set(), 100, 0))).toBe(true);
+    expect(Number.isFinite(scoreMemorySalience(rogue, new Set(), NOBODY, 100, 0))).toBe(true);
   });
 });
 
 describe("selectRelevantMemories", () => {
   it("returns an empty list for an empty store", () => {
-    expect(selectRelevantMemories([], new Set(), 8)).toEqual([]);
+    expect(selectRelevantMemories([], new Set(), NOBODY, 8)).toEqual([]);
   });
 
   it("caps selection at maxMemories", () => {
     const store = Array.from({ length: 20 }, (_, i) =>
       memory({ id: `m${i}`, createdAt: i + 1 }),
     );
-    expect(selectRelevantMemories(store, new Set(), 8)).toHaveLength(8);
+    expect(selectRelevantMemories(store, new Set(), NOBODY, 8)).toHaveLength(8);
   });
 
   it("ranks a salient old memory ahead of fresh noise", () => {
@@ -127,8 +152,26 @@ describe("selectRelevantMemories", () => {
       }),
       memory({ id: "noise-3", createdAt: 103 }),
     ];
-    const selected = selectRelevantMemories(store, new Set(["bruno"]), 2);
+    const selected = selectRelevantMemories(store, new Set(["bruno"]), NOBODY, 2);
     expect(selected[0]!.id).toBe("open-intent");
+  });
+
+  it("ranks a self-subject memory ahead of fresh noise, with no one else involved", () => {
+    const store = [
+      memory({ id: "noise-1", createdAt: 101 }),
+      memory({ id: "noise-2", createdAt: 102 }),
+      memory({
+        id: "my-secret",
+        type: "self",
+        subjectAgentIds: ["bruno"],
+        confidence: 0.9,
+        unresolved: true,
+        createdAt: 40,
+      }),
+      memory({ id: "noise-3", createdAt: 103 }),
+    ];
+    const selected = selectRelevantMemories(store, new Set(), "bruno", 2);
+    expect(selected[0]!.id).toBe("my-secret");
   });
 
   it("breaks exact ties by recency deterministically", () => {
@@ -136,9 +179,9 @@ describe("selectRelevantMemories", () => {
     // so the scores tie and createdAt is the only term left to order them.
     const older = memory({ id: "older", createdAt: 10, confidence: 1.0 });
     const newer = memory({ id: "newer", createdAt: 20, confidence: 0.5 });
-    expect(scoreMemorySalience(older, new Set(), 20, 10)).toBe(
-      scoreMemorySalience(newer, new Set(), 20, 10),
+    expect(scoreMemorySalience(older, new Set(), NOBODY, 20, 10)).toBe(
+      scoreMemorySalience(newer, new Set(), NOBODY, 20, 10),
     );
-    expect(selectRelevantMemories([older, newer], new Set(), 1)[0]!.id).toBe("newer");
+    expect(selectRelevantMemories([older, newer], new Set(), NOBODY, 1)[0]!.id).toBe("newer");
   });
 });

--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -107,6 +107,7 @@ export function buildPerceptionPacket(
   const relevantMemories = selectRelevantMemories(
     agent.memories,
     involvedPeople,
+    agent.agentId,
     MAX_MEMORIES,
   );
 

--- a/packages/engine/src/perception/memory-salience.ts
+++ b/packages/engine/src/perception/memory-salience.ts
@@ -26,10 +26,18 @@ const RECENCY_WEIGHT = 0.5;
 export function scoreMemorySalience(
   memory: Memory,
   involvedPeople: ReadonlySet<string>,
+  selfId: string,
   newestCreatedAt: number,
   oldestCreatedAt: number,
 ): number {
-  const relevant = memory.subjectAgentIds.some(id => involvedPeople.has(id)) ? 1 : 0;
+  // Root-caused via a real capture: `involvedPeople` deliberately excludes
+  // the agent's own id (it means "who ELSE is in this exchange" — see
+  // build-perception-packet.ts). A self-subject memory (subjectAgentIds:
+  // [agent's own id] — exactly the shape used for "my own secret/plan",
+  // the hidden-objective mechanic's bread and butter) could therefore NEVER
+  // earn the dominant relevance bonus, no matter how central it was to the
+  // agent's own behavior. A memory about myself is trivially relevant to me.
+  const relevant = memory.subjectAgentIds.some(id => involvedPeople.has(id) || id === selfId) ? 1 : 0;
   const typeWeight = MEMORY_TYPE_WEIGHTS[memory.type] ?? 0.3;
 
   // Normalized over the whole store's span, not per-memory: a per-memory span
@@ -51,6 +59,7 @@ export function scoreMemorySalience(
 export function selectRelevantMemories(
   memories: readonly Memory[],
   involvedPeople: ReadonlySet<string>,
+  selfId: string,
   maxMemories: number,
 ): Memory[] {
   if (memories.length === 0) return [];
@@ -61,7 +70,7 @@ export function selectRelevantMemories(
   return [...memories]
     .map(memory => ({
       memory,
-      score: scoreMemorySalience(memory, involvedPeople, newestCreatedAt, oldestCreatedAt),
+      score: scoreMemorySalience(memory, involvedPeople, selfId, newestCreatedAt, oldestCreatedAt),
     }))
     .sort((a, b) => b.score - a.score || b.memory.createdAt - a.memory.createdAt)
     .slice(0, maxMemories)


### PR DESCRIPTION
## What

Makes an agent's memory about itself relevant to itself:

- `scoreMemorySalience`/`selectRelevantMemories` take `selfId`; a memory whose `subjectAgentIds` include the agent earns the relevance bonus alongside `involvedPeople`; `buildPerceptionPacket` passes `agent.agentId`.
- Three tests: self-subject memory surfaces with nobody involved, self memory ranks alongside peer memories, existing callers updated to the new signature.

## Why

`involvedPeople` excludes the agent's own id by design ("who else is in this exchange"), so the "my own secret" memory shape — the hidden-objective mechanic's bread and butter — could never rank, however central it was. Overlaps `#157`'s `scoreMemorySalience` signature change; rebases after it merges.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (+3)
- Direct call with the `hoc_fatia_que_nao_existe` seeds and `involvedPeople = {iris, theo}`: both Bruno's and Marcela's secret memories surface, where before neither did.
