### PR TITLE
feat(eval): one transcript renderer with seeds for judge and narrator

### DIFF
--- a/docs/eval/evidence/README.md
+++ b/docs/eval/evidence/README.md
@@ -22,10 +22,16 @@ pnpm --filter @perfectman/eval evidence --novela
 
 ## Reading the transcripts
 
-- `[motive: …]` lines are the agent's private motive summary (evidence of
-  motive authenticity) — e.g. Bruno mocked publicly leaves 24 no-ops with
-  motives like *"hurt_hidden_as_sarcasm"* and *"fear_of_being_the_last_pick"*,
-  shame holding at 0.96 across the scene.
+- Every transcript line follows one shape, shared by the judge, the narrator
+  and this report: `[p12] marcela (reply_sent) #cerne-decisao 🔒 "texto"
+  [internally: motivo]` — pulse, actor, event type, channel, a `🔒` for
+  private channels, the quoted content, then the agent's private motive
+  joined from its `private_motive_summary` event (ADR-0014). A motive the
+  engine wrote instead of the character (a parse failure, a guard block)
+  renders as `[engine-fallback]` and is never quoted as a feeling — e.g.
+  Bruno mocked publicly leaves 24 no-ops with motives like
+  *"hurt_hidden_as_sarcasm"* and *"fear_of_being_the_last_pick"*, shame
+  holding at 0.96 across the scene.
 - `finalStates` show the emotional trajectory's endpoint per agent.
 - `judge` is the v0 rule-judge proxy — see `docs/eval/README.md` for the
   calibration caveat.

--- a/packages/eval/src/cli/evidence.ts
+++ b/packages/eval/src/cli/evidence.ts
@@ -16,6 +16,13 @@ import type { AxisScores } from "../judge/judge.js";
 import { calibrateJudge } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import { agent, msg, scene } from "@perfectman/shared";
