### PR TITLE
feat(eval): honest calibration status, bench warnings, seeds/run-id flags

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -38,12 +38,18 @@ PERFECTMAN_LLM_MODEL=qwen3:8b \
 pnpm --filter @perfectman/eval bench --mode local --judge llm --out out/bench-local.json
 
 # heuristic LLM-as-judge with per-turn narrative-cohesion scoring.
-# The judge defaults to HIGH temperature (PERFECTMAN_JUDGE_TEMPERATURE) —
-# varied, creative reads expose cohesion/voice failures a strict low-temp
-# judge misses. Set it to 0 for deterministic calibration runs.
+# bench and calibrate both default the judge to temperature 0 — a judge
+# sampling creatively cannot gate a change, the same transcript scores
+# differently run to run. PERFECTMAN_JUDGE_TEMPERATURE overrides it.
 PERFECTMAN_LLM_PROVIDER=deepseek \
-PERFECTMAN_JUDGE_TEMPERATURE=1.0 \
 pnpm --filter @perfectman/eval bench --mode local --judge llm --per-turn --limit 6
+
+# experiment runs: N seeds per scenario, a pulse cap, and a committed
+# evidence directory (docs/eval/evidence/<run-id>/ with bench-report.json,
+# run-meta.json and per-scenario transcripts; refuses to overwrite without
+# --force). Per-axis mean/sd/min/max over the seeds lands in judgeAxisStats.
+pnpm --filter @perfectman/eval bench --slice hoc --mode local --judge llm \
+  --seeds 42,43,44 --pulse-limit 32 --run-id hoc-baseline-<sha7>
 
 # slices
 pnpm --filter @perfectman/eval bench --category edge_chaos
@@ -158,8 +164,8 @@ config file describes the experiment, the `.env` holds the secrets:
 3. otherwise the environment (`PERFECTMAN_JUDGE_BASE_URL` / `_MODEL` /
    `_TEMPERATURE`, `PERFECTMAN_LLM_*`, `PERFECTMAN_LLM_PROVIDER=deepseek`
    shortcut) — the env layer stays exactly as documented above;
-4. otherwise defaults (local qwen3:8b endpoint; bench temperature 1.0,
-   calibration 0).
+4. otherwise defaults (local qwen3:8b endpoint; temperature 0 for both
+   bench and calibration).
 
 `providerType` is `"openai-compatible" | "rule" | "mock"` — DeepSeek is
 not a type, it is an openai-compatible endpoint in a file. Secrets are

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -10,8 +10,9 @@
  * the LLM judge against the same endpoint.
  */
 
