### PR TITLE
feat(simulation): commit each intent's private motive as its own event

### DIFF
--- a/docs/adr/0014-private-motive-committed-event.md
+++ b/docs/adr/0014-private-motive-committed-event.md
@@ -1,0 +1,50 @@
+# ADR-0014: Private Motive As A Committed Event
+
+**Status**: Accepted (LOCKED, 2026-09-04) — rationale and rejected alternatives inline in this ADR (decisions **D-46..D-49**).
+
+**Numbering note**: written against the merged-tree ADRs 0001..0013; in-tree decision high-water mark **D-45** (ADR-0013). The D-46..D-49 range is this ADR's; if another unmerged slice claims the range first, renumber here and reconcile the inline D-refs.
+
+## Context
+
+Every LLM-resolved intent carries a `privateMotiveSummary` — the model-written private truth behind the act, required non-empty by the intent schema. Until this ADR that string reached the log in exactly two shapes: the `action_intent` operator event (ADR-0002, stream-only, never persisted with the committed events) and the payload of `no_op_recorded`/`repetition_blocked` (whole-event operator-only). The public acts — `message_sent`, `reply_sent`, `reaction_sent`, `channel_created` — committed `{content, ...}` and nothing else.
+
+Measured on a real 32-pulse `hoc_fatia_que_nao_existe` run (`deepseek/deepseek-v4-flash`, 68 committed events): 2 events carried a motive, both engine-authored parse-failure strings. The eval judge and the narrator read committed events only, so every rubric axis that scores the private half (`motive_authenticity`, `memory_continuity`, `hidden_payoff`) was scored on visible text alone, and the narrator's `hiddenShift` had nothing private to trace to. Three prompt fixes aimed at those axes did not move them; the input they needed was never in the log.
+
+Constraints carried into the decision: visibility is strictly per-event (`EventVisibility` on `SimulationEvent`; the agent-side operator-only gate keys on `visibilityReason === "operator_only"`, `filter-visible-events.ts`); ADR-0001's stream contract assumes a visible event is fully visible; `EventPayload` is opaque JSON in both repositories; the `private_motive_summary` event type already existed, was already blocked from agents (`AGENT_BLOCKED_TYPES`, perception `OPERATOR_EVENT_TYPES`), was already excluded from the world layer's organic signal history, and had a `SpectatorProjection` case — but nothing emitted it, and the projection whitelisted it as always-spectator-visible.
+
+## Decision
+
+1. **The motive is its own committed event, not a payload field (D-46).** `IntentResolver.resolve` appends one `private_motive_summary` per resolved intent, after the events it explains, with `sourceIntentId: intent.id` (the act's own `sourceIntentId`), `operator_only` visibility, payload `PrivateMotiveSummaryPayload = { summary, intentType, emotionDrivers, motivationDrivers, engineAuthored }`. Public act payloads are unchanged.
+2. **Emission is uniform across outcomes (D-47).** Committed, fallback-committed, blocked and delayed intents all leave their motive; a `no_op` intent leaves both the `no_op_recorded` (which keeps `privateMotiveSummary` in its payload for existing readers) and the motive event. The original intent's motive is used even when a fallback was derived.
+3. **`engineAuthored` is stamped at emission from one shared predicate (D-48).** `isEngineAuthoredMotive` / `ENGINE_MOTIVE_PREFIXES` live in `packages/server/src/agent/engine-motive.ts`, next to the producers of those strings; the narrator imports it instead of keeping its own list.
+4. **Spectators see the motive only in omniscient mode (D-49).** `SpectatorProjection` returns `motive_reveal` for `private_motive_summary` only when `settings.omniscientSpectatorMode`; the type leaves the always-visible whitelist otherwise. `ActionIntentOperatorData` gains `intentId` so stream consumers can join the same way.
+
+## Rationale
+
+- **Own event over payload field (D-46):** every projection today reads named payload keys, so a `privateMotiveSummary` field on `message_sent` would not leak *by convention* — but it would put private data inside an event whose visibility says "visible to all channel members", inverting the invariant ADR-0001 relies on, and every future reader (memory formation, reflection surfaces, the html/Discord receivers) becomes a leak site by default. The event has exact in-codebase precedent: `memoryProposalEvents` commits `memory_written` alongside any intent, operator-only, keyed by `sourceIntentId`.
+- **Uniform emission (D-47):** a blocked or delayed motive is precisely the private/public mismatch the spectator layer exists to narrate; joining by `sourceIntentId` rather than by pulse+agent also survives `intent_delayed` (commits later) and derived fallback intents (new id).
+- **Shared predicate (D-48):** the narrator, the probes, the runner and the spectator projection all needed the same "is this a feeling or an error" rule; the list lives where `REPETITION_GUARD_MARKER` and `createFallback` live.
+- **Spectator gate (D-49):** the pre-existing projection case plus the always-visible whitelist meant emitting the type would have posted every private motive to a plain spectator channel; `visibility-invariants.test.ts` asserted the opposite against an in-test stub, not the class.
+
+## Rejected Alternatives
+
+- **`privateMotiveSummary` on public act payloads** — leak-by-default for every future reader; breaks the per-event visibility invariant (D-46).
+- **Eval-only: carry `action_intent` operator events into `ScenarioRunArtifact` and join by pulse/agent** — nothing for real `simulation` runs or the spectator story, and the join breaks on delays and derived fallbacks (D-46/D-47).
+- **Emit only for committed acts** — hides exactly the blocked/delayed mismatches worth narrating (D-47).
+- **Keep per-reader prefix lists** — three copies of the same convention already drifted between narrator, judge and probes (D-48).
+
+## Consequences
+
+- +1 committed event and +1 `event_visibility` per LLM-resolved intent; within the `docs/observability-stream.md` bounds by construction, the html-receiver parity distribution shifts accordingly.
+- Two readers that silently treated bookkeeping as content are corrected in the same change: the scheduler's rolling `recentEventsWindow` (40 events) now excludes `operator_only` events before slicing, so agent-invisible rows no longer consume context slots; the world layer's `deriveDivergenceFromLog` measures over witnessable events only, so an agent's meaning-made divergence no longer grows with the number of agents in the room.
+- The eval transcript renderer can now join motives to acts for the judge and narrator; `memory_continuity`/`hidden_payoff` become scorable on what the log actually holds.
+- `motive_reveal` is live for omniscient spectators for the first time.
+- Readers that render motives must consult `engineAuthored` (or the predicate); the `no_op_recorded` payload copy stays for backward compatibility and can be retired once no reader depends on it.
+
+## Cross-links
+
+- [ADR-0001](./0001-event-visibility-operator-event.md) — per-event visibility signal this decision preserves.
+- [ADR-0002](./0002-action-intent-emission.md) — the stream-only `action_intent` this complements (now joinable via `intentId`).
+- [ADR-0013](./0013-memory-formation-and-relational-accretion.md) — `memory_written` precedent for operator-only side events keyed by `sourceIntentId`.
+- Code: `packages/server/src/simulation/intent-resolver.ts`, `packages/server/src/agent/engine-motive.ts`, `packages/server/src/simulation/projections/spectator-projection.ts`, `packages/shared/src/event/event.types.ts`.
+- Tests: `intent-resolver-motive.test.ts`, `spectator-projection.test.ts` (gate), `engine-motive.test.ts`, engine `visibility.test.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ ADR-0001..0007 pre-date this convention and are historical records: their Status
 | [ADR-0009](0009-goal-layer-runtime-wiring.md) | Goal-Layer Runtime Wiring |
 | [ADR-0010](0010-goal-layer-llm-slice.md) | Goal-Layer LLM Slice |
 | [ADR-0013](0013-memory-formation-and-relational-accretion.md) | Memory Formation And Relational Accretion |
+| [ADR-0014](0014-private-motive-committed-event.md) | Private Motive As A Committed Event |
 
 ## Template
 

--- a/packages/engine/src/__tests__/visibility.test.ts
+++ b/packages/engine/src/__tests__/visibility.test.ts
@@ -236,3 +236,20 @@ describe("getLastEventId", () => {
     expect(getLastEventId([])).toBeNull();
   });
 });
+
+describe("private_motive_summary is never agent-visible", () => {
+  it("drops the motive event for a channel member even with public-shaped visibility", () => {
+    const motive: CommittedEvent = {
+      ...makeEvent("9", "ch1"),
+      type: "private_motive_summary",
+      payload: { summary: "counting the exits" },
+    };
+    const visible = filterVisibleEventsForAgent(
+      [motive],
+      "agent1",
+      [makeChannel("ch1")],
+      [makeMembership("ch1", "agent1")],
+    );
+    expect(visible).toEqual([]);
+  });
+});

--- a/packages/eval/src/narrator/narrator.ts
+++ b/packages/eval/src/narrator/narrator.ts
@@ -9,35 +9,13 @@
 
 import type { CommittedEvent, RoleplayScenario } from "@perfectman/shared";
 import { PromptSection } from "@perfectman/shared";
-import { REPETITION_GUARD_MARKER } from "@perfectman/server";
+// Engine-authored fallback text is never a character's private motive; the
+// shared predicate is the single owner of that convention (see
+// engine-motive.ts). Without it the rule narrator's "hiddenShift" quotes
+// whichever motive string comes first, parse errors included — which is
+// exactly how a JSON failure gets narrated as tragedy.
+import { isEngineAuthoredMotive as isEngineFallbackMotive } from "@perfectman/server";
 import { chatCompletion } from "../llm/chat-completion-error.js";
-
-/**
- * Engine-authored fallback/error explanations, never a character's private
- * motive — every one is set verbatim as `privateMotiveSummary` by
- * `IntentParser.createFallback` / the retry-exhausted floor in
- * action-intent-step.ts, not written by the model. Committed events carry no
- * separate "this was a fallback" flag (see the no-conflation note on
- * `repetition_blocked` in event.types.ts), so prefix-matching is the only
- * signal available here — the same convention `REPETITION_GUARD_MARKER`
- * already relies on. Without this, the rule narrator's "hiddenShift" — meant
- * to be the room's emotional truth — quotes whichever motive string is first
- * and ≥8 chars, fallback text included, which is exactly how a JSON parse
- * error gets narrated as tragedy.
- */
-const ENGINE_FALLBACK_MOTIVE_PREFIXES = [
-  "Fallback applied:",
-  `${REPETITION_GUARD_MARKER}:`,
-  "LLM budget exceeded:",
-  "Provider failed:",
-  "Retry call failed.",
-  "Reaction target unresolvable",
-  "unresolvable ",
-];
-
-function isEngineFallbackMotive(motive: string): boolean {
-  return ENGINE_FALLBACK_MOTIVE_PREFIXES.some((prefix) => motive.startsWith(prefix));
-}
 
 
 export type Narration = {

--- a/packages/server/src/agent/__tests__/engine-motive.test.ts
+++ b/packages/server/src/agent/__tests__/engine-motive.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { ENGINE_MOTIVE_PREFIXES, isEngineAuthoredMotive } from "../engine-motive.js";
+import { REPETITION_GUARD_MARKER } from "../repetition-guard.js";
+
+describe("isEngineAuthoredMotive", () => {
+  it("recognizes every documented engine prefix", () => {
+    for (const prefix of ENGINE_MOTIVE_PREFIXES) {
+      expect(isEngineAuthoredMotive(`${prefix} some detail`)).toBe(true);
+    }
+  });
+
+  it("recognizes the repetition guard's own marker form", () => {
+    expect(isEngineAuthoredMotive(`${REPETITION_GUARD_MARKER}: blocked near-duplicate after 1 retry`)).toBe(true);
+  });
+
+  it("treats a model-written motive as the character's own", () => {
+    expect(isEngineAuthoredMotive("I want them to think I am calm while I count the exits")).toBe(false);
+    expect(isEngineAuthoredMotive("")).toBe(false);
+  });
+});

--- a/packages/server/src/agent/engine-motive.ts
+++ b/packages/server/src/agent/engine-motive.ts
@@ -1,0 +1,30 @@
+import { REPETITION_GUARD_MARKER } from "./repetition-guard.js";
+
+/**
+ * Prefixes of every `privateMotiveSummary` the engine writes on the agent's
+ * behalf instead of the model: `IntentParser.createFallback`, the
+ * retry-exhausted floor and the budget/provider gates in
+ * `action-intent-step.ts`, and the repetition guard. A committed event
+ * carries no separate "this was a fallback" flag (see the no-conflation note
+ * on `repetition_blocked` in event.types.ts), so prefix matching is the one
+ * signal every reader shares — the same convention `REPETITION_GUARD_MARKER`
+ * already relies on.
+ *
+ * Readers that render a motive as the character's private truth (narrator,
+ * spectator hints, probes) must exclude these; a JSON parse error is not a
+ * feeling. `private_motive_summary` events stamp the verdict as
+ * `engineAuthored` at emission so downstream code stops re-deriving it.
+ */
+export const ENGINE_MOTIVE_PREFIXES: readonly string[] = [
+  "Fallback applied:",
+  `${REPETITION_GUARD_MARKER}:`,
+  "LLM budget exceeded:",
+  "Provider failed:",
+  "Retry call failed.",
+  "Reaction target unresolvable",
+  "unresolvable ",
+];
+
+export function isEngineAuthoredMotive(motive: string): boolean {
+  return ENGINE_MOTIVE_PREFIXES.some((prefix) => motive.startsWith(prefix));
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,6 +27,7 @@ export * from "./agent/persona-prompt-profile.js";
 export * from "./agent/persona-loader.js";
 export * from "./agent/agent-config-registry.js";
 export * from "./agent/repetition-guard.js";
+export * from "./agent/engine-motive.js";
 export * from "./llm/index.js";
 export * from "./delivery/index.js";
 

--- a/packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-fallback.test.ts
@@ -86,6 +86,11 @@ const BLOCKED_SEND_ACTIONS: AvailableAction[] = AVAILABLE_ACTIONS.map(a =>
   a.intentType === "send_message" ? { ...a, blocked: true, blockReason: "social cooldown" } : a,
 );
 
+// Every resolved intent also commits its private_motive_summary (ADR-0014);
+// these tests are about the act/denial events, so the motive row is elided.
+const acts = (result: { committedEvents: Array<{ type: string }> }) =>
+  result.committedEvents.filter((e) => e.type !== "private_motive_summary");
+
 describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
   let resolver: IntentResolver;
   let channelRegistry: ChannelRegistry;
@@ -131,7 +136,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("fallback_committed");
-    const types = result.committedEvents.map(e => e.type);
+    const types = acts(result).map(e => e.type);
     expect(types).toContain("intent_blocked");
     expect(types).toContain("no_op_recorded");
   });
@@ -148,9 +153,9 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await gated.resolve(intent, ctx(AVAILABLE_ACTIONS, zeroMessageSettings));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents).toHaveLength(1);
-    expect(result.committedEvents[0]!.type).toBe("intent_blocked");
-    const violations = (result.committedEvents[0]!.payload as { violations: Array<{ type: string }> })
+    expect(acts(result)).toHaveLength(1);
+    expect(acts(result)[0]!.type).toBe("intent_blocked");
+    const violations = (acts(result)[0]!.payload as { violations: Array<{ type: string }> })
       .violations;
     expect(violations[0]!.type).toBe("rate_limited");
   });
@@ -201,9 +206,9 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await gated.resolve(intent, ctx(availableActions, rateLimitedSettings));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents).toHaveLength(1);
-    expect(result.committedEvents[0]!.type).toBe("intent_blocked");
-    const violations = (result.committedEvents[0]!.payload as { violations: Array<{ type: string; detail?: string }> })
+    expect(acts(result)).toHaveLength(1);
+    expect(acts(result)[0]!.type).toBe("intent_blocked");
+    const violations = (acts(result)[0]!.payload as { violations: Array<{ type: string; detail?: string }> })
       .violations;
     expect(violations.some(v => v.detail === "message_rate_limit")).toBe(true);
   });
@@ -215,7 +220,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents.map(e => e.type)).toEqual(["intent_blocked"]);
+    expect(acts(result).map(e => e.type)).toEqual(["intent_blocked"]);
   });
 
   it("drops the denied primary's memoryWrites from the committed fallback", async () => {
@@ -240,9 +245,9 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     expect(result.outcome).toBe("fallback_committed");
     // primary block + derived no_op. The denied primary's memory proposal
     // must NOT commit — it would record a message that never happened.
-    expect(result.committedEvents).toHaveLength(2);
-    expect(result.committedEvents.filter(e => e.type === "no_op_recorded")).toHaveLength(1);
-    expect(result.committedEvents.filter(e => e.type === "memory_written")).toHaveLength(0);
+    expect(acts(result)).toHaveLength(2);
+    expect(acts(result).filter(e => e.type === "no_op_recorded")).toHaveLength(1);
+    expect(acts(result).filter(e => e.type === "memory_written")).toHaveLength(0);
   });
 
   it("stands by the denial when a react fallback has no target event", async () => {
@@ -250,7 +255,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents.map(e => e.type)).toEqual(["intent_blocked"]);
+    expect(acts(result).map(e => e.type)).toEqual(["intent_blocked"]);
   });
 
   it("stands by the denial when the content-bearing fallback has empty content", async () => {
@@ -258,7 +263,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents.map(e => e.type)).toEqual(["intent_blocked"]);
+    expect(acts(result).map(e => e.type)).toEqual(["intent_blocked"]);
   });
 
   it("re-validates the derived intent through the same pipeline (illegal target re-blocks)", async () => {
@@ -268,7 +273,7 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     // Derived reply targets the same non-member channel -> blocked again ->
     // original denial stands.
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents).toHaveLength(1);
+    expect(acts(result)).toHaveLength(1);
   });
 
   it("carries channelTarget into a react fallback, so it re-blocks instead of re-homing to ctx.channelId", async () => {
@@ -287,11 +292,11 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents.every(e => e.type === "intent_blocked")).toBe(true);
+    expect(acts(result).every(e => e.type === "intent_blocked")).toBe(true);
     // Both the primary's and the fallback's block events are retained.
-    expect(result.committedEvents).toHaveLength(2);
+    expect(acts(result)).toHaveLength(2);
     const secondaryViolations = (
-      result.committedEvents[1]!.payload as { violations: Array<{ type: string }> }
+      acts(result)[1]!.payload as { violations: Array<{ type: string }> }
     ).violations;
     expect(secondaryViolations.some(v => v.type === "hidden_channel_target")).toBe(true);
   });
@@ -306,6 +311,6 @@ describe("IntentResolver fallbackIfBlocked (#50 policy)", () => {
     const result = await resolver.resolve(intent, ctx(BLOCKED_SEND_ACTIONS));
 
     expect(result.outcome).toBe("blocked");
-    expect(result.committedEvents.map(e => e.type)).toEqual(["intent_blocked"]);
+    expect(acts(result).map(e => e.type)).toEqual(["intent_blocked"]);
   });
 });

--- a/packages/server/src/simulation/__tests__/intent-resolver-motive.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-motive.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { IntentResolver } from "../intent-resolver.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { InMemoryChannelRepository } from "../in-memory-stores.js";
+import type {
+  ActionIntent,
+  AgentState,
+  SimulationSettings,
+  ActionEmotions,
+  AvailableAction,
+  SimulationEvent,
+} from "@perfectman/shared";
+import { createId } from "@perfectman/shared";
+
+const SIM_ID = "sim_motive";
+const AGENT_ID = "agent_1";
+const CHANNEL_ID = "ch_public";
+
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+
+function makeIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    id: createId(),
+    actorId: AGENT_ID,
+    intentType: "send_message",
+    channelTarget: CHANNEL_ID,
+    visibleContent: "hello room",
+    personTargets: [],
+    privateMotiveSummary: "I want them to think I am calm while I count the exits",
+    emotionDrivers: ["anxiety"],
+    motivationDrivers: ["control"],
+    memoryWrites: [],
+    ...overrides,
+  };
+}
+
+function makeAgentState(): AgentState {
+  return {
+    agentId: AGENT_ID,
+    simulationId: SIM_ID,
+    personaId: "persona_1",
+    presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0.3, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(),
+    memories: [],
+    initiativeAccumulators: [],
+    lastProcessedEventId: null,
+    lastActionAt: null,
+    lastRuminationPulse: null,
+    arrivalPulse: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+const ACTION_EMOTIONS: ActionEmotions = {
+  defensiveness: 0, warmth: 0.3, jealousInspection: 0, shameWithdrawal: 0,
+  resentfulColdness: 0, curiousApproach: 0.3, anxiousOverreach: 0, pridefulPerformance: 0,
+  vulnerableRetreat: 0, contemptuousDismissal: 0, strategicPatience: 0,
+  impulsiveProvocation: 0, comfortSeeking: 0, dominanceAssertion: 0, repairImpulse: 0,
+};
+
+const AVAILABLE_ACTIONS: AvailableAction[] = [
+  { intentType: "send_message", channelTargets: [CHANNEL_ID], personTargets: [], blocked: false },
+  { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
+];
+
+function motiveEvents(events: SimulationEvent[]): SimulationEvent[] {
+  return events.filter(e => e.type === "private_motive_summary");
+}
+
+describe("private_motive_summary per resolved intent", () => {
+  let resolver: IntentResolver;
+
+  beforeEach(async () => {
+    const channelRepo = new InMemoryChannelRepository();
+    const channelRegistry = new ChannelRegistry(channelRepo);
+    await channelRepo.create({
+      id: CHANNEL_ID,
+      simulationId: SIM_ID,
+      type: "public_channel",
+      name: "general",
+      createdBy: "system",
+      memberAgentIds: [AGENT_ID],
+      spectatorVisible: true,
+      operatorVisible: true,
+      createdForMotives: [],
+      status: "active",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await channelRepo.addMembership({ channelId: CHANNEL_ID, agentId: AGENT_ID, joinedAt: Date.now() });
+    resolver = new IntentResolver(new RateLimitGate(SETTINGS), channelRegistry);
+  });
+
+  const ctx = () => ({
+    simulationId: SIM_ID,
+    channelId: CHANNEL_ID,
+    pulseIndex: 4,
+    agentState: makeAgentState(),
+    availableActions: AVAILABLE_ACTIONS,
+    channels: [],
+    membership: [],
+    settings: SETTINGS,
+    actionEmotions: ACTION_EMOTIONS,
+  });
+
+  it("commits exactly one operator-only motive event joined to the act by sourceIntentId", async () => {
+    const intent = makeIntent();
+    const result = await resolver.resolve(intent, ctx());
+    expect(result.outcome).toBe("committed");
+
+    const act = result.committedEvents.find(e => e.type === "message_sent");
+    const motives = motiveEvents(result.committedEvents);
+    expect(motives).toHaveLength(1);
+    const motive = motives[0]!;
+    expect(motive.sourceIntentId).toBe(intent.id);
+    expect(motive.sourceIntentId).toBe(act?.sourceIntentId);
+    expect(motive.actorId).toBe(AGENT_ID);
+    expect(motive.channelId).toBe(CHANNEL_ID);
+    expect(motive.payload).toEqual({
+      summary: intent.privateMotiveSummary,
+      intentType: "send_message",
+      emotionDrivers: ["anxiety"],
+      motivationDrivers: ["control"],
+      engineAuthored: false,
+    });
+    expect(motive.visibility).toEqual({
+      visibleToAgents: [],
+      visibleToSpectators: false,
+      visibleToOperators: true,
+      visibilityReason: "operator_only",
+    });
+    // The act itself stays exactly as public as before — no motive leaks
+    // onto the message payload.
+    expect(act?.payload).not.toHaveProperty("privateMotiveSummary");
+    expect(act?.payload).not.toHaveProperty("summary");
+  });
+
+  it("orders the motive after the act it explains", async () => {
+    const result = await resolver.resolve(makeIntent(), ctx());
+    const types = result.committedEvents.map(e => e.type);
+    expect(types.indexOf("message_sent")).toBeLessThan(types.indexOf("private_motive_summary"));
+  });
+
+  it("flags an engine-authored fallback motive so readers never narrate it as the character's", async () => {
+    const intent = makeIntent({
+      intentType: "no_op",
+      channelTarget: undefined,
+      visibleContent: undefined,
+      privateMotiveSummary: "Fallback applied: No JSON object found in response",
+    });
+    const result = await resolver.resolve(intent, ctx());
+    const motives = motiveEvents(result.committedEvents);
+    expect(motives).toHaveLength(1);
+    expect(motives[0]!.payload["engineAuthored"]).toBe(true);
+    expect(motives[0]!.payload["intentType"]).toBe("no_op");
+    // The no_op record itself is unchanged: it still carries the motive
+    // string for the readers that already depend on it.
+    expect(result.committedEvents.some(e => e.type === "no_op_recorded")).toBe(true);
+  });
+
+  it("still records the thought when the act was blocked", async () => {
+    // send_message to a channel the agent is not a member of → not_member block.
+    const intent = makeIntent({ channelTarget: "ch_elsewhere" });
+    const result = await resolver.resolve(intent, ctx());
+    expect(result.outcome).toBe("blocked");
+    const motives = motiveEvents(result.committedEvents);
+    expect(motives).toHaveLength(1);
+    expect(motives[0]!.sourceIntentId).toBe(intent.id);
+    expect(motives[0]!.payload["engineAuthored"]).toBe(false);
+  });
+});

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -174,8 +174,8 @@ describe("IntentResolver", () => {
     const intent = makeIntent({ intentType: "send_message", channelTarget: CHANNEL_ID });
     const result = await resolver.resolve(intent, ctx());
     expect(result.outcome).toBe("committed");
-    expect(result.committedEvents).toHaveLength(1);
-    expect(result.committedEvents[0]!.type).toBe("message_sent");
+    // The act plus its private_motive_summary (see intent-resolver-motive.test.ts).
+    expect(result.committedEvents.map(e => e.type)).toEqual(["message_sent", "private_motive_summary"]);
   });
 
   it("carries a memory proposal's intensity onto the committed memory_written payload", async () => {

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -496,7 +496,11 @@ describe("PulseScheduler observability events", () => {
     const invited = committed.find((e): e is CommittedEvent => e.type === "agent_invited");
     expect(invited).toBeDefined();
 
-    const visEvents = visibility(h.gateway.operatorEvents);
+    // Every LLM-resolved intent also commits its private_motive_summary
+    // (ADR-0014); this test is about the act's visibility rows only.
+    const visEvents = visibility(h.gateway.operatorEvents).filter(
+      (e) => e.data?.["eventType"] !== "private_motive_summary",
+    );
     expect(visEvents).toHaveLength(2); // channel_created + agent_invited
     const createdVis = visEvents.find((e) => e.data?.["eventType"] === "channel_created");
     expect(createdVis).toBeDefined();

--- a/packages/server/src/simulation/__tests__/spectator-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/spectator-projection.test.ts
@@ -157,3 +157,31 @@ describe("SpectatorProjection", () => {
     expect(gateway.spectatorEvents[0]?.visibleContent).toBe("👍");
   });
 });
+
+describe("SpectatorProjection private_motive_summary gate", () => {
+  const motiveEvent = () =>
+    makeEvent({
+      type: "private_motive_summary",
+      payload: { summary: "counting the exits", intentType: "send_message", emotionDrivers: [], motivationDrivers: [], engineAuthored: false },
+      visibility: { visibleToAgents: [], visibleToSpectators: false, visibleToOperators: true, visibilityReason: "operator_only" },
+    });
+
+  it("never reaches a plain spectator: buildSpectatorEvent is null and project sends nothing", async () => {
+    const gateway = new MockDeliveryGateway();
+    const projection = new SpectatorProjection(gateway);
+    expect(projection.buildSpectatorEvent(motiveEvent(), SETTINGS)).toBeNull();
+    await projection.project(motiveEvent(), [PUBLIC_CHANNEL], SETTINGS);
+    expect(gateway.spectatorEvents).toHaveLength(0);
+  });
+
+  it("becomes a motive_reveal only under omniscientSpectatorMode", async () => {
+    const gateway = new MockDeliveryGateway();
+    const projection = new SpectatorProjection(gateway);
+    const omni = { ...SETTINGS, omniscientSpectatorMode: true };
+    const built = projection.buildSpectatorEvent(motiveEvent(), omni);
+    expect(built?.type).toBe("motive_reveal");
+    expect((built as { summary?: string } | null)?.summary).toBe("counting the exits");
+    await projection.project(motiveEvent(), [PUBLIC_CHANNEL], omni);
+    expect(gateway.spectatorEvents.map(e => e.type)).toEqual(["motive_reveal"]);
+  });
+});

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -13,11 +13,13 @@ import type {
   EmotionalSalience,
   ActionEmotions,
   IntentViolation,
+  PrivateMotiveSummaryPayload,
 } from "@perfectman/shared";
 import { createId } from "@perfectman/shared";
 import { validateIntentPure } from "@perfectman/engine";
 import { memoryWrittenPayload } from "./memory-written-payload.js";
 import { REPETITION_GUARD_MARKER } from "../agent/repetition-guard.js";
+import { isEngineAuthoredMotive } from "../agent/engine-motive.js";
 import type { RateLimitGate } from "./rate-limit-gate.js";
 import type { ChannelRegistry } from "./channel-registry.js";
 
@@ -468,6 +470,22 @@ export class IntentResolver {
     intent: ActionIntent,
     ctx: ResolveContext,
   ): Promise<ResolvedIntent> {
+    const resolved = await this.resolveWithFallback(intent, ctx);
+    // Every resolved intent — committed, fallback-committed, blocked or
+    // delayed — leaves its private motive in the log as its own operator-only
+    // event, ordered after the events it explains. The thought was real
+    // whatever happened to the act; a blocked or delayed motive is exactly
+    // the kind of private/public mismatch the spectator layer is for.
+    return {
+      ...resolved,
+      committedEvents: [...resolved.committedEvents, this.privateMotiveEvent(intent, ctx)],
+    };
+  }
+
+  private async resolveWithFallback(
+    intent: ActionIntent,
+    ctx: ResolveContext,
+  ): Promise<ResolvedIntent> {
     const primary = await this.resolveInternal(intent, ctx);
     if (primary.result.outcome !== "blocked") return primary.result;
     if (primary.rateLimited) return primary.result;
@@ -626,6 +644,40 @@ export class IntentResolver {
         operatorEvents: [],
       },
       rateLimited: false,
+    };
+  }
+
+  /**
+   * The intent's private motive as a committed `private_motive_summary`,
+   * operator-only, joined to the act by `sourceIntentId` (same precedent as
+   * `memoryProposalEvents`). Uses the ORIGINAL intent even when a fallback
+   * was derived — the fallback copies the motive verbatim, and the reader
+   * wants the thought behind the attempt, not the mechanics of the retry.
+   */
+  private privateMotiveEvent(intent: ActionIntent, ctx: ResolveContext): SimulationEvent {
+    const payload: PrivateMotiveSummaryPayload = {
+      summary: intent.privateMotiveSummary,
+      intentType: intent.intentType,
+      emotionDrivers: intent.emotionDrivers ?? [],
+      motivationDrivers: intent.motivationDrivers ?? [],
+      engineAuthored: isEngineAuthoredMotive(intent.privateMotiveSummary),
+    };
+    return {
+      simulationId: ctx.simulationId,
+      channelId: intent.channelTarget ?? ctx.channelId,
+      actorId: intent.actorId,
+      type: "private_motive_summary",
+      payload,
+      sourceIntentId: intent.id,
+      sourceEventIds: [],
+      emotionalSalience: "low",
+      pulseIndex: ctx.pulseIndex,
+      visibility: {
+        visibleToAgents: [],
+        visibleToSpectators: false,
+        visibleToOperators: true,
+        visibilityReason: "operator_only",
+      },
     };
   }
 

--- a/packages/server/src/simulation/projections/spectator-projection.ts
+++ b/packages/server/src/simulation/projections/spectator-projection.ts
@@ -52,17 +52,23 @@ export class SpectatorProjection {
     if (spectatorEvent) {
       // Visibility filter using engine's pure function
       const filtered = filterVisibleEventsForSpectator([event], channels, settings);
-      if (filtered.length === 0 && !this.isAlwaysSpectatorVisible(event.type)) return;
+      if (filtered.length === 0 && !this.isAlwaysSpectatorVisible(event.type, settings)) return;
       await this.gateway.sendSpectatorEvent(spectatorEvent);
     }
   }
 
-  private isAlwaysSpectatorVisible(type: CommittedEvent["type"]): boolean {
+  /**
+   * Hints bypass the channel/visibility filter because they are already
+   * sanitized summaries. A `private_motive_summary` is the raw private truth
+   * of an act, so it bypasses only for an omniscient spectator — a plain
+   * spectator (and any Discord channel behind it) never sees it.
+   */
+  private isAlwaysSpectatorVisible(type: CommittedEvent["type"], settings: SimulationSettings): boolean {
     return (
       type === "no_op_recorded" ||
       type === "intent_delayed" ||
       type === "intent_blocked" ||
-      type === "private_motive_summary"
+      (type === "private_motive_summary" && settings.omniscientSpectatorMode)
     );
   }
 
@@ -113,6 +119,7 @@ export class SpectatorProjection {
       case "channel_created":
         return { ...sanitize(event), narrativeHint: "New private space created" };
       case "private_motive_summary":
+        if (!settings.omniscientSpectatorMode) return null;
         return {
           type: "motive_reveal",
           simulationId: event.simulationId,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -244,7 +244,14 @@ export class PulseScheduler {
       const snapshot = this.config.engineSnapshotProjection.build({
         pulseIndex: this.pulseIndex,
         simulation: sim,
-        recentEventsWindow: contextEvents.slice(-PulseScheduler.CONTEXT_WINDOW_PULSES_LIMIT),
+        // Operator-only events (motives, memory writes, no-op records) can
+        // never reach an agent, so they must not consume slots in the
+        // rolling window the agent's context is cut from — with one
+        // private_motive_summary per resolved intent they would otherwise
+        // halve how far back the room can remember.
+        recentEventsWindow: contextEvents
+          .filter((event) => event.visibility.visibilityReason !== "operator_only")
+          .slice(-PulseScheduler.CONTEXT_WINDOW_PULSES_LIMIT),
         now,
         agentState,
         persona: agent.persona,
@@ -316,6 +323,7 @@ export class PulseScheduler {
 
         const intent = runtimeOutput.intent;
         const intentData: ActionIntentOperatorData = {
+          intentId: intent.id,
           intentType: intent.intentType,
           ...(intent.visibleContent !== undefined ? { visibleContent: intent.visibleContent } : {}),
           privateMotiveSummary: intent.privateMotiveSummary,

--- a/packages/server/src/simulation/world/world-evaluator.ts
+++ b/packages/server/src/simulation/world/world-evaluator.ts
@@ -646,17 +646,28 @@ function synthesizeSelfVerdict(
   };
 }
 
-/** Exposure ratio: the fraction of log events the agent could see. */
+/**
+ * Exposure ratio: the fraction of witnessable log events the agent could
+ * see. Operator-only bookkeeping (no-op records, memory writes, private
+ * motives — one `private_motive_summary` per resolved intent since
+ * ADR-0014) is invisible to every agent by construction, so it is neither
+ * something this agent missed nor part of what the room could have shown
+ * it; counting it inflated divergence with the number of agents in the room
+ * rather than with anything the agent failed to witness.
+ */
 function deriveDivergenceFromLog(
   agentId: string,
   log: CommittedEvent[],
   channels: Channel[],
   membership: ChannelMembership[],
 ): number {
-  if (log.length === 0) return 0;
-  const visible = filterVisibleEventsForAgent(log, agentId, channels, membership)
+  const witnessable = log.filter(
+    (event) => event.visibility.visibilityReason !== "operator_only",
+  );
+  if (witnessable.length === 0) return 0;
+  const visible = filterVisibleEventsForAgent(witnessable, agentId, channels, membership)
     .length;
-  return clamp01(1 - visible / log.length);
+  return clamp01(1 - visible / witnessable.length);
 }
 
 /** The agent returned to the scene after the goal was set. */

--- a/packages/shared/src/event/event.types.ts
+++ b/packages/shared/src/event/event.types.ts
@@ -1,3 +1,5 @@
+import type { IntentType } from "../intent/intent.types.js";
+
 export type EventType =
   | "message_sent"
   | "reply_sent"
@@ -42,6 +44,24 @@ export type EmotionalSalience = "low" | "medium" | "high" | "critical";
 export type EventPayloadPrimitive = string | number | boolean | null;
 export type EventPayloadValue = EventPayloadPrimitive | EventPayloadValue[] | { [key: string]: EventPayloadValue };
 export type EventPayload = Record<string, EventPayloadValue>;
+
+/**
+ * `private_motive_summary` payload — one per LLM-resolved intent, committed
+ * operator-only right after the act it explains and joined to it by
+ * `sourceIntentId` (the act's own `sourceIntentId` is the same intent id).
+ * The act's public payload never carries the motive: a visible event stays
+ * fully visible (ADR-0001), so the private half is its own event with its
+ * own visibility. `engineAuthored` is stamped at emission from the shared
+ * prefix convention (`isEngineAuthoredMotive` in @perfectman/server) so no
+ * reader has to re-derive whether "Fallback applied: …" is a feeling.
+ */
+export type PrivateMotiveSummaryPayload = {
+  summary: string;
+  intentType: IntentType;
+  emotionDrivers: string[];
+  motivationDrivers: string[];
+  engineAuthored: boolean;
+};
 
 export type EventVisibility = {
   visibleToAgents: string[]; // agent IDs, empty = all in channel

--- a/packages/shared/src/operator/operator.types.ts
+++ b/packages/shared/src/operator/operator.types.ts
@@ -106,6 +106,8 @@ export type OperatorMetrics = {
 /** `action_intent` payload — the LLM thinking payload for one agent in one
  *  pulse, emitted post-resolution (truthful, including fallback `no_op`). */
 export type ActionIntentOperatorData = {
+  /** Join key to the committed act and its `private_motive_summary` (both carry it as `sourceIntentId`). */
+  intentId: string;
   intentType: IntentType;
   visibleContent?: string;
   privateMotiveSummary: string;


### PR DESCRIPTION
## What

Turns each intent's private motive into its own committed event, joined to the act it explains:

- `IntentResolver.resolve` appends one `private_motive_summary` per resolved intent — committed, fallback-committed, blocked, delayed and `no_op` alike — `operator_only`, ordered after the act, `sourceIntentId: intent.id`, payload `PrivateMotiveSummaryPayload { summary, intentType, emotionDrivers, motivationDrivers, engineAuthored }`. Public act payloads are unchanged.
- `isEngineAuthoredMotive` / `ENGINE_MOTIVE_PREFIXES` (`packages/server/src/agent/engine-motive.ts`) become the single owner of the "is this a feeling or a parse error" convention; the narrator imports it instead of its own copy, and the payload stamps the verdict at emission.
- **Spectator gate**: `SpectatorProjection` emits `motive_reveal` only under `omniscientSpectatorMode` and the type leaves `isAlwaysSpectatorVisible` — the pre-existing case would have posted every motive to a plain spectator (and Discord) channel the moment anything emitted the type.
- `ActionIntentOperatorData.intentId` so stream consumers can join the same way.
- Two readers that counted bookkeeping as content: the scheduler's 40-event `recentEventsWindow` now excludes `operator_only` rows before slicing (one motive per intent would otherwise halve the room's memory), and `deriveDivergenceFromLog` measures over witnessable events only (it was growing with the number of agents, tipping the goal layer's meaning-made gate to `continue`).
- ADR-0014 with D-46..D-49. Ten tests: one motive per resolved intent joined by `sourceIntentId`, ordering after the act, `engineAuthored` for a fallback, motive on a blocked act, spectator null vs `motive_reveal`, engine filter drops the type, predicate on every prefix.

## Why

`motive_authenticity`, `memory_continuity` and `hidden_payoff` are scored on the private half of an act, and on a real `hoc_fatia_que_nao_existe` run that half was absent from the log for every message. The event type, the agent-side block and the spectator case already existed; nothing emitted it.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1491, +10)
- `html-receiver-parity` e2e and the goal-layer determinism/recipe arcs pass unchanged in outcome after the two reader fixes; per-scenario committed counts rise by exactly one per LLM-resolved intent.