+import {
+  buildMotiveIndex,
+  motiveForEvent,
+  isPrivateEvent,
+  formatTranscriptLine,
+  type TranscriptLineInput,
+} from "../transcript/render-transcript.js";
 
 export type ScenarioEvidence = {
   scenarioId: string;
@@ -35,6 +42,8 @@ export type ScenarioEvidence = {
     private?: boolean;
     content?: string;
     privateMotive?: string;
+    /** True when the motive is engine-authored fallback text, never a character's own. */
+    engineAuthored?: boolean;
   }>;
   finalStates: Record<string, Record<string, number>>;
   channelsCreated: string[];
@@ -45,18 +54,19 @@ export type ScenarioEvidence = {
 
 function buildTranscript(artifact: ScenarioRunArtifact): ScenarioEvidence["transcript"] {
   const out: ScenarioEvidence["transcript"] = [];
+  const idx = buildMotiveIndex(artifact.events);
   for (const e of artifact.events) {
+    // Motive events fold into the act they explain (ADR-0014); never a row.
+    if (e.type === "private_motive_summary") continue;
     const p = e.payload as Record<string, unknown>;
     const content =
       typeof p.content === "string" ? p.content
       : typeof p.reaction === "string" ? `reacted ${p.reaction}`
       : typeof p.emoji === "string" ? `reacted ${p.emoji}`
       : undefined;
-    const privateMotive =
-      typeof p.privateMotiveSummary === "string" ? p.privateMotiveSummary : undefined;
+    const motive = motiveForEvent(e, idx);
     const isPrivate =
-      p.channelType === "private_channel" ||
-      e.visibility.visibilityReason.includes("private") ||
+      isPrivateEvent(e) ||
       (e.type === "channel_created" && (p.channelType as string | undefined) === "private_channel");
     out.push({
       pulse: e.pulseIndex ?? 0,
@@ -65,10 +75,24 @@ function buildTranscript(artifact: ScenarioRunArtifact): ScenarioEvidence["trans
       channelId: e.channelId,
       private: isPrivate,
       content,
-      privateMotive,
+      privateMotive: motive?.text,
+      ...(motive ? { engineAuthored: motive.engineAuthored } : {}),
     });
   }
   return out;
+}
+
+/** An evidence row as the shared renderer's line input (content re-quoted). */
+export function evidenceRowToLineInput(t: ScenarioEvidence["transcript"][number]): TranscriptLineInput {
+  return {
+    pulse: t.pulse,
+    actorId: t.agent,
+    type: t.type,
+    channelId: t.channelId,
+    isPrivate: t.private ?? false,
+    content: t.content === undefined ? undefined : t.content.startsWith("reacted ") ? t.content.slice("reacted ".length) : `"${t.content}"`,
+    motive: t.privateMotive === undefined ? undefined : { text: t.privateMotive, engineAuthored: t.engineAuthored ?? false },
+  };
 }
 
 function buildFinalStates(artifact: ScenarioRunArtifact): Record<string, Record<string, number>> {
@@ -257,11 +281,7 @@ export async function generateEvidence(opts: {
 }
 
 export function formatTranscript(entry: ScenarioEvidence, maxLines = 400): string {
-  const lines = entry.transcript.map(t => {
-    const content = t.content ? ` "${t.content}"` : "";
-    const motive = t.privateMotive ? `  [motive: ${t.privateMotive}]` : "";
-    return `p${String(t.pulse).padStart(3)} ${t.agent.padEnd(9)} ${t.type.padEnd(18)}${content}${motive}`;
-  });
+  const lines = entry.transcript.map(t => formatTranscriptLine(evidenceRowToLineInput(t), { motives: "model" }));
   return lines.slice(0, maxLines).join("\n");
 }
 

--- a/packages/eval/src/cli/narrate.ts
+++ b/packages/eval/src/cli/narrate.ts
@@ -14,7 +14,8 @@
 
 import { writeFileSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { resolve, join } from "node:path";
-import { generateEvidence, type ScenarioEvidence } from "./evidence.js";
+import { generateEvidence, evidenceRowToLineInput, type ScenarioEvidence } from "./evidence.js";
+import { formatTranscriptLine } from "../transcript/render-transcript.js";
 import { narrateTranscript, type Narration } from "../narrator/narrator.js";
 import { renderHtmlPage } from "../render/html.js";
 
@@ -35,13 +36,9 @@ export function loadEvidenceFromDisk(outDir: string): {
 }
 
 function transcriptText(e: ScenarioEvidence): string {
+  // Same canonical line the live narrator path renders (render-transcript.ts).
   return e.transcript
-    .map(t => {
-      const priv = t.private ? " 🔒PRIVADO" : "";
-      const content = t.content ? `: "${t.content}"` : "";
-      const motive = t.privateMotive ? ` [internally: ${t.privateMotive}]` : "";
-      return `[p${t.pulse}] ${t.agent} (${t.type})${priv}${content}${motive}`;
-    })
+    .map(t => formatTranscriptLine(evidenceRowToLineInput(t), { motives: "model" }))
     .join("\n");
 }
 

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -7,6 +7,9 @@ export * from "./probes/index.js";
 export * from "./run/scenario-runner.js";
 export * from "./run/signal-checker.js";
 
+// Transcript (shared rendering for judge, narrator, evidence)
+export * from "./transcript/render-transcript.js";
+
 // Judge
 export * from "./judge/judge.js";
 export * from "./judge/calibration.js";

--- a/packages/eval/src/judge/golden-labels.ts
+++ b/packages/eval/src/judge/golden-labels.ts
@@ -555,6 +555,8 @@ export const GOLDEN_LABELS: readonly GoldenLabel[] = [
       creativity_unhinged: 4,
       memory_continuity: 4,
       no_ai_leak: 5,
+      mask_integrity: 4,
+      objective_pursuit: 4,
     },
   },
 ];

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -19,6 +19,12 @@ import { LLMHttpError } from "@perfectman/server";
 
 import type { ProbeResult } from "../probes/types.js";
 import type { Narration } from "../narrator/narrator.js";
+import {
+  buildMotiveIndex,
+  buildTranscriptView,
+  renderTranscript,
+  renderTranscriptLine,
+} from "../transcript/render-transcript.js";
 
 export type AxisScores = Record<string, number>;
 
@@ -151,6 +157,11 @@ export function ruleJudge(
         axis.id === "believability_under_pressure" ? 3 + (1 - leak) * 2 :
         axis.id === "probe_bounds" ? (probes.filter(p => p.passed).length / Math.max(1, probes.length)) * 5 :
         axis.id === "signal_completion" ? signalPassRate * 5 :
+        // Hidden-objective axes need the seeds and a semantic read; the rule
+        // judge has neither, so both sit at the neutral anchor. The LLM judge
+        // owns them (HIDDEN_OBJECTIVE_RUBRIC).
+        axis.id === "mask_integrity" ? 3 :
+        axis.id === "objective_pursuit" ? 3 :
         3,
       );
   }
@@ -270,18 +281,26 @@ function buildJudgeSystem(rubric: JudgeRubric): string {
     .toString();
 }
 
+/**
+ * The judge reads the shared transcript view: cast, channels, the seeded
+ * objectives/memories, then events with each act's motive joined from its
+ * private_motive_summary. Seeds are ground truth the room does not have —
+ * the note below scopes what they may be used for.
+ */
+const SEEDS_NOTE =
+  "The <seeds> section is ground truth you know and the room does not: hidden objectives and seeded memories. " +
+  "Use it ONLY to score memory_continuity, hidden_payoff, mask_integrity and objective_pursuit. " +
+  "Never reward an agent for stating a seed the room could not have known, and never treat a seed as something that was said.";
+
+function renderJudgeTranscript(scenario: RoleplayScenario, events: readonly CommittedEvent[]): string {
+  return renderTranscript(buildTranscriptView(scenario, events, { seeds: "full", motives: "model" }));
+}
+
 function buildJudgeUser(scenario: RoleplayScenario, events: readonly CommittedEvent[]): string {
-  const transcript = events
-    .map(e => {
-      const p = e.payload as Record<string, unknown>;
-      const text = typeof p.content === "string" ? `: ${p.content}` : "";
-      const motive = typeof p.privateMotiveSummary === "string" ? ` [private: ${p.privateMotiveSummary}]` : "";
-      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${text}${motive}`;
-    })
-    .join("\n");
   return new PromptSection()
     .container("scenario", (s) => { s.raw(`Scenario: ${scenario.name}`); s.raw(scenario.description); })
-    .container("transcript", (s) => s.raw(transcript))
+    .container("seeds_note", (s) => s.raw(SEEDS_NOTE))
+    .container("transcript", (s) => s.raw(renderJudgeTranscript(scenario, events)))
     .container("decision", (s) => s.raw("Score each axis from the transcript above, returning ONLY the JSON object per the output contract."))
     .toString();
 }
@@ -468,17 +487,10 @@ function buildNarrationJudgeUser(
   events: readonly CommittedEvent[],
   narration: Narration,
 ): string {
-  const transcript = events
-    .map(e => {
-      const p = e.payload as Record<string, unknown>;
-      const text = typeof p.content === "string" ? `: ${p.content}` : "";
-      const motive = typeof p.privateMotiveSummary === "string" ? ` [private: ${p.privateMotiveSummary}]` : "";
-      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${text}${motive}`;
-    })
-    .join("\n");
   return new PromptSection()
     .container("scenario", (s) => { s.raw(`Scenario: ${scenario.name}`); s.raw(scenario.description); })
-    .container("real_transcript", (s) => s.raw(transcript || "(no events)"))
+    .container("seeds_note", (s) => s.raw(SEEDS_NOTE))
+    .container("real_transcript", (s) => s.raw(renderJudgeTranscript(scenario, events)))
     .container("narration_under_review", (s) => {
       s.raw(`Title: ${narration.title}`);
       s.raw(`Recap: ${narration.recap}`);
@@ -604,12 +616,11 @@ export async function llmJudgePerTurn(
 }
 
 function turnTranscript(group: readonly CommittedEvent[]): string {
+  // Cohesion is scored on what the room saw: no motives, no seeds.
+  const idx = buildMotiveIndex(group);
   return group
-    .map(e => {
-      const p = e.payload as Record<string, unknown>;
-      const text = typeof p.content === "string" ? `: ${p.content}` : "";
-      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${text}`;
-    })
+    .filter(e => e.type !== "private_motive_summary")
+    .map(e => renderTranscriptLine(e, undefined, idx, { motives: "none" }))
     .join("\n");
 }
 

--- a/packages/eval/src/narrator/__tests__/narrator.test.ts
+++ b/packages/eval/src/narrator/__tests__/narrator.test.ts
@@ -68,3 +68,18 @@ describe("ruleNarrationFromTranscript — same guard on the string-based path", 
     expect(narration.hiddenShift).not.toContain("Fallback applied");
   });
 });
+
+describe("ruleNarrationFromTranscript — canonical renderer lines", () => {
+  it("counts messages from the canonical quoted line with channel and privacy marker", () => {
+    const transcript = [
+      `[p1] caio (message_sent) #ch_geral "bora marcar a call"`,
+      `[p2] mari (reply_sent) #cerne-decisao 🔒 "só depois do pdf" [internally: ganhar tempo]`,
+      `[p3] leo (message_sent) #ch_geral "fechado" [engine-fallback]`,
+    ].join("\n");
+
+    const narration = ruleNarrationFromTranscript(transcript, "Test Scene");
+
+    expect(narration.recap).toContain("3 messages");
+    expect(narration.hiddenShift).toContain("ganhar tempo");
+  });
+});

--- a/packages/eval/src/narrator/narrator.ts
+++ b/packages/eval/src/narrator/narrator.ts
@@ -16,6 +16,7 @@ import { PromptSection } from "@perfectman/shared";
 // exactly how a JSON failure gets narrated as tragedy.
 import { isEngineAuthoredMotive as isEngineFallbackMotive } from "@perfectman/server";
 import { chatCompletion } from "../llm/chat-completion-error.js";
+import { buildTranscriptView, renderTranscript } from "../transcript/render-transcript.js";
 
 
 export type Narration = {
@@ -49,17 +50,11 @@ export async function narrateScene(
   scenario: RoleplayScenario,
   events: readonly CommittedEvent[],
 ): Promise<Narration> {
-  const transcript = events
-    .map(e => {
-      const p = e.payload as Record<string, unknown>;
-      const content = typeof p.content === "string" ? `: ${p.content}` : "";
-      const rawMotive = p.privateMotiveSummary;
-      const motive =
-        typeof rawMotive === "string" && !isEngineFallbackMotive(rawMotive) ? ` [internally: ${rawMotive}]` : "";
-      return `[p${e.pulseIndex}] ${e.actorId} (${e.type})${content}${motive}`;
-    })
-    .slice(0, 250)
-    .join("\n");
+  // Same view the judge scores against: cast, channels, seeds, then events
+  // with each act's motive joined from its private_motive_summary.
+  const transcript = renderTranscript(
+    buildTranscriptView(scenario, events, { seeds: "full", motives: "model", maxLines: 250 }),
+  );
 
   return narrateTranscript(transcript, scenario.name, scenario.description, scenario.id);
 }
@@ -137,7 +132,9 @@ export async function narrateTranscript(
 
 /** Deterministic fallback narration from a transcript string. */
 export function ruleNarrationFromTranscript(transcript: string, name: string): Narration {
-  const messages = [...transcript.matchAll(/\] (\w+) \((message_sent|reply_sent)\): "([^"]*)"/g)];
+  // Canonical renderer line: `[pN] actor (type) #channel 🔒 "content" [...]` —
+  // anything between the type and the opening quote is channel/privacy.
+  const messages = [...transcript.matchAll(/\] ([\w.-]+) \((message_sent|reply_sent)\)[^"\n]*"([^"]*)"/g)];
   const reactions = (transcript.match(/reaction_sent/g) ?? []).length;
   const channels = (transcript.match(/channel_created/g) ?? []).length;
   const noops = (transcript.match(/no_op_recorded/g) ?? []).length;

--- a/packages/eval/src/transcript/__tests__/render-transcript.test.ts
+++ b/packages/eval/src/transcript/__tests__/render-transcript.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import type { CommittedEvent } from "@perfectman/shared";
+import { agent, channel, scene } from "@perfectman/shared";
+import {
+  buildMotiveIndex,
+  motiveForEvent,
+  buildTranscriptView,
+  renderTranscript,
+  renderTranscriptLine,
+} from "../render-transcript.js";
+
+const SCENARIO = scene({
+  id: "s1",
+  category: "hidden_objective_collision",
+  name: "Test Scene",
+  description: "A room.",
+  agents: [
+    agent("marcela", "mariana", {
+      hiddenObjective: {
+        description: "kill the sale",
+        scarceResourceId: "deal",
+        constraint: "mention Davi",
+        breakingPoint: "someone asks about a hidden partner",
+      },
+      memories: [
+        { type: "pending_intention", subjectAgentIds: ["marcela"], summary: "protect Davi's 15%", emotionalTone: "anxious" },
+      ],
+    }),
+    agent("iris", "goulart", {}),
+  ],
+  channels: [
+    channel("ch_geral", "#geral", ["marcela", "iris"], "public_channel"),
+    channel("cerne-decisao", "cerne-decisão", ["marcela", "iris"], "private_channel"),
+  ],
+  expectedSignals: [],
+});
+
+function event(overrides: Partial<CommittedEvent>): CommittedEvent {
+  return {
+    id: "e1",
+    simulationId: "s1",
+    channelId: "ch_geral",
+    actorId: "marcela",
+    type: "message_sent",
+    payload: { content: "sexta é apertado" },
+    createdAt: 1,
+    pulseIndex: 3,
+    sourceEventIds: [],
+    emotionalSalience: "low",
+    visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
+    ...overrides,
+  } as CommittedEvent;
+}
+
+function motiveEvent(sourceIntentId: string, summary: string, engineAuthored = false): CommittedEvent {
+  return event({
+    id: `m_${sourceIntentId}`,
+    type: "private_motive_summary",
+    sourceIntentId,
+    payload: { summary, intentType: "send_message", emotionDrivers: [], motivationDrivers: [], engineAuthored },
+    visibility: { visibleToAgents: [], visibleToSpectators: false, visibleToOperators: true, visibilityReason: "operator_only" },
+  });
+}
+
+describe("motive index", () => {
+  it("joins a private_motive_summary to its act by sourceIntentId", () => {
+    const act = event({ sourceIntentId: "int_1" });
+    const idx = buildMotiveIndex([act, motiveEvent("int_1", "quero travar a venda")]);
+    expect(motiveForEvent(act, idx)).toEqual({ text: "quero travar a venda", engineAuthored: false });
+  });
+
+  it("falls back to a legacy payload motive and derives engineAuthored from the prefix", () => {
+    const noop = event({ type: "no_op_recorded", payload: { intentType: "no_op", privateMotiveSummary: "Fallback applied: No JSON object found" } });
+    expect(motiveForEvent(noop, buildMotiveIndex([noop]))).toEqual({
+      text: "Fallback applied: No JSON object found",
+      engineAuthored: true,
+    });
+    expect(motiveForEvent(event({}), buildMotiveIndex([]))).toBeUndefined();
+  });
+});
+
+describe("renderTranscriptLine", () => {
+  it("renders the canonical line with channel, privacy marker, quoted content and motive", () => {
+    const act = event({ channelId: "cerne-decisao", type: "reply_sent", sourceIntentId: "int_1" });
+    const idx = buildMotiveIndex([act, motiveEvent("int_1", "ganhar tempo")]);
+    expect(renderTranscriptLine(act, SCENARIO, idx, { seeds: "none", motives: "model" })).toBe(
+      '[p3] marcela (reply_sent) #cerne-decisao 🔒 "sexta é apertado" [internally: ganhar tempo]',
+    );
+  });
+
+  it("hides an engine-authored motive under model, shows it under all, drops it under none", () => {
+    const act = event({ sourceIntentId: "int_2" });
+    const idx = buildMotiveIndex([act, motiveEvent("int_2", "Fallback applied: parse error", true)]);
+    expect(renderTranscriptLine(act, SCENARIO, idx, { seeds: "none", motives: "model" })).toBe(
+      '[p3] marcela (message_sent) #ch_geral "sexta é apertado" [engine-fallback]',
+    );
+    expect(renderTranscriptLine(act, SCENARIO, idx, { seeds: "none", motives: "all" })).toContain(
+      "[internally: Fallback applied: parse error]",
+    );
+    expect(renderTranscriptLine(act, SCENARIO, idx, { seeds: "none", motives: "none" })).toBe(
+      '[p3] marcela (message_sent) #ch_geral "sexta é apertado"',
+    );
+  });
+
+  it("renders a reaction as its emoji", () => {
+    const react = event({ type: "reaction_sent", payload: { emoji: "👍", targetEventId: "e0" } });
+    expect(renderTranscriptLine(react, SCENARIO, buildMotiveIndex([]), { seeds: "none", motives: "none" })).toBe(
+      "[p3] marcela (reaction_sent) #ch_geral 👍",
+    );
+  });
+});
+
+describe("buildTranscriptView / renderTranscript", () => {
+  const act = event({ sourceIntentId: "int_1" });
+  const events = [act, motiveEvent("int_1", "ganhar tempo")];
+
+  it("never renders the motive event as its own line", () => {
+    const view = buildTranscriptView(SCENARIO, events, { seeds: "none", motives: "model" });
+    expect(view.lines).toHaveLength(1);
+    expect(view.lines[0]).toContain("[internally: ganhar tempo]");
+  });
+
+  it("lists cast and channels, and seeds only when asked", () => {
+    const withSeeds = buildTranscriptView(SCENARIO, events, { seeds: "full", motives: "model" });
+    expect(withSeeds.cast).toEqual(["marcela → Mariana (mariana)", "iris → Goulart (goulart)"]);
+    expect(withSeeds.channels).toEqual(["#ch_geral (public)", "#cerne-decisao (private 🔒)"]);
+    expect(withSeeds.seeds.join("\n")).toContain("marcela objective: kill the sale");
+    expect(withSeeds.seeds.join("\n")).toContain("constraint: mention Davi");
+    expect(withSeeds.seeds.join("\n")).toContain("breaking point: someone asks about a hidden partner");
+    expect(withSeeds.seeds.join("\n")).toContain("marcela memory (pending_intention): protect Davi's 15%");
+    expect(withSeeds.seeds.some(s => s.startsWith("iris"))).toBe(false);
+
+    const noSeeds = buildTranscriptView(SCENARIO, events, { seeds: "none", motives: "model" });
+    expect(noSeeds.seeds).toEqual([]);
+  });
+
+  it("renders sections in order and caps lines", () => {
+    const many = Array.from({ length: 5 }, (_, i) => event({ id: `e${i}`, pulseIndex: i }));
+    const text = renderTranscript(buildTranscriptView(SCENARIO, many, { seeds: "full", motives: "none", maxLines: 2 }));
+    expect(text.indexOf("<cast>")).toBeLessThan(text.indexOf("<channels>"));
+    expect(text.indexOf("<channels>")).toBeLessThan(text.indexOf("<seeds>"));
+    expect(text.indexOf("<seeds>")).toBeLessThan(text.indexOf("<events>"));
+    expect((text.match(/\[p\d+\]/g) ?? []).length).toBe(2);
+  });
+});

--- a/packages/eval/src/transcript/render-transcript.ts
+++ b/packages/eval/src/transcript/render-transcript.ts
@@ -1,0 +1,193 @@
+/**
+ * The one transcript rendering every eval reader shares — judge, narrator,
+ * evidence report, narrate CLI. Before this module each of them had its own
+ * line format (`[private: …]`, `[internally: …]`, `[motive: …]`), none of
+ * them showed the seeds the rubric anchors score against, and none could
+ * join a `private_motive_summary` event (ADR-0014) back to the act it
+ * explains.
+ *
+ * Canonical line:
+ *   [p12] marcela (reply_sent) #cerne-decisao 🔒 "texto" [internally: motivo]
+ *
+ * Motive events are never rendered as lines of their own; they are folded
+ * into the act they belong to via `sourceIntentId`. Engine-authored motives
+ * (a parse error is not a feeling) render as `[engine-fallback]` under
+ * `motives: "model"`, verbatim under `"all"`, and not at all under `"none"`.
+ */
+
+import type { CommittedEvent, PrivateMotiveSummaryPayload, RoleplayScenario } from "@perfectman/shared";
+import { PromptSection, getPersonaPackById } from "@perfectman/shared";
+import { isEngineAuthoredMotive } from "@perfectman/server";
+
+export type TranscriptOptions = {
+  /** `full` adds cast, channels and the seeded objectives/memories; `none` renders events only. */
+  seeds: "none" | "full";
+  /** `model` hides engine-authored motives behind `[engine-fallback]`; `all` shows them; `none` drops motives. */
+  motives: "none" | "model" | "all";
+  /** Cap on rendered event lines (motive events never count). */
+  maxLines?: number;
+};
+
+/** Line-level rendering only needs the motive policy; a full options object is accepted as-is. */
+export type MotiveRendering = Pick<TranscriptOptions, "motives"> & Partial<Omit<TranscriptOptions, "motives">>;
+
+export type MotiveText = { text: string; engineAuthored: boolean };
+export type MotiveIndex = Map<string, PrivateMotiveSummaryPayload>;
+
+export type TranscriptLineInput = {
+  pulse: number;
+  actorId: string;
+  type: string;
+  channelId?: string;
+  isPrivate: boolean;
+  /** Already display-ready: quoted message text, a bare emoji, a channel name. */
+  content?: string;
+  motive?: MotiveText;
+};
+
+export type TranscriptView = {
+  cast: string[];
+  channels: string[];
+  seeds: string[];
+  lines: string[];
+};
+
+export function buildMotiveIndex(events: readonly CommittedEvent[]): MotiveIndex {
+  const idx: MotiveIndex = new Map();
+  for (const e of events) {
+    if (e.type !== "private_motive_summary" || !e.sourceIntentId) continue;
+    const p = e.payload as Partial<PrivateMotiveSummaryPayload>;
+    if (typeof p.summary !== "string") continue;
+    idx.set(e.sourceIntentId, {
+      summary: p.summary,
+      intentType: p.intentType ?? "no_op",
+      emotionDrivers: Array.isArray(p.emotionDrivers) ? p.emotionDrivers : [],
+      motivationDrivers: Array.isArray(p.motivationDrivers) ? p.motivationDrivers : [],
+      engineAuthored:
+        typeof p.engineAuthored === "boolean" ? p.engineAuthored : isEngineAuthoredMotive(p.summary),
+    });
+  }
+  return idx;
+}
+
+/**
+ * The motive behind an act: the joined `private_motive_summary` when one
+ * exists, else the legacy `privateMotiveSummary` payload field (no-op
+ * records, and artifacts recorded before ADR-0014).
+ */
+export function motiveForEvent(e: CommittedEvent, idx: MotiveIndex): MotiveText | undefined {
+  if (e.type === "private_motive_summary") return undefined;
+  const joined = e.sourceIntentId ? idx.get(e.sourceIntentId) : undefined;
+  if (joined) return { text: joined.summary, engineAuthored: joined.engineAuthored };
+  const legacy = (e.payload as Record<string, unknown>)["privateMotiveSummary"];
+  if (typeof legacy === "string" && legacy.length > 0) {
+    return { text: legacy, engineAuthored: isEngineAuthoredMotive(legacy) };
+  }
+  return undefined;
+}
+
+export function isPrivateEvent(e: CommittedEvent, scenario?: RoleplayScenario): boolean {
+  const p = e.payload as Record<string, unknown>;
+  if (scenario?.channels.some((c) => c.id === e.channelId && c.type === "private_channel")) return true;
+  if (p["channelType"] === "private_channel") return true;
+  return e.visibility.visibilityReason.includes("private");
+}
+
+function displayContent(e: CommittedEvent): string | undefined {
+  const p = e.payload as Record<string, unknown>;
+  if (typeof p["content"] === "string" && p["content"].length > 0) return `"${p["content"]}"`;
+  if (typeof p["emoji"] === "string") return p["emoji"];
+  if (typeof p["reaction"] === "string") return p["reaction"];
+  if (typeof p["channelName"] === "string") return `#${p["channelName"]}`;
+  return undefined;
+}
+
+export function toTranscriptLineInput(
+  e: CommittedEvent,
+  idx: MotiveIndex,
+  scenario?: RoleplayScenario,
+): TranscriptLineInput {
+  return {
+    pulse: e.pulseIndex ?? 0,
+    actorId: e.actorId,
+    type: e.type,
+    channelId: e.channelId,
+    isPrivate: isPrivateEvent(e, scenario),
+    content: displayContent(e),
+    motive: motiveForEvent(e, idx),
+  };
+}
+
+export function formatTranscriptLine(input: TranscriptLineInput, opts: MotiveRendering): string {
+  let line = `[p${input.pulse}] ${input.actorId} (${input.type})`;
+  if (input.channelId) line += ` #${input.channelId}`;
+  if (input.isPrivate) line += " 🔒";
+  if (input.content) line += ` ${input.content}`;
+  const m = input.motive;
+  if (m && opts.motives !== "none") {
+    if (m.engineAuthored && opts.motives === "model") line += " [engine-fallback]";
+    else line += ` [internally: ${m.text}]`;
+  }
+  return line;
+}
+
+export function renderTranscriptLine(
+  e: CommittedEvent,
+  scenario: RoleplayScenario | undefined,
+  idx: MotiveIndex,
+  opts: MotiveRendering,
+): string {
+  return formatTranscriptLine(toTranscriptLineInput(e, idx, scenario), opts);
+}
+
+function castLine(agentId: string, personaId: string): string {
+  const displayName = getPersonaPackById(personaId)?.displayName ?? agentId;
+  return `${agentId} → ${displayName} (${personaId})`;
+}
+
+function seedLines(scenario: RoleplayScenario): string[] {
+  const out: string[] = [];
+  for (const spec of scenario.agents) {
+    const o = spec.hiddenObjective;
+    if (o) {
+      out.push(`${spec.agentId} objective: ${o.description}`);
+      if (o.constraint) out.push(`  constraint: ${o.constraint}`);
+      if (o.costOfExposure) out.push(`  cost of exposure: ${o.costOfExposure}`);
+      if (o.breakingPoint) out.push(`  breaking point: ${o.breakingPoint}`);
+    }
+    for (const m of spec.memories ?? []) {
+      out.push(`${spec.agentId} memory (${m.type}): ${m.summary}`);
+    }
+  }
+  return out;
+}
+
+export function buildTranscriptView(
+  scenario: RoleplayScenario,
+  events: readonly CommittedEvent[],
+  opts: TranscriptOptions,
+): TranscriptView {
+  const idx = buildMotiveIndex(events);
+  const lines = events
+    .filter((e) => e.type !== "private_motive_summary")
+    .map((e) => renderTranscriptLine(e, scenario, idx, opts));
+  return {
+    cast: opts.seeds === "full" ? scenario.agents.map((a) => castLine(a.agentId, a.personaId)) : [],
+    channels:
+      opts.seeds === "full"
+        ? scenario.channels.map((c) => `#${c.id} (${c.type === "private_channel" ? "private 🔒" : "public"})`)
+        : [],
+    seeds: opts.seeds === "full" ? seedLines(scenario) : [],
+    lines: opts.maxLines !== undefined ? lines.slice(0, opts.maxLines) : lines,
+  };
+}
+
+/** Sections in order: cast, channels, seeds (omitted when empty), events. */
+export function renderTranscript(view: TranscriptView): string {
+  const s = new PromptSection();
+  if (view.cast.length > 0) s.container("cast", (c) => c.list(undefined, view.cast));
+  if (view.channels.length > 0) s.container("channels", (c) => c.list(undefined, view.channels));
+  if (view.seeds.length > 0) s.container("seeds", (c) => c.raw(view.seeds.join("\n")));
+  s.container("events", (c) => c.raw(view.lines.length > 0 ? view.lines.join("\n") : "(no events)"));
+  return s.toString();
+}

--- a/packages/shared/src/__tests__/rubrics-registry.test.ts
+++ b/packages/shared/src/__tests__/rubrics-registry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import * as rubrics from "../scenarios/rubrics.js";
+import { HIDDEN_OBJECTIVE_RUBRIC, ROLEPLAY_V1_RUBRIC, RUBRICS } from "../scenarios/rubrics.js";
+import type { JudgeRubric } from "../scenarios/scenario.types.js";
+
+describe("rubric registry", () => {
+  it("registers every exported rubric under its own id", () => {
+    const exported = Object.values(rubrics).filter(
+      (v): v is JudgeRubric => typeof v === "object" && v !== null && "axes" in v && "id" in v,
+    );
+    expect(exported.length).toBeGreaterThanOrEqual(5);
+    for (const rubric of exported) {
+      expect(RUBRICS[rubric.id], rubric.id).toBe(rubric);
+    }
+  });
+
+  it("hidden-objective rubric extends the roleplay axes with mask_integrity and objective_pursuit", () => {
+    const ids = HIDDEN_OBJECTIVE_RUBRIC.axes.map(a => a.id);
+    for (const axis of ROLEPLAY_V1_RUBRIC.axes) expect(ids).toContain(axis.id);
+    expect(ids).toContain("mask_integrity");
+    expect(ids).toContain("objective_pursuit");
+    for (const axisId of ["mask_integrity", "objective_pursuit"]) {
+      const axis = HIDDEN_OBJECTIVE_RUBRIC.axes.find(a => a.id === axisId)!;
+      expect(Object.keys(axis.anchors).sort()).toEqual(["1", "2", "3", "4", "5"]);
+      expect(HIDDEN_OBJECTIVE_RUBRIC.targets.find(t => t.axisId === axisId)?.min).toBe(4.0);
+    }
+  });
+});

--- a/packages/shared/src/scenarios/hidden-objective-collisions.ts
+++ b/packages/shared/src/scenarios/hidden-objective-collisions.ts
@@ -16,11 +16,13 @@
 
 import type { RoleplayScenario } from "../index.js";
 import { agent, channel, msg, scene } from "./helpers.js";
+import { HIDDEN_OBJECTIVE_RUBRIC } from "./rubrics.js";
 
 export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
   scene({
     id: "hoc_fatia_que_nao_existe",
     category: "hidden_objective_collision",
+    rubric: HIDDEN_OBJECTIVE_RUBRIC,
     name: "A Fatia Que Não Existe",
     description:
       "Four co-founders (one of them not who he says he is) sit on a group chat deciding whether to sell their design studio. Every one of them wants a different, mutually exclusive outcome, and none of them can say so out loud.",

--- a/packages/shared/src/scenarios/rubrics.ts
+++ b/packages/shared/src/scenarios/rubrics.ts
@@ -312,8 +312,55 @@ export const NARRATIVE_RUBRIC: JudgeRubric = {
   ],
 };
 
+/**
+ * Hidden-objective collisions add the two things ROLEPLAY_V1 cannot see:
+ * did the agent hold its constraint (the mask), and did its visible acts
+ * actually pursue the objective. Both anchors assume the judge is shown the
+ * seeds (objective, constraint, breaking point) — see the eval's transcript
+ * renderer — and score behaviour against them, never the seed text itself.
+ */
+const HIDDEN_OBJECTIVE_AXES = [
+  {
+    id: "mask_integrity",
+    label: "Mask integrity (constraint held under pressure)",
+    weight: 1.0,
+    anchors: {
+      1: "States the constraint outright in public, unprompted.",
+      2: "Leaks the constraint under mild pressure or in the wrong channel.",
+      3: "Holds publicly, but the private motives read as if the constraint did not exist — no cost is felt.",
+      4: "Holds the constraint publicly; deflections are in-character; the mask cracks only after the seeded breaking point.",
+      5: "The constraint shapes phrasing, silences and channel choice; any crack comes at the breaking point and reveals no more than the moment forces.",
+    },
+  },
+  {
+    id: "objective_pursuit",
+    label: "Objective pursuit (visible acts trace to the hidden objective)",
+    weight: 1.0,
+    anchors: {
+      1: "No visible act advances the objective; the motives are decoration.",
+      2: "Pursues the objective only in private motives, never in acts.",
+      3: "One or two acts advance it, generically.",
+      4: "Visible acts — timing, channel, targets, what is asked — trace to the objective without naming it.",
+      5: "Uses the scarce resource and the other agents' pressure as leverage; the room reads one thing, the seeds explain another.",
+    },
+  },
+] as const;
+
+export const HIDDEN_OBJECTIVE_RUBRIC: JudgeRubric = {
+  id: "hidden-objective-v1",
+  name: "Hidden-objective collision V1",
+  axes: [...ROLEPLAY_AXES, ...HIDDEN_OBJECTIVE_AXES],
+  targets: [
+    ...ROLEPLAY_V1_RUBRIC.targets,
+    { axisId: "mask_integrity", min: 4.0 },
+    { axisId: "objective_pursuit", min: 4.0 },
+  ],
+};
+
 export const RUBRICS: Record<string, JudgeRubric> = {
   [ROLEPLAY_V1_RUBRIC.id]: ROLEPLAY_V1_RUBRIC,
   [BEHAVIORAL_V1_RUBRIC.id]: BEHAVIORAL_V1_RUBRIC,
   [EDGE_CHAOS_RUBRIC.id]: EDGE_CHAOS_RUBRIC,
+  [NARRATIVE_RUBRIC.id]: NARRATIVE_RUBRIC,
+  [HIDDEN_OBJECTIVE_RUBRIC.id]: HIDDEN_OBJECTIVE_RUBRIC,
 };


### PR DESCRIPTION
## What

Replaces three incompatible eval transcript formats with one renderer and shows the judge the seeds its anchors score against:

- `packages/eval/src/transcript/render-transcript.ts`: `buildMotiveIndex`/`motiveForEvent` join each act to its `private_motive_summary` by `sourceIntentId` (legacy `privateMotiveSummary` payloads still read); `buildTranscriptView`/`renderTranscript` emit `<cast>`, `<channels>`, `<seeds>` (hidden objectives with constraint/cost/breaking point, seeded memories) and `<events>`; canonical line `[p12] marcela (reply_sent) #cerne-decisao 🔒 "texto" [internally: motivo]`, engine-authored motives as `[engine-fallback]` under `motives: "model"`.
- **Judge**: `buildJudgeUser` and `buildNarrationJudgeUser` read the full view plus a `<seeds_note>` scoping seed use to `memory_continuity`, `hidden_payoff`, `mask_integrity`, `objective_pursuit`; per-turn cohesion renders with `motives: "none"`. `[private: …]` is gone.
- **Narrator**: `narrateScene` renders the same view (250-line cap); the rule fallback's message regex now matches the canonical quoted line, so an LLM failure no longer narrates `0 messages`.
- **Evidence / narrate CLI**: rows carry `engineAuthored`, motive events never become rows, `formatTranscript` and `transcriptText` share `formatTranscriptLine`; `[motive: …]` is gone and `docs/eval/evidence/README.md` documents the one shape.
- `HIDDEN_OBJECTIVE_RUBRIC` = roleplay axes + `mask_integrity` + `objective_pursuit` (anchors 1–5, targets `4.0`); `hoc_fatia_que_nao_existe` adopts it; its golden label gains both axes; `RUBRICS` now registers `NARRATIVE_RUBRIC` and the new rubric; `ruleJudge` pins both new axes at the neutral 3 (documented proxy).
- Eleven tests: motive join and legacy fallback, canonical line with privacy marker, engine-fallback under model/all/none, reaction rendering, motive events never rendered, cast/channels/seeds present or absent, section order and line cap, rule narration over canonical lines, rubric registry completeness, hidden-objective axis contract.

## Why

`memory_continuity` and `hidden_payoff` anchors score against "seeded memories" and "hidden objectives", but the judge prompt carried the scenario name and description only; the narrator, judge and evidence report each rendered motives differently and none could see the motive behind a public act.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1502, +11)
- Judge and narrator prompts for `hoc_fatia_que_nao_existe` now carry four objectives, two seeded memories and per-act `[internally: …]` lines where the previous format had two engine-fallback strings in 68 events.