-import { writeFileSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { execSync } from "node:child_process";
 import {
   SCENARIO_REGISTRY,
   expandVariants,
@@ -31,7 +32,7 @@ import {
   type JuryVerdict,
 } from "../judge/judge.js";
 import { MockJudgeProvider } from "../judge/mock-judge-provider.js";
-import { calibrateJudge, baseScenarioId } from "../judge/calibration.js";
+import { calibrateJudge, baseScenarioId, calibrationVerdict } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import { GOLDEN_NARRATIONS } from "../judge/golden-narrations.js";
 import { loadJudgeConfig, applyJudgeShorthand } from "../llm/judge-config.js";
@@ -50,10 +51,29 @@ export function judgeConfig(): Promise<import("../judge/judge.js").LLMJudgeConfi
   return loadJudgeConfig([], { envOnly: true }).then((resolved) => resolved.config);
 }
 
+/** A non-fatal failure the bench kept going past; surfaced instead of swallowed. */
+export type BenchWarning = {
+  scenarioId?: string;
+  stage: "narration" | "narration_judge" | "golden_narration";
+  message: string;
+};
+
+export type AxisStats = { mean: number; sd: number; min: number; max: number; n: number };
+
 export type BenchReport = {
   version: "bench-report-v1";
   mode: "mock" | "local";
   generatedAt: string;
+  /** `--run-id`: the evidence directory this report was written to. */
+  runId?: string;
+  /** `--seeds`: every scenario ran once per seed; empty when the default seed was used. */
+  seeds: number[];
+  pulseLimit?: number;
+  warnings: BenchWarning[];
+  /** Per-axis spread over all runs (scenarios × seeds) — the number that decides whether a change beat the noise. */
+  judgeAxisStats: Record<string, AxisStats>;
+  /** Axis means split by rubric id, since a mixed selection aggregates axes that not every rubric scores. */
+  judgeAxisMeansByRubric: Record<string, Record<string, number>>;
   scenariosRun: number;
   scenariosFailed: number;
   signalPassRate: number;
@@ -97,6 +117,7 @@ export type BenchReport = {
     juryVoterCount?: number;
     /** Jury mode only: jurors that errored (label → reason) — non-empty means the verdict degraded. */
     juryFailed?: Record<string, string>;
+    seed?: number;
     narration?: Narration;
     narrativeAxisScores?: AxisScores;
     narrativeSalvaged?: boolean;
@@ -116,7 +137,22 @@ export async function runBench(opts: {
   perTurn?: boolean;
   /** CLI args for --judge-config resolution (defaults to the module args). */
   args?: string[];
+  /** `--seeds 42,43,44`: run every selected scenario once per seed. */
+  seeds?: number[];
+  /** `--pulse-limit N`: cap every run at N pulses (never above the scenario's own count). */
+  pulseLimit?: number;
+  /** `--run-id <id>`: write bench-report.json, run-meta.json and per-run transcripts under `<evidenceRoot>/<id>/`. */
+  runId?: string;
+  /** `--force`: allow `--run-id` to overwrite an existing evidence directory. */
+  force?: boolean;
+  /** Where `--run-id` directories go (default `docs/eval/evidence`). */
+  evidenceRoot?: string;
 }): Promise<BenchReport> {
+  const seeds = opts.seeds && opts.seeds.length > 0 ? opts.seeds : [];
+  const evidenceDir = opts.runId ? resolve(opts.evidenceRoot ?? "docs/eval/evidence", opts.runId) : undefined;
+  if (evidenceDir && existsSync(evidenceDir) && !opts.force) {
+    throw new Error(`Evidence directory already exists: ${evidenceDir} — pass --force to overwrite it`);
+  }
   const mode = opts.mode ?? "mock";
   const perTurn = opts.perTurn ?? false;
 
@@ -177,6 +213,12 @@ export async function runBench(opts: {
     version: "bench-report-v1",
     mode,
     generatedAt: new Date().toISOString(),
+    ...(opts.runId ? { runId: opts.runId } : {}),
+    seeds,
+    ...(opts.pulseLimit !== undefined ? { pulseLimit: opts.pulseLimit } : {}),
+    warnings: [],
+    judgeAxisStats: {},
+    judgeAxisMeansByRubric: {},
     scenariosRun: 0,
     scenariosFailed: 0,
     signalPassRate: 0,
@@ -201,7 +243,9 @@ export async function runBench(opts: {
   // equivalent (see NARRATIVE_RUBRIC's doc comment) — and jury narration
   // scoring is out of scope for now, so it runs only in single-judge
   // openai-compatible mode.
-  const scoreNarratives = !useJury && judgeMode === "openai-compatible";
+  // Under a jury the narration is scored by the primary judge config rather
+  // than dropped — narrative axes are part of the experiment's decision rule.
+  const scoreNarratives = judgeMode === "openai-compatible";
 
   const judgeScores = new Map<string, AxisScores>();
   const narrativeAxisAgg: Record<string, { sum: number; count: number }> = {};
@@ -216,9 +260,18 @@ export async function runBench(opts: {
   const allPromptVersions = new Set<string>();
   const allTemplateVersions = new Set<string>();
 
-  for (const scenario of limited) {
+  const axisValues: Record<string, number[]> = {};
+  const rubricAxisAgg: Record<string, Record<string, { sum: number; count: number }>> = {};
+  const evidenceRecords: Array<{ file: string; record: unknown }> = [];
+  const runSeeds: Array<number | undefined> = seeds.length > 0 ? seeds : [undefined];
+
+  for (const scenario of limited) for (const seed of runSeeds) {
     try {
-      const artifact: ScenarioRunArtifact = await ScenarioRunner.run(scenario, { llmMode: mode });
+      const artifact: ScenarioRunArtifact = await ScenarioRunner.run(scenario, {
+        llmMode: mode,
+        ...(seed !== undefined ? { seed } : {}),
+        ...(opts.pulseLimit !== undefined ? { pulseLimit: opts.pulseLimit } : {}),
+      });
       report.scenariosRun++;
       report.recoveredFallbacks += artifact.recoveredFallbacks ?? 0;
       report.signalsSkipped += artifact.skippedSignals ?? 0;
@@ -258,6 +311,11 @@ export async function runBench(opts: {
         axisAgg[axis] ??= { sum: 0, count: 0 };
         axisAgg[axis]!.sum += v;
         axisAgg[axis]!.count++;
+        (axisValues[axis] ??= []).push(v);
+        const byRubric = (rubricAxisAgg[scenario.rubric.id] ??= {});
+        byRubric[axis] ??= { sum: 0, count: 0 };
+        byRubric[axis]!.sum += v;
+        byRubric[axis]!.count++;
       }
 
       signalsPassed += artifact.passedSignals;
@@ -295,10 +353,14 @@ export async function runBench(opts: {
               narrativeAxisAgg[axis]!.count++;
             }
           }
-        } catch {
-          // Recorded as absent (no narrativeAxisScores) rather than thrown —
-          // consistent with how a single judge/probe failure elsewhere in
-          // this loop does not fail the whole scenario.
+        } catch (err) {
+          // Recorded as absent (no narrativeAxisScores) and as a warning —
+          // never thrown, so one narration failure does not fail the
+          // scenario, and never silent, so a shrinking narrative sample
+          // cannot pass unnoticed.
+          const message = err instanceof Error ? err.message : String(err);
+          report.warnings.push({ scenarioId: scenario.id, stage: narration ? "narration_judge" : "narration", message });
+          console.error(`[bench] ${scenario.id}: ${narration ? "narration judge" : "narration"} failed — ${message}`);
         }
       }
 
@@ -312,6 +374,7 @@ export async function runBench(opts: {
         axisScores,
         fallbackCount: artifact.fallbackCount,
         recoveredFallbacks: artifact.recoveredFallbacks ?? 0,
+        ...(seed !== undefined ? { seed } : {}),
         latencyMs: artifact.latencyMs,
         promptVersions: artifact.promptVersions,
         judgeSalvaged: judgeResult.salvaged,
@@ -321,6 +384,25 @@ export async function runBench(opts: {
         narrativeAxisScores,
         narrativeSalvaged,
       });
+      if (evidenceDir) {
+        evidenceRecords.push({
+          file: `${scenario.id}${seed !== undefined ? `__s${seed}` : ""}.json`,
+          record: {
+            id: scenario.id,
+            seed,
+            events: artifact.events,
+            axisScores,
+            narration,
+            narrativeAxisScores,
+            signalResults: artifact.signalResults,
+            probeResults: artifact.probeResults,
+            llmCalls: Object.fromEntries(artifact.llmCalls),
+            fallbackCount: artifact.fallbackCount,
+            fallbackNoOps: artifact.fallbackNoOps,
+            recoveredFallbacks: artifact.recoveredFallbacks,
+          },
+        });
+      }
     } catch (err) {
       report.scenariosFailed++;
       report.perScenario.push({
@@ -333,6 +415,7 @@ export async function runBench(opts: {
         axisScores: {},
         fallbackCount: 0,
         recoveredFallbacks: 0,
+        ...(seed !== undefined ? { seed } : {}),
         latencyMs: 0,
         promptVersions: [],
         failed: err instanceof Error ? err.message : String(err),
@@ -352,12 +435,36 @@ export async function runBench(opts: {
   report.judgeAxisMeans = Object.fromEntries(
     Object.entries(axisAgg).map(([id, a]) => [id, Math.round((a.sum / a.count) * 1000) / 1000]),
   );
-  const targets = selected[0]?.rubric.targets ?? [];
+  // Targets are the union over every selected rubric — a mixed selection
+  // (roleplay + hidden-objective) must show mask_integrity's bar, not just
+  // whatever the first scenario happened to score. Conflicting mins keep the
+  // stricter one.
+  const targetMin: Record<string, number> = {};
+  for (const scenario of limited) {
+    for (const t of scenario.rubric.targets) {
+      targetMin[t.axisId] = Math.max(targetMin[t.axisId] ?? 0, t.min);
+    }
+  }
   report.judgeAxisTargets = Object.fromEntries(
-    targets.map(t => [t.axisId, {
-      target: t.min,
-      met: (report.judgeAxisMeans[t.axisId] ?? 0) >= t.min,
+    Object.entries(targetMin).map(([axisId, min]) => [axisId, {
+      target: min,
+      met: (report.judgeAxisMeans[axisId] ?? 0) >= min,
     }]),
+  );
+  report.judgeAxisMeansByRubric = Object.fromEntries(
+    Object.entries(rubricAxisAgg).map(([rubricId, axes]) => [
+      rubricId,
+      Object.fromEntries(Object.entries(axes).map(([id, a]) => [id, Math.round((a.sum / a.count) * 1000) / 1000])),
+    ]),
+  );
+  report.judgeAxisStats = Object.fromEntries(
+    Object.entries(axisValues).map(([axis, values]) => {
+      const n = values.length;
+      const mean = values.reduce((s, v) => s + v, 0) / n;
+      const sd = n > 1 ? Math.sqrt(values.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1)) : 0;
+      const r = (x: number) => Math.round(x * 1000) / 1000;
+      return [axis, { mean: r(mean), sd: r(sd), min: Math.min(...values), max: Math.max(...values), n }];
+    }),
   );
   report.byCategory = Object.fromEntries(
     Object.entries(catAgg).map(([cat, a]) => [cat, {
@@ -389,9 +496,14 @@ export async function runBench(opts: {
       try {
         const result = await judgeNarration(golden.scenario, golden.events, golden.narration, resolvedJudge.config);
         if (!result.salvaged) narrativeJudgeScores.set(golden.id, result.axes);
-      } catch {
+      } catch (err) {
         // A single golden-narration judging failure must not sink the whole
-        // calibration report — it just contributes no data point for that id.
+        // calibration report — it contributes no data point for that id, and
+        // says so, because a calibration over fewer pairs than the golden
+        // set holds is a different (weaker) measurement.
+        const message = err instanceof Error ? err.message : String(err);
+        report.warnings.push({ scenarioId: golden.id, stage: "golden_narration", message });
+        console.error(`[bench] golden narration ${golden.id}: judge failed — ${message}`);
       }
     }
     report.narrativeCalibration = calibrateJudge(
@@ -406,7 +518,60 @@ export async function runBench(opts: {
     mkdirSync(dirname(outPath), { recursive: true });
     writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
   }
+  if (evidenceDir) {
+    writeEvidenceRun(evidenceDir, report, resolvedJudge, evidenceRecords, mode);
+  }
   return report;
+}
+
+/**
+ * `--run-id`: a committed, reproducible evidence directory. `run-meta.json`
+ * records what produced the numbers — git sha, generator and judge routes,
+ * seeds, pulse cap, prompt/template versions — and the NAMES of the
+ * PERFECTMAN_* environment variables in force, never their values.
+ */
+function writeEvidenceRun(
+  dir: string,
+  report: BenchReport,
+  judge: Awaited<ReturnType<typeof loadJudgeConfig>>,
+  records: ReadonlyArray<{ file: string; record: unknown }>,
+  mode: "mock" | "local",
+): void {
+  mkdirSync(join(dir, "scenarios"), { recursive: true });
+  let gitSha: string | null = null;
+  try {
+    gitSha = execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+  } catch {
+    gitSha = null;
+  }
+  const meta = {
+    runId: report.runId,
+    generatedAt: report.generatedAt,
+    gitSha,
+    mode,
+    generator: {
+      provider: process.env.PERFECTMAN_LLM_PROVIDER ?? null,
+      model: process.env.PERFECTMAN_LLM_MODEL ?? null,
+      baseUrl: process.env.PERFECTMAN_LLM_BASE_URL ?? null,
+    },
+    judge: {
+      providerType: judge.providerType,
+      model: judge.config.model,
+      baseUrl: judge.config.baseUrl,
+      temperature: judge.config.temperature ?? null,
+      jury: (judge.jury ?? []).map(j => ({ label: j.label ?? null, model: j.model, baseUrl: j.baseUrl })),
+    },
+    seeds: report.seeds,
+    pulseLimit: report.pulseLimit ?? null,
+    promptVersions: report.promptVersions,
+    promptTemplateVersions: report.promptTemplateVersions,
+    envVarNames: Object.keys(process.env).filter(k => k.startsWith("PERFECTMAN_")).sort(),
+  };
+  writeFileSync(join(dir, "run-meta.json"), JSON.stringify(meta, null, 2), "utf8");
+  writeFileSync(join(dir, "bench-report.json"), JSON.stringify(report, null, 2), "utf8");
+  for (const { file, record } of records) {
+    writeFileSync(join(dir, "scenarios", file), JSON.stringify(record, null, 2), "utf8");
+  }
 }
 
 function printReport(report: BenchReport): void {
@@ -427,15 +592,21 @@ function printReport(report: BenchReport): void {
   for (const [id, a] of Object.entries(report.probeAverages)) {
     console.log(`  ${id.padEnd(26)} ${a.mean.toFixed(3)} | ${(a.passedPct * 100).toFixed(0)}%`);
   }
-  console.log("\njudge axis means (target):");
+  console.log(`\njudge axis means (target)${report.seeds.length > 0 ? ` — seeds ${report.seeds.join(",")}, mean ± sd [min..max] n` : ""}:`);
   for (const [axis, mean] of Object.entries(report.judgeAxisMeans)) {
     const t = report.judgeAxisTargets[axis];
     const mark = t ? (t.met ? "OK" : "LOW") : "";
-    console.log(`  ${axis.padEnd(26)} ${mean.toFixed(2)} ${t ? `(>=${t.target}) ${mark}` : ""}`);
+    const s = report.judgeAxisStats[axis];
+    const spread = s && s.n > 1 ? ` ± ${s.sd.toFixed(2)} [${s.min}..${s.max}] n=${s.n}` : "";
+    console.log(`  ${axis.padEnd(26)} ${mean.toFixed(2)}${spread} ${t ? `(>=${t.target}) ${mark}` : ""}`);
+  }
+  if (report.warnings.length > 0) {
+    console.log(`\nwarnings (${report.warnings.length}) — recorded, not swallowed:`);
+    for (const w of report.warnings.slice(0, 8)) console.log(`  ${w.stage}${w.scenarioId ? ` ${w.scenarioId}` : ""}: ${w.message}`);
   }
   console.log("\ncalibration (judge vs golden labels):");
   const cal = report.calibration;
-  console.log(`  kappa ${cal.kappa} (target ${cal.targetKappa}) ${cal.passed ? "PASS" : "FAIL"} | alpha ${cal.alpha} | n=${cal.nScenes}`);
+  console.log(`  kappa ${cal.kappa} (target ${cal.targetKappa}) ${calibrationVerdict(cal)} | alpha ${cal.alpha} | matched ${cal.nScenes}/${cal.nGolden} scenes, ${cal.nAxisPairs} axes`);
   if (cal.disagreements.length > 0) {
     console.log("  disagreements:");
     for (const d of cal.disagreements.slice(0, 5)) console.log(`    - ${d}`);
@@ -449,7 +620,7 @@ function printReport(report: BenchReport): void {
     }
     console.log("\nnarrative calibration (judge vs golden narrations):");
     const ncal = report.narrativeCalibration;
-    console.log(`  kappa ${ncal.kappa} (target ${ncal.targetKappa}) ${ncal.passed ? "PASS" : "FAIL"} | alpha ${ncal.alpha} | n=${ncal.nScenes}`);
+    console.log(`  kappa ${ncal.kappa} (target ${ncal.targetKappa}) ${calibrationVerdict(ncal)} | alpha ${ncal.alpha} | matched ${ncal.nScenes}/${ncal.nGolden} scenes, ${ncal.nAxisPairs} axes`);
     if (ncal.disagreements.length > 0) {
       console.log("  disagreements:");
       for (const d of ncal.disagreements.slice(0, 5)) console.log(`    - ${d}`);
@@ -486,8 +657,13 @@ export async function main(): Promise<void> {
     // actually passed — absent, the file (and the rule default) decides.
     judge: args.includes("--judge") ? (argValue("--judge") as "rule" | "llm") : undefined,
     perTurn: args.includes("--per-turn"),
+    seeds: argValue("--seeds") ? (argValue("--seeds") ?? "").split(",").map(Number).filter(n => Number.isFinite(n)) : undefined,
+    pulseLimit: argValue("--pulse-limit") ? Number(argValue("--pulse-limit")) : undefined,
+    runId: argValue("--run-id"),
+    force: args.includes("--force"),
   });
   printReport(report);
+  if (report.runId) console.log(`\nevidence written under docs/eval/evidence/${report.runId}/`);
 }
 
 if (process.argv[1]?.endsWith("bench.js") || process.argv[1]?.endsWith("bench.ts")) {

--- a/packages/eval/src/cli/calibrate.ts
+++ b/packages/eval/src/cli/calibrate.ts
@@ -15,7 +15,7 @@ import { dirname, resolve } from "node:path";
 import { ScenarioRunner } from "../run/scenario-runner.js";
 import { ruleJudge, llmJudge } from "../judge/judge.js";
 import { MockJudgeProvider } from "../judge/mock-judge-provider.js";
-import { calibrateJudge } from "../judge/calibration.js";
+import { calibrateJudge, calibrationVerdict } from "../judge/calibration.js";
 import { GOLDEN_LABELS } from "../judge/golden-labels.js";
 import { loadJudgeConfig, applyJudgeShorthand } from "../llm/judge-config.js";
 import { getScenario } from "@perfectman/shared";
@@ -104,7 +104,7 @@ export async function main(): Promise<void> {
 
   const cal = report.calibration;
   console.log(`\n=== Calibration (mock transcripts, ${report.judge} judge, full length) ===`);
-  console.log(`kappa ${cal.kappa} (target ${cal.targetKappa}) ${cal.passed ? "PASS" : "FAIL"} | alpha ${cal.alpha} | n=${cal.nScenes}`);
+  console.log(`kappa ${cal.kappa} (target ${cal.targetKappa}) ${calibrationVerdict(cal)} | alpha ${cal.alpha} | matched ${cal.nScenes}/${cal.nGolden} scenes, ${cal.nAxisPairs} axes`);
   for (const [axis, k] of Object.entries(cal.perAxisKappa)) {
     console.log(`  ${axis.padEnd(26)} ${k.toFixed(3)}`);
   }

--- a/packages/eval/src/cli/evidence.ts
+++ b/packages/eval/src/cli/evidence.ts
@@ -328,7 +328,7 @@ export function writeEvidenceReport(
   md.push(`- Scenarios: ${evidence.length} (base, no rotation)`);
   md.push(`- Signal pass rate: ${pct(signalsPassed, signalsTotal)}`);
   md.push(`- Probe pass rate: ${pct(probesPassed, probesTotal)}`);
-  md.push(`- Judge calibration (rule judge vs golden labels): kappa ${cal.kappa} (target ${cal.targetKappa}) — ${cal.passed ? "PASS" : "FAIL (expected for v0 rule judge; calibrate with the LLM judge)"}\n`);
+  md.push(`- Judge calibration (rule judge vs golden labels): kappa ${cal.kappa} (target ${cal.targetKappa}) — ${cal.status === "pass" ? "PASS" : cal.status === "no_data" ? "NO DATA (no golden scene paired with a judged run)" : "FAIL (expected for v0 rule judge; calibrate with the LLM judge)"}\n`);
 
   md.push(`## By category (signals)\n`);
   md.push(`| Category | Pass |`);

--- a/packages/eval/src/judge/calibration.ts
+++ b/packages/eval/src/judge/calibration.ts
@@ -17,14 +17,30 @@ export type GoldenLabel = {
 };
 
 export type CalibrationReport = {
+  /** Golden entries offered for matching. */
+  nGolden: number;
+  /** Golden scenes that actually paired with a judge score on at least one axis. */
   nScenes: number;
+  /** Axes with enough matched pairs (>= 2) to compute a kappa. */
+  nAxisPairs: number;
   kappa: number;
   alpha: number;
   targetKappa: number;
-  passed: boolean;
+  /**
+   * `no_data` when nothing paired: a kappa of 0 over zero pairs is not a
+   * failing judge, it is an unmeasured one — reported as such so a run with
+   * no golden overlap never prints FAIL and never prints PASS.
+   */
+  status: "pass" | "fail" | "no_data";
+  /** `null` iff `status === "no_data"`. */
+  passed: boolean | null;
   perAxisKappa: Record<string, number>;
   disagreements: string[];
 };
+
+export function calibrationVerdict(report: CalibrationReport): string {
+  return report.status === "no_data" ? "NO DATA" : report.status === "pass" ? "PASS" : "FAIL";
+}
 
 function axisValue(scores: Record<string, number>, axis: string): number | undefined {
   const v = scores[axis];
@@ -114,6 +130,7 @@ export function calibrateJudge(
   const axisIds = new Set<string>();
   for (const g of golden) for (const k of Object.keys(g.axes)) axisIds.add(k);
   const perAxisKappa: Record<string, number> = {};
+  const matchedScenes = new Set<string>();
   let axisPairs = 0;
   let kappaSum = 0;
   let allA: number[] = [];
@@ -127,6 +144,7 @@ export function calibrateJudge(
       const j = sceneScores ? axisValue(sceneScores, axis) : undefined;
       const h = axisValue(g.axes, axis);
       if (typeof j === "number" && typeof h === "number") {
+        matchedScenes.add(g.scenarioId);
         a.push(j);
         b.push(h);
         if (Math.abs(j - h) >= 2) {
@@ -146,13 +164,18 @@ export function calibrateJudge(
 
   const kappa = axisPairs > 0 ? kappaSum / axisPairs : 0;
   const alpha = krippendorffAlpha(allA, allB);
+  const status: CalibrationReport["status"] =
+    axisPairs === 0 ? "no_data" : kappa >= targetKappa ? "pass" : "fail";
 
   return {
-    nScenes: golden.length,
+    nGolden: golden.length,
+    nScenes: matchedScenes.size,
+    nAxisPairs: axisPairs,
     kappa: Math.round(kappa * 1000) / 1000,
     alpha: Math.round(alpha * 1000) / 1000,
     targetKappa,
-    passed: kappa >= targetKappa,
+    status,
+    passed: status === "no_data" ? null : status === "pass",
     perAxisKappa,
     disagreements,
   };

--- a/packages/eval/src/test/bench-hygiene.test.ts
+++ b/packages/eval/src/test/bench-hygiene.test.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const runMock = vi.fn();
+vi.mock("../run/scenario-runner.js", () => ({
+  ScenarioRunner: { run: (...args: unknown[]) => runMock(...args) },
+}));
+
+const narrateMock = vi.fn();
+vi.mock("../narrator/narrator.js", () => ({
+  narrateScene: (...args: unknown[]) => narrateMock(...args),
+}));
+
+vi.mock("../judge/judge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../judge/judge.js")>();
+  return {
+    ...actual,
+    llmJudge: vi.fn().mockResolvedValue({ axes: { in_character: 4, voice_match: 5 }, salvaged: false, imputedAxes: [] }),
+    judgeNarration: vi.fn().mockResolvedValue({ axes: { concreteness: 4 }, salvaged: false, imputedAxes: [] }),
+  };
+});
+
+const { runBench } = await import("../cli/bench.js");
+
+function artifact(seed: unknown) {
+  return {
+    scenarioId: "s",
+    events: [],
+    agentStates: new Map(),
+    llmCalls: new Map(),
+    fallbackCount: 0,
+    operatorFailures: 0,
+    probeResults: [],
+    signalResults: [],
+    passedSignals: 0,
+    totalSignals: 0,
+    latencyMs: 1,
+    pulseResults: 1,
+    promptVersions: ["p1"],
+    templateVersions: ["t1"],
+    seedEcho: seed,
+  };
+}
+
+afterEach(() => {
+  runMock.mockReset();
+  narrateMock.mockReset();
+  delete process.env.PERFECTMAN_LLM_PROVIDER;
+});
+
+describe("bench hygiene", () => {
+  it("expands --seeds into one run per seed, threads seed and pulseLimit to the runner, and reports per-axis spread", async () => {
+    runMock.mockImplementation(async (_scenario: unknown, opts: { seed?: number }) => artifact(opts.seed));
+    const report = await runBench({ mode: "mock", scenarios: ["motive_gossip"], limit: 1, seeds: [42, 43], pulseLimit: 5 });
+    expect(runMock).toHaveBeenCalledTimes(2);
+    expect(runMock.mock.calls.map(c => (c[1] as { seed?: number }).seed)).toEqual([42, 43]);
+    expect((runMock.mock.calls[0]![1] as { pulseLimit?: number }).pulseLimit).toBe(5);
+    expect(report.perScenario.map(s => s.seed)).toEqual([42, 43]);
+    expect(report.seeds).toEqual([42, 43]);
+    const stats = report.judgeAxisStats["in_character"];
+    expect(stats?.n).toBe(2);
+    expect(stats?.min).toBeLessThanOrEqual(stats?.max ?? 0);
+  });
+
+  it("records a narration failure as a warning instead of swallowing it, without failing the scenario", async () => {
+    runMock.mockResolvedValue(artifact(undefined));
+    narrateMock.mockRejectedValue(new Error("narrator HTTP 503: boom"));
+    const report = await runBench({ mode: "mock", scenarios: ["motive_gossip"], limit: 1, judge: "llm", args: [] });
+    expect(report.scenariosFailed).toBe(0);
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toMatchObject({ stage: "narration", scenarioId: "motive_gossip__v0" });
+    expect(report.warnings[0]!.message).toContain("503");
+  });
+
+  it("unions judge targets across the selected scenarios' rubrics", async () => {
+    runMock.mockResolvedValue(artifact(undefined));
+    // --limit truncates AFTER variant expansion (7 per scenario), so 8 runs
+    // reach the first hoc variant.
+    const report = await runBench({ mode: "mock", scenarios: ["motive_gossip", "hoc_fatia_que_nao_existe"], limit: 8 });
+    expect(report.judgeAxisTargets["mask_integrity"]?.target).toBe(4);
+    expect(report.judgeAxisTargets["in_character"]?.target).toBe(4);
+    expect(Object.keys(report.judgeAxisMeansByRubric).sort()).toEqual(["hidden-objective-v1", "roleplay-v1"]);
+  });
+
+  it("writes an evidence directory for --run-id with run-meta carrying env var names only, and refuses to overwrite without --force", async () => {
+    runMock.mockResolvedValue(artifact(undefined));
+    process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
+    const root = mkdtempSync(join(tmpdir(), "bench-evidence-"));
+    const report = await runBench({ mode: "mock", scenarios: ["motive_gossip"], limit: 1, runId: "hoc-test", evidenceRoot: root, seeds: [7] });
+    const dir = join(root, "hoc-test");
+    expect(existsSync(join(dir, "bench-report.json"))).toBe(true);
+    expect(existsSync(join(dir, "scenarios", "motive_gossip__v0__s7.json"))).toBe(true);
+    const meta = JSON.parse(readFileSync(join(dir, "run-meta.json"), "utf8")) as Record<string, unknown>;
+    expect(meta["runId"]).toBe("hoc-test");
+    expect(meta["seeds"]).toEqual([7]);
+    expect(meta["envVarNames"]).toContain("PERFECTMAN_LLM_PROVIDER");
+    expect(JSON.stringify(meta)).not.toContain("sk-");
+    expect(report.runId).toBe("hoc-test");
+
+    await expect(runBench({ mode: "mock", scenarios: ["motive_gossip"], limit: 1, runId: "hoc-test", evidenceRoot: root })).rejects.toThrow(/--force/);
+    const forced = await runBench({ mode: "mock", scenarios: ["motive_gossip"], limit: 1, runId: "hoc-test", evidenceRoot: root, force: true, seeds: [8] });
+    expect(forced.runId).toBe("hoc-test");
+    const rewritten = JSON.parse(readFileSync(join(dir, "run-meta.json"), "utf8")) as Record<string, unknown>;
+    expect(rewritten["seeds"]).toEqual([8]);
+  });
+});

--- a/packages/eval/src/test/calibration-matching.test.ts
+++ b/packages/eval/src/test/calibration-matching.test.ts
@@ -32,8 +32,12 @@ describe("calibration matching (#24)", () => {
     expect(report.disagreements).toEqual([]);
   });
 
-  it("reports kappa 0 when nothing matches (vacuous case stays detectable)", () => {
+  it("reports no_data when nothing matches — never PASS, never FAIL", () => {
     const report = calibrateJudge(new Map(), GOLDEN_LABELS.slice(0, 1), 0.7);
-    expect(report.passed).toBe(false);
+    expect(report.status).toBe("no_data");
+    expect(report.passed).toBeNull();
+    expect(report.nGolden).toBe(1);
+    expect(report.nScenes).toBe(0);
+    expect(report.nAxisPairs).toBe(0);
   });
 });

--- a/packages/eval/src/test/judge-signals.test.ts
+++ b/packages/eval/src/test/judge-signals.test.ts
@@ -254,12 +254,17 @@ describe("calibration math", () => {
   });
 
   it("calibration report is honest on disagreement", () => {
+    // Two matched scenes: kappa needs >= 2 pairs per axis to be a measurement
+    // at all (one scene would be no_data, not a fail).
+    const allOnes = { in_character: 1, voice_match: 1, motive_authenticity: 1, interpretation: 1, creativity_unhinged: 1, memory_continuity: 1, no_ai_leak: 1 };
     const report = calibrateJudge(
-      new Map([["v1_casual_chat", { in_character: 1, voice_match: 1, motive_authenticity: 1, interpretation: 1, creativity_unhinged: 1, memory_continuity: 1, no_ai_leak: 1 }]]),
+      new Map([["v1_casual_chat", allOnes], ["v1_exclusion_inferred", allOnes]]),
       GOLDEN_LABELS,
       0.7,
     );
+    expect(report.status).toBe("fail");
     expect(report.passed).toBe(false);
+    expect(report.nScenes).toBe(2);
     expect(report.disagreements.length).toBeGreaterThan(0);
   });
 });

--- a/packages/eval/src/test/narration-calibration-matching.test.ts
+++ b/packages/eval/src/test/narration-calibration-matching.test.ts
@@ -32,12 +32,14 @@ describe("narration calibration matching (reuses calibrateJudge, not a new imple
     expect(report.disagreements).toEqual([]);
   });
 
-  it("reports kappa 0 when nothing matches (vacuous case stays detectable)", () => {
+  it("reports no_data when nothing matches — never PASS, never FAIL", () => {
     const report = calibrateJudge(
       new Map(),
       GOLDEN_NARRATIONS.slice(0, 1).map(g => ({ scenarioId: g.id, axes: g.axes, note: g.note })),
       0.7,
     );
-    expect(report.passed).toBe(false);
+    expect(report.status).toBe("no_data");
+    expect(report.passed).toBeNull();
+    expect(report.nScenes).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Makes the bench report honest about what it did not measure and gives it the flags an experiment needs:

- `CalibrationReport` gains `nGolden`, `nScenes` (actually matched), `nAxisPairs` and `status: "pass" | "fail" | "no_data"` with `passed: null` on no data — a kappa of 0 over zero pairs printed `FAIL` before; `calibrationVerdict` prints `NO DATA` in bench, calibrate and the evidence report.
- `BenchReport.warnings`: the narration, narration-judge and golden-narration `catch {}` blocks now record `{ scenarioId, stage, message }` and log it; a shrinking narrative sample can no longer pass unnoticed.
- `judgeAxisTargets` is the union over every selected rubric (stricter min wins) and `judgeAxisMeansByRubric` splits means by rubric id — a mixed roleplay + hidden-objective selection used to show only the first scenario's bar.
- `--seeds 42,43,44` runs each scenario once per seed (threaded to `RunnerOpts.seed`), records `perScenario[].seed` and `judgeAxisStats` (`mean`, `sd`, `min`, `max`, `n`); `--pulse-limit N` reaches `RunnerOpts.pulseLimit` for the first time; `--run-id <id>` writes `docs/eval/evidence/<id>/{bench-report.json, run-meta.json, scenarios/*.json}` and refuses an existing directory without `--force`. `run-meta.json` carries git sha, generator and judge routes, seeds, pulse cap, prompt/template versions and the *names* of the `PERFECTMAN_*` variables in force.
- Narration is scored under a jury too (primary judge config) instead of being dropped; `docs/eval/README.md` now states the temperature-0 default and the experiment flags.
- Six tests: seed expansion with per-axis spread, narration failure recorded as a warning without failing the scenario, target union across rubrics, evidence directory with env-var names only plus the `--force` refusal, and the two vacuous calibration cases now asserting `no_data`; the disagreement case matches two scenes so it measures a real `fail`.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1521, +4)
- `bench --slice hoc --mode mock --judge rule --seeds 1,2 --run-id smoke` writes the three artifacts and prints `NO DATA` for calibration (no golden overlap in a two-run smoke) where it printed `FAIL` before.
