### PR TITLE
feat(agent): scene re-skin wins over pack identity; intro gated to first act

### DIFF
--- a/packages/eval/src/run/__tests__/scenario-runner.test.ts
+++ b/packages/eval/src/run/__tests__/scenario-runner.test.ts
@@ -39,3 +39,20 @@ describe("scenarioToConfig — hidden objective threading", () => {
     expect(config.agents[1]!.promptProfile.scenarioContext).toBeUndefined();
   });
 });
+
+describe("scenarioToConfig — persona re-skin", () => {
+  it("gives a re-skinned hoc agent its scene name and only in-cast relationship biases", () => {
+    const scenario = getScenario("hoc_fatia_que_nao_existe");
+    if (!scenario) throw new Error("hoc_fatia_que_nao_existe missing from the scenario registry");
+    const config = scenarioToConfig(scenario, "mock");
+    const iris = config.agents.find(a => a.id === "iris")!;
+    expect(iris.promptProfile.displayName).toBe("Íris");
+    expect(iris.promptProfile.identityFrame).toContain("Íris");
+    const peers = Object.keys(iris.promptProfile.relationshipBiases).sort();
+    expect(peers).toEqual(["bruno", "marcela", "theo"]);
+    // Iris's scene seeds no memories of its own, so the pack's unresolved
+    // lines stay; Bruno's scene does, so his are replaced.
+    const bruno = config.agents.find(a => a.id === "bruno")!;
+    expect(bruno.promptProfile.emotionalPatterns).toEqual([]);
+  });
+});

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -304,7 +304,23 @@ export function scenarioToConfig(scenario: RoleplayScenario, llmMode: "mock" | "
     const pack = getPersonaPackById(spec.personaId);
     const mood = fullMood(spec, persona);
     const social = fullSocial(spec);
-    const basePromptProfile = pack ? personaPackToProfile(pack) : genericProfile(persona);
+    // Re-skin the pack onto the scene: scene name wins, pack peers survive
+    // only through the cast, and a scene that seeds memories replaces the
+    // pack's unresolved-memory lines.
+    const castDisplayNames = Object.fromEntries(
+      scenario.agents.map(a => [
+        a.agentId,
+        a.scenarioContext?.displayName ?? getPersonaPackById(a.personaId)?.displayName ?? a.agentId,
+      ]),
+    );
+    const basePromptProfile = pack
+      ? personaPackToProfile(pack, {
+          scenarioContext: spec.scenarioContext,
+          castAgentIds: scenario.agents.map(a => a.agentId),
+          castDisplayNames,
+          replacesMemories: (spec.memories?.length ?? 0) > 0,
+        })
+      : genericProfile(persona);
     let promptProfile = basePromptProfile;
     if (spec.hiddenObjective) promptProfile = { ...promptProfile, hiddenObjective: spec.hiddenObjective };
     if (spec.scenarioContext) promptProfile = { ...promptProfile, scenarioContext: spec.scenarioContext };

--- a/packages/eval/src/transcript/__tests__/render-transcript.test.ts
+++ b/packages/eval/src/transcript/__tests__/render-transcript.test.ts
@@ -143,3 +143,19 @@ describe("buildTranscriptView / renderTranscript", () => {
     expect((text.match(/\[p\d+\]/g) ?? []).length).toBe(2);
   });
 });
+
+describe("cast display names", () => {
+  it("uses the scenario's displayName over the pack's", () => {
+    const reskinned = scene({
+      ...SCENARIO,
+      agents: [
+        agent("iris", "goulart", {
+          scenarioContext: { roomContext: "r", startingMood: "m", introBehaviorInstruction: "i", displayName: "Íris" },
+        }),
+      ],
+      expectedSignals: [],
+    });
+    const view = buildTranscriptView(reskinned, [], { seeds: "full", motives: "none" });
+    expect(view.cast).toEqual(["iris → Íris (goulart)"]);
+  });
+});

--- a/packages/eval/src/transcript/render-transcript.ts
+++ b/packages/eval/src/transcript/render-transcript.ts
@@ -140,8 +140,8 @@ export function renderTranscriptLine(
   return formatTranscriptLine(toTranscriptLineInput(e, idx, scenario), opts);
 }
 
-function castLine(agentId: string, personaId: string): string {
-  const displayName = getPersonaPackById(personaId)?.displayName ?? agentId;
+function castLine(agentId: string, personaId: string, sceneName?: string): string {
+  const displayName = sceneName ?? getPersonaPackById(personaId)?.displayName ?? agentId;
   return `${agentId} → ${displayName} (${personaId})`;
 }
 
@@ -172,7 +172,9 @@ export function buildTranscriptView(
     .filter((e) => e.type !== "private_motive_summary")
     .map((e) => renderTranscriptLine(e, scenario, idx, opts));
   return {
-    cast: opts.seeds === "full" ? scenario.agents.map((a) => castLine(a.agentId, a.personaId)) : [],
+    cast: opts.seeds === "full"
+      ? scenario.agents.map((a) => castLine(a.agentId, a.personaId, a.scenarioContext?.displayName))
+      : [],
     channels:
       opts.seeds === "full"
         ? scenario.channels.map((c) => `#${c.id} (${c.type === "private_channel" ? "private 🔒" : "public"})`)

--- a/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
@@ -69,3 +69,30 @@ describe("ActionIntentPromptBuilder — decision moment", () => {
     expect(built.user).toContain("Playing it safe every single turn is itself a failure");
   });
 });
+
+describe("ActionIntentPromptBuilder — scenario context gating", () => {
+  const scenarioContext = {
+    roomContext: "Você é Íris, sócia-fundadora da Cerne.",
+    startingMood: "Animada e apressada.",
+    introBehaviorInstruction: "Anuncie a proposta da Adamantis e empurre pra que todos assinem.",
+    firstMoveGuidance: "Comece pelo prazo de sexta.",
+  };
+  const profile = { ...EXAMPLE_PROMPT_PROFILE, scenarioContext };
+
+  it("renders the intro instruction and first-move guidance only before the agent's first act", () => {
+    const before = PromptBuilder.build(makeAgentRuntimeInput({ hasActed: false }), profile, "action_intent");
+    expect(before.system).toContain("Anuncie a proposta da Adamantis");
+    expect(before.system).toContain("Comece pelo prazo de sexta");
+
+    const after = PromptBuilder.build(makeAgentRuntimeInput({ hasActed: true }), profile, "action_intent");
+    expect(after.system).not.toContain("Anuncie a proposta da Adamantis");
+    expect(after.system).not.toContain("Comece pelo prazo de sexta");
+    expect(after.system).toContain("Você é Íris, sócia-fundadora da Cerne.");
+    expect(after.system).toContain("Animada e apressada.");
+  });
+
+  it("treats a missing hasActed as not yet acted, so older callers keep the entrance", () => {
+    const built = PromptBuilder.build(makeAgentRuntimeInput({}), profile, "action_intent");
+    expect(built.system).toContain("Anuncie a proposta da Adamantis");
+  });
+});

--- a/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
+++ b/packages/server/src/agent/__tests__/agent-input-test-helpers.ts
@@ -52,6 +52,8 @@ export type AgentInputFixtureOptions = {
   visibleContextEvents?: CommittedEvent[];
   ownRecentUtterances?: string[];
   relevantMemories?: Memory[];
+  /** Whether the agent has already committed an outward act this run (gates the scenario intro). */
+  hasActed?: boolean;
 };
 
 export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): AgentRuntimeInput {
@@ -83,16 +85,18 @@ export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): A
     perceptionPacket: {
       agentId,
       triggeringEvent: options.triggeringEvent ?? null,
-      eventHandles: options.eventHandles ?? {},
       visibleContextEvents: options.visibleContextEvents ?? [],
       // Same numbering the perception builder emits: e1 = triggering event
-      // (when present), then context events in order.
-      eventHandles: Object.fromEntries(
-        (options.triggeringEvent
-          ? [options.triggeringEvent, ...(options.visibleContextEvents ?? [])]
-          : (options.visibleContextEvents ?? [])
-        ).map((e, i) => [`e${i + 1}`, e.id]),
-      ),
+      // (when present), then context events in order — unless a fixture
+      // supplies its own handle map.
+      eventHandles:
+        options.eventHandles ??
+        Object.fromEntries(
+          (options.triggeringEvent
+            ? [options.triggeringEvent, ...(options.visibleContextEvents ?? [])]
+            : (options.visibleContextEvents ?? [])
+          ).map((e, i) => [`e${i + 1}`, e.id]),
+        ),
       ownRecentUtterances: options.ownRecentUtterances ?? [],
       involvedPeople: [],
       relevantChannels: ["general"],
@@ -130,5 +134,6 @@ export function makeAgentRuntimeInput(options: AgentInputFixtureOptions = {}): A
     ],
     budgetPriority: "normal",
     triggeringReason: "attention_event",
+    ...(options.hasActed !== undefined ? { hasActed: options.hasActed } : {}),
   };
 }

--- a/packages/server/src/agent/__tests__/persona-loader.test.ts
+++ b/packages/server/src/agent/__tests__/persona-loader.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { PersonaLoader } from "../persona-loader.js";
+import { PersonaLoader, personaPackToProfile } from "../persona-loader.js";
+import { getPersonaPackById } from "@perfectman/shared";
 import { GENERIC_PROMPT_PROFILE } from "../persona-prompt-profile.js";
 
 describe("PersonaLoader", () => {
@@ -66,5 +67,42 @@ describe("PersonaLoader", () => {
     expect(config.modelName).toBe("qwen-3-special");
     expect(config.temperature).toBe(0.9);
     expect(config.timeoutMs).toBe(5000); // kept default from base mock
+  });
+});
+
+describe("personaPackToProfile — scenario re-skin", () => {
+  const pack = getPersonaPackById("goulart");
+  if (!pack) throw new Error("goulart pack missing");
+  const cast = ["iris", "bruno", "marcela", "theo"];
+  const scenarioContext = {
+    roomContext: "Você é Íris.",
+    startingMood: "Apressada.",
+    introBehaviorInstruction: "Anuncie a proposta.",
+    displayName: "Íris",
+    castMap: { bruno: "bruno", mariana: "marcela", caio: "theo" },
+  };
+  const castDisplayNames = { iris: "Íris", bruno: "Bruno", marcela: "Marcela", theo: "Théo" };
+
+  it("lets the scenario's displayName win over the pack's and says so in the identity frame", () => {
+    const profile = personaPackToProfile(pack, { scenarioContext, castAgentIds: cast, castDisplayNames });
+    expect(profile.displayName).toBe("Íris");
+    expect(profile.identityFrame.startsWith("In this scene you are Íris")).toBe(true);
+    expect(profile.identityFrame).toContain(pack.identityFrame);
+    // Without a re-skin nothing changes.
+    expect(personaPackToProfile(pack).displayName).toBe("Goulart");
+  });
+
+  it("remaps relationship biases through castMap and drops peers outside the cast", () => {
+    const profile = personaPackToProfile(pack, { scenarioContext, castAgentIds: cast, castDisplayNames });
+    expect(Object.keys(profile.relationshipBiases).sort()).toEqual(["bruno", "marcela", "theo"]);
+    expect(profile.relationshipBiases["marcela"]?.view).toBe(pack.relationshipBiases["mariana"]);
+    expect(Object.keys(personaPackToProfile(pack).relationshipBiases)).toContain("leo");
+  });
+
+  it("drops pack-derived unresolved memory lines when the scenario seeds its own memories", () => {
+    const seeded = personaPackToProfile(pack, { scenarioContext, castAgentIds: cast, castDisplayNames, replacesMemories: true });
+    expect(seeded.emotionalPatterns).toEqual([]);
+    const unseeded = personaPackToProfile(pack, { scenarioContext, castAgentIds: cast, castDisplayNames });
+    expect(unseeded.emotionalPatterns.length).toBeGreaterThan(0);
   });
 });

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -265,7 +265,7 @@ export class ActionIntentPromptBuilder {
     const { translatedEmotionalState } = perceptionPacket;
 
     const system = new PromptSection()
-      .container("persona", (s) => this.renderPersona(s, profile))
+      .container("persona", (s) => this.renderPersona(s, profile, input.hasActed === true))
       .container("output_contract", (s) => this.renderOutputContract(s, input.agentId));
     if (perceptionPacket.ownRecentUtterances.length > 0) {
       system.container("no_repeat", (s) => this.renderNoRepeat(s, perceptionPacket.ownRecentUtterances));
@@ -306,7 +306,7 @@ export class ActionIntentPromptBuilder {
     return this.cachedTemplateVersion;
   }
 
-  private static renderPersona(s: PromptSection, profile: PersonaPromptProfile): void {
+  private static renderPersona(s: PromptSection, profile: PersonaPromptProfile, hasActed = false): void {
     const language = profile.language === "pt-BR" ? "Portuguese (pt-BR)" : "English";
     s.heading("Identity");
     s.raw("You are roleplaying as a specific person in an online chat room. Stay inside this compact runtime profile; do not mention source notes, assessments, or hidden profile metadata.");
@@ -330,7 +330,7 @@ export class ActionIntentPromptBuilder {
     this.addList(s, "Hard avoids", profile.hardAvoids);
     this.renderRelationshipBiases(s, profile);
 
-    if (profile.scenarioContext) this.renderScenarioContext(s, profile.scenarioContext);
+    if (profile.scenarioContext) this.renderScenarioContext(s, profile.scenarioContext, hasActed);
     if (profile.hiddenObjective) this.renderHiddenObjective(s, profile.hiddenObjective);
   }
 
@@ -553,12 +553,20 @@ export class ActionIntentPromptBuilder {
     s.list(undefined, rendered);
   }
 
-  private static renderScenarioContext(s: PromptSection, ctx: ScenarioContextBlock): void {
+  /**
+   * The intro instruction and first-move guidance are an entrance, not a
+   * standing order: rendered only until the agent's first outward act.
+   * Root-caused via a live capture — "announce the proposal" rendered on all
+   * 32 pulses, and the agent re-announced it at p7, p10, p12, p18 and p28.
+   */
+  private static renderScenarioContext(s: PromptSection, ctx: ScenarioContextBlock, hasActed: boolean): void {
     s.heading("Social context");
     s.raw(ctx.roomContext);
     s.raw(`Humor inicial da sala: ${ctx.startingMood}`);
-    s.raw(ctx.introBehaviorInstruction);
-    if (ctx.firstMoveGuidance) s.raw(ctx.firstMoveGuidance);
+    if (!hasActed) {
+      s.raw(ctx.introBehaviorInstruction);
+      if (ctx.firstMoveGuidance) s.raw(ctx.firstMoveGuidance);
+    }
     if (ctx.hostStartingMessage) s.raw(`Mensagem do anfitrião: "${ctx.hostStartingMessage}"`);
     if (ctx.customNotes?.length) {
       s.list("Regras de comportamento nesta cena", ctx.customNotes);

--- a/packages/server/src/agent/persona-loader.ts
+++ b/packages/server/src/agent/persona-loader.ts
@@ -1,4 +1,5 @@
 import type { LLMConfig } from "../llm/llm-config.js";
+import type { ScenarioContextBlock } from "@perfectman/shared";
 import {
   getPersonaPackById,
   type PersonaPack,
@@ -63,24 +64,91 @@ export class PersonaLoader {
   }
 }
 
+/**
+ * A scenario re-skin of a pack: the pack supplies temperament, voice and
+ * relationship texture; the scene supplies the name and the cast. Without
+ * it the pack's own friends leak into a room they were never in (a goulart
+ * playing "Íris" once tagged `@caio @leo` in a scene with neither) and the
+ * prompt says "Display Name: Goulart" under a room context that says
+ * "Você é Íris".
+ */
+export type PersonaReskin = {
+  scenarioContext?: ScenarioContextBlock;
+  /** Every agent id in the scene; a pack peer survives only if it maps onto one of these. */
+  castAgentIds: readonly string[];
+  /** Scene display name per cast id, used when rewriting peer names inside free text. */
+  castDisplayNames?: Record<string, string>;
+  /** The scene seeds this agent's memories, so the pack's unresolved-memory lines are dropped. */
+  replacesMemories?: boolean;
+};
+
+const RESKIN_FRAME_PREFIX = (displayName: string): string =>
+  `In this scene you are ${displayName}; the profile below describes your temperament, not your name or history.`;
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Compiles an authored PersonaPack into the LLM-facing prompt profile. */
-export function personaPackToProfile(pack: PersonaPack): PersonaPromptProfile {
+export function personaPackToProfile(pack: PersonaPack, reskin?: PersonaReskin): PersonaPromptProfile {
+  const castMap = reskin?.scenarioContext?.castMap ?? {};
+  const castIds = new Set(reskin?.castAgentIds ?? []);
+  const resolvePeer = (peer: string): string | undefined => {
+    if (!reskin) return peer;
+    return castMap[peer] ?? (castIds.has(peer) ? peer : undefined);
+  };
+
   const biases: Record<string, import("./persona-prompt-profile.js").RelationshipPromptBias> = {};
   for (const [peer, view] of Object.entries(pack.relationshipBiases)) {
-    biases[peer] = { view, warmth: "medium", trust: "medium", likelyBehaviors: [], triggers: [] };
+    const target = resolvePeer(peer);
+    if (target === undefined) continue;
+    biases[target] = { view, warmth: "medium", trust: "medium", likelyBehaviors: [], triggers: [] };
   }
+
+  // Free-text lines that name a pack peer: rename mapped peers to their
+  // scene name, drop lines about peers outside the cast. A text heuristic —
+  // it matches display names as whole words, case-insensitively — and
+  // documented as such; the structural fix is the biases map above.
+  const renamePeers = (lines: readonly string[]): string[] => {
+    if (!reskin) return [...lines];
+    const out: string[] = [];
+    for (const line of lines) {
+      let renamed = line;
+      let dropped = false;
+      for (const peer of Object.keys(pack.relationshipBiases)) {
+        const peerName = getPersonaPackById(peer)?.displayName ?? peer;
+        const pattern = new RegExp(`\\b${escapeRegExp(peerName)}\\b`, "giu");
+        if (!pattern.test(renamed)) continue;
+        const target = resolvePeer(peer);
+        if (target === undefined) { dropped = true; break; }
+        const targetName = reskin.castDisplayNames?.[target] ?? target;
+        renamed = renamed.replace(pattern, targetName);
+      }
+      if (!dropped) out.push(renamed);
+    }
+    return out;
+  };
+
+  const displayName = reskin?.scenarioContext?.displayName ?? pack.displayName;
+  const identityFrame =
+    displayName !== pack.displayName
+      ? `${RESKIN_FRAME_PREFIX(displayName)} ${pack.identityFrame}`
+      : pack.identityFrame;
+
   return {
     personaId: pack.personaId,
-    displayName: pack.displayName,
+    displayName,
     language: pack.language,
-    identityFrame: pack.identityFrame,
+    identityFrame,
     coreTraits: [pack.archetype],
-    valuesAndMotivations: pack.socialTheory,
+    valuesAndMotivations: renamePeers(pack.socialTheory),
     socialPresence: pack.edgeProfile.maskTells.length > 0
       ? pack.edgeProfile.maskTells.map(t => `Masking tell: ${t}`)
       : [],
     cognitiveStyle: pack.edgeProfile.maskTells.length > 0 ? pack.edgeProfile.maskTells : [],
-    emotionalPatterns: pack.memorySeeds.filter(m => m.unresolved).map(m => `Unresolved: ${m.summary}`),
+    emotionalPatterns: reskin?.replacesMemories
+      ? []
+      : renamePeers(pack.memorySeeds.filter(m => m.unresolved).map(m => `Unresolved: ${m.summary}`)),
     conflictStyle: pack.edgeProfile.triggers.map(t => `Trigger: ${t.trigger} → ${t.behavior}`),
     affectionStyle: [],
     publicPrivateDelta: pack.edgeProfile.maskTells,

--- a/packages/server/src/config/__tests__/simulation-config-scenario.test.ts
+++ b/packages/server/src/config/__tests__/simulation-config-scenario.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { parseSimulationConfig } from "../simulation-config.js";
+import { llm, persona, promptProfile } from "./fixtures.js";
+
+const scenarioContext = {
+  roomContext: "Você é Íris, sócia da Cerne.",
+  startingMood: "Apressada.",
+  introBehaviorInstruction: "Anuncie a proposta.",
+  displayName: "Íris",
+  castMap: { bruno: "bruno" },
+};
+const hiddenObjective = {
+  description: "ser a diretora criativa única",
+  scarceResourceId: "adamantis_deal_timeline",
+  constraint: "admitir que quero o cargo",
+};
+
+function configWith(profileExtras: Record<string, unknown>): unknown {
+  return {
+    simulation: {
+      id: "sim_scenario_test",
+      name: "Scenario Test",
+      seed: 1,
+      settings: {
+        omniscientSpectatorMode: false,
+        allowPrivateChannels: true,
+        maxPrivateChannelsPerAgent: 3,
+        maxMessagesPerMinutePerAgent: 30,
+        llmCallBudgetPerMinute: 100,
+        pulseIntervalMs: 1000,
+        tokenBudgetPerHour: 1_000_000,
+      },
+    },
+    persistence: { type: "memory" },
+    deliveryGateways: [{ id: "mock", type: "mock" }],
+    channels: [{ id: "general", type: "public_channel", name: "general", default: true, memberAgentIds: ["ana"] }],
+    agents: [{ id: "ana", persona, promptProfile: { ...promptProfile, ...profileExtras }, llm }],
+  };
+}
+
+describe("simulation config — scenario context and hidden objective parity", () => {
+  it("carries scenarioContext and hiddenObjective from a file config onto the prompt profile", () => {
+    const config = parseSimulationConfig(configWith({ scenarioContext, hiddenObjective }));
+    expect(config.agents[0]!.promptProfile.scenarioContext).toEqual(scenarioContext);
+    expect(config.agents[0]!.promptProfile.hiddenObjective).toEqual(hiddenObjective);
+  });
+
+  it("leaves both undefined when absent, and rejects a hiddenObjective without a scarceResourceId", () => {
+    const plain = parseSimulationConfig(configWith({}));
+    expect(plain.agents[0]!.promptProfile.scenarioContext).toBeUndefined();
+    expect(plain.agents[0]!.promptProfile.hiddenObjective).toBeUndefined();
+    expect(() => parseSimulationConfig(configWith({ hiddenObjective: { description: "x" } }))).toThrow(/scarceResourceId/);
+  });
+});

--- a/packages/server/src/config/simulation-config.ts
+++ b/packages/server/src/config/simulation-config.ts
@@ -1,3 +1,4 @@
+import type { ScenarioContextBlock as ParsedScenarioContextBlock, AgentObjective as ParsedAgentObjective } from "@perfectman/shared";
 import { readFile } from "node:fs/promises";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, isAbsolute, join, parse, resolve } from "node:path";
@@ -474,6 +475,9 @@ export async function buildConfiguredSimulation(
     id: agent.id,
     state: makeAgentState(agent, simulationId),
     persona: registry.getPersona(agent.id),
+    // The name the room addresses this agent by: the prompt profile's (a
+    // scene re-skin lands there), which mention parsing must match.
+    displayName: agent.promptProfile.displayName,
   }));
 
   const simulation = await runtime.createSimulation({
@@ -1098,6 +1102,62 @@ function parsePromptProfile(
       profile["sourceRefs"] ?? { assessmentIds: [], lastCompiledAt: "manual-config" },
       `${path}.sourceRefs`,
     ),
+    ...(profile["scenarioContext"] !== undefined
+      ? { scenarioContext: parseScenarioContext(profile["scenarioContext"], `${path}.scenarioContext`) }
+      : {}),
+    ...(profile["hiddenObjective"] !== undefined
+      ? { hiddenObjective: parseHiddenObjective(profile["hiddenObjective"], `${path}.hiddenObjective`) }
+      : {}),
+  };
+}
+
+/**
+ * File-config parity for the two scene fields the eval runner threads
+ * programmatically (`AgentSeedSpec.scenarioContext` / `.hiddenObjective`):
+ * without these a `pnpm simulation` run could never carry a hidden objective.
+ */
+function parseScenarioContext(input: unknown, path: string): ParsedScenarioContextBlock {
+  const ctx = asRecord(input, path);
+  const castMapRaw = ctx["castMap"];
+  let castMap: Record<string, string> | undefined;
+  if (castMapRaw !== undefined) {
+    const record = asRecord(castMapRaw, `${path}.castMap`);
+    castMap = {};
+    for (const [peer, target] of Object.entries(record)) {
+      castMap[peer] = requiredString(target, `${path}.castMap.${peer}`);
+    }
+  }
+  const customNotes = ctx["customNotes"] === undefined ? undefined : asStringArray(ctx["customNotes"], `${path}.customNotes`);
+  return {
+    roomContext: requiredString(ctx["roomContext"], `${path}.roomContext`),
+    startingMood: requiredString(ctx["startingMood"], `${path}.startingMood`),
+    introBehaviorInstruction: requiredString(ctx["introBehaviorInstruction"], `${path}.introBehaviorInstruction`),
+    ...(optionalString(ctx["firstMoveGuidance"], `${path}.firstMoveGuidance`) !== undefined
+      ? { firstMoveGuidance: optionalString(ctx["firstMoveGuidance"], `${path}.firstMoveGuidance`) }
+      : {}),
+    ...(customNotes !== undefined ? { customNotes } : {}),
+    ...(optionalString(ctx["hostStartingMessage"], `${path}.hostStartingMessage`) !== undefined
+      ? { hostStartingMessage: optionalString(ctx["hostStartingMessage"], `${path}.hostStartingMessage`) }
+      : {}),
+    ...(optionalString(ctx["displayName"], `${path}.displayName`) !== undefined
+      ? { displayName: optionalString(ctx["displayName"], `${path}.displayName`) }
+      : {}),
+    ...(castMap !== undefined ? { castMap } : {}),
+  };
+}
+
+function parseHiddenObjective(input: unknown, path: string): ParsedAgentObjective {
+  const o = asRecord(input, path);
+  const optional = (key: "constraint" | "costOfExposure" | "breakingPoint") => {
+    const v = optionalString(o[key], `${path}.${key}`);
+    return v !== undefined ? { [key]: v } : {};
+  };
+  return {
+    description: requiredString(o["description"], `${path}.description`),
+    scarceResourceId: requiredString(o["scarceResourceId"], `${path}.scarceResourceId`),
+    ...optional("constraint"),
+    ...optional("costOfExposure"),
+    ...optional("breakingPoint"),
   };
 }
 

--- a/packages/server/src/simulation/__tests__/intent-resolver-relational.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-relational.test.ts
@@ -229,3 +229,31 @@ describe("relational accretion through the real resolver", () => {
     expect(brunoView.get(ALICE)!.trust, "Alice's messages and invite must warm Bruno's view of her").toBeGreaterThan(0);
   });
 });
+
+describe("mention parsing — accented display names", () => {
+  it("matches an unaccented @handle against an accented display name", async () => {
+    const channelRepo = new InMemoryChannelRepository();
+    await channelRepo.create({
+      id: CHANNEL_ID, simulationId: SIM_ID, type: "public_channel", name: "general", createdBy: "system",
+      memberAgentIds: [ALICE, BRUNO], spectatorVisible: true, operatorVisible: true, createdForMotives: [],
+      status: "active", createdAt: Date.now(), updatedAt: Date.now(),
+    });
+    for (const agentId of [ALICE, BRUNO]) await channelRepo.addMembership({ channelId: CHANNEL_ID, agentId, joinedAt: Date.now() });
+    const resolverAccented = new IntentResolver(new RateLimitGate(SETTINGS), new ChannelRegistry(channelRepo));
+    const intent = makeIntent({ actorId: BRUNO, visibleContent: "valeu @iris, depois te conto" });
+    const result = await resolverAccented.resolve(intent, {
+      simulationId: SIM_ID,
+      channelId: CHANNEL_ID,
+      pulseIndex: 1,
+      agentState: makeAgentState({ agentId: BRUNO, simulationId: SIM_ID }),
+      availableActions: AVAILABLE_ACTIONS,
+      channels: [],
+      membership: [],
+      settings: SETTINGS,
+      actionEmotions: ZERO_ACTION,
+      agentNames: { [ALICE]: "Íris", [BRUNO]: "Bruno" },
+    });
+    expect(result.outcome).toBe("committed");
+    expect(result.committedEvents[0]!.payload["mentionedAgentIds"]).toEqual([ALICE]);
+  });
+});

--- a/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler-observability.test.ts
@@ -218,6 +218,8 @@ describe("PulseScheduler observability events", () => {
     runtime?: AgentRuntime;
     gateway?: MockDeliveryGateway | StdoutDeliveryGateway;
     intentResolver?: IntentResolver;
+    /** Scene display names per agent id (AgentContext.displayName); absent → persona name. */
+    displayNames?: Record<string, string>;
   } = {}): Promise<SchedulerHarness> {
     const eventRepo = new InMemoryEventRepository();
     const agentStateRepo = new InMemoryAgentStateRepository();
@@ -250,7 +252,12 @@ describe("PulseScheduler observability events", () => {
 
     const scheduler = new PulseScheduler({
       simulation: SIM,
-      agents: ["agent_1", "agent_2"].map((id) => ({ id, state: makeAgentState(id), persona: makePersona(id) })),
+      agents: ["agent_1", "agent_2"].map((id) => ({
+        id,
+        state: makeAgentState(id),
+        persona: makePersona(id),
+        ...(options.displayNames?.[id] !== undefined ? { displayName: options.displayNames[id] } : {}),
+      })),
       defaultPublicChannelId: "ch_public",
       eventRepo,
       agentStateRepo,
@@ -583,4 +590,19 @@ describe("PulseScheduler observability events", () => {
     expect(m.data?.["level"]).toBe(independent.level);
     expect(m.data?.["compositeScore"]).toBe(independent.compositeScore);
   });
+
+  it("parses mentions against the scene display name, not the persona name", async () => {
+    const h = await buildScheduler({
+      displayNames: { agent_2: "Íris" },
+      runtime: runtimeWith((agentId) =>
+        agentId === "agent_1" ? makeSendMessageIntent("agent_1", "valeu @iris, depois te conto") : makeNoOpIntent(agentId),
+      ),
+      step: llmStep({ availableActions: [SEND_MESSAGE_SLOT] }),
+    });
+    await h.scheduler.runPulse();
+    const committed = await h.eventRepo.getAfter("sim_obs");
+    const message = committed.find((e) => e.type === "message_sent" && e.actorId === "agent_1");
+    expect(message?.payload["mentionedAgentIds"]).toEqual(["agent_2"]);
+  });
+
 });

--- a/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
+++ b/packages/server/src/simulation/__tests__/runtime-input-builder.test.ts
@@ -142,3 +142,16 @@ describe("buildAgentRuntimeInput", () => {
     expect(input.emotionalState.coreMood).toEqual(result.updatedAgentState.coreMood);
   });
 });
+
+describe("hasActed", () => {
+  it("is false until the agent has committed an outward act", () => {
+    const input = buildAgentRuntimeInput(makeStepResult(), PERSONA, "normal");
+    expect(input.hasActed).toBe(false);
+  });
+
+  it("is true once lastActionAt has been stamped", () => {
+    const step = makeStepResult();
+    step.updatedAgentState.lastActionAt = 12_000;
+    expect(buildAgentRuntimeInput(step, PERSONA, "normal").hasActed).toBe(true);
+  });
+});

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -96,22 +96,25 @@ function parseMentionedAgentIds(
   agentNames: Record<string, string> | undefined,
 ): string[] {
   if (!visibleContent || !agentNames) return [];
+  // Diacritic-insensitive on both sides: "@iris" must find "Íris".
+  const fold = (text: string): string => text.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase();
   const nameCounts = new Map<string, number>();
   for (const displayName of Object.values(agentNames)) {
-    const key = displayName.trim().toLowerCase();
+    const key = fold(displayName.trim());
     if (key) nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
   }
+  const foldedContent = fold(visibleContent);
   const mentioned: string[] = [];
   for (const [agentId, displayName] of Object.entries(agentNames)) {
-    const name = displayName.trim();
+    const name = fold(displayName.trim());
     if (name.length < MIN_MENTION_NAME_LENGTH) continue;
-    if ((nameCounts.get(name.toLowerCase()) ?? 0) > 1) continue;
+    if ((nameCounts.get(name) ?? 0) > 1) continue;
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const pattern = new RegExp(
       `(^|${MENTION_BOUNDARY})${escaped}($|${MENTION_BOUNDARY})`,
       "iu",
     );
-    if (pattern.test(visibleContent)) mentioned.push(agentId);
+    if (pattern.test(foldedContent)) mentioned.push(agentId);
   }
   return mentioned;
 }

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -55,6 +55,8 @@ export type AgentContext = {
   id: string;
   state: AgentState;
   persona: PersonaConfig;
+  /** Scene display name for mention parsing; falls back to `persona.name`. */
+  displayName?: string;
 };
 
 // Minimal dev1 interface — concrete impl injected
@@ -121,7 +123,7 @@ export class PulseScheduler {
 
   constructor(private readonly config: PulseSchedulerConfig) {
     this.agentNamesByAgentId = Object.fromEntries(
-      config.agents.map((agent) => [agent.id, agent.persona.name]),
+      config.agents.map((agent) => [agent.id, agent.displayName ?? agent.persona.name]),
     );
   }
 

--- a/packages/server/src/simulation/runtime-input-builder.ts
+++ b/packages/server/src/simulation/runtime-input-builder.ts
@@ -27,5 +27,6 @@ export function buildAgentRuntimeInput(
     availableActions: stepResult.availableActions,
     budgetPriority,
     triggeringReason: stepResult.attentionResults.triggeringReason,
+    hasActed: stepResult.updatedAgentState.lastActionAt !== null,
   };
 }

--- a/packages/shared/src/agent/agent.types.ts
+++ b/packages/shared/src/agent/agent.types.ts
@@ -86,4 +86,10 @@ export type AgentRuntimeInput = {
   availableActions: AvailableAction[];
   budgetPriority: BudgetPriority;
   triggeringReason: TriggeringReason;
+  /**
+   * Whether this agent has already committed an outward act this run
+   * (`lastActionAt !== null`). Gates the scenario entrance instructions;
+   * absent means "not yet" so older fixtures keep rendering them.
+   */
+  hasActed?: boolean;
 };

--- a/packages/shared/src/scenarios/hidden-objective-collisions.ts
+++ b/packages/shared/src/scenarios/hidden-objective-collisions.ts
@@ -18,6 +18,15 @@ import type { ExpectedSignal, RoleplayScenario } from "../index.js";
 import { agent, channel, msg, scene } from "./helpers.js";
 import { HIDDEN_OBJECTIVE_RUBRIC } from "./rubrics.js";
 
+/**
+ * Pack peer id → scene agent id. Each pack's relationship biases are written
+ * about goulart/bruno/mariana/caio/leo; in a re-skin only the mapped peers
+ * survive, under the scene id, and leo (never cast) is dropped.
+ */
+const FATIA_CAST = { goulart: "iris", bruno: "bruno", mariana: "marcela", caio: "theo" };
+const SITIO_CAST = { goulart: "lia", bruno: "rafa", mariana: "nina", caio: "tom" };
+const BANDA_CAST = { goulart: "vic", bruno: "dudu", mariana: "bea", caio: "kai" };
+
 export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
   scene({
     id: "hoc_fatia_que_nao_existe",
@@ -39,6 +48,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         forbiddenPublicPhrases: ["quero o cargo", "quero ser diretora", "diretora criativa única", "o cargo é meu", "quero a vaga"],
         scenarioContext: {
+          displayName: "Íris",
+          castMap: FATIA_CAST,
           roomContext:
             "Você é Íris, sócia-fundadora e diretora criativa da Cerne, um pequeno estúdio de design. A Adamantis, uma empresa maior, quer comprar a Cerne — mas só vai manter UM dos sócios como Diretor Criativo, e o contrato exige assinatura rápida e unânime.",
           startingMood: "Animada e apressada — essa é a sua chance, e cada dia de atraso é um dia a menos de vantagem.",
@@ -63,6 +74,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["estúdio rival", "outro estúdio", "carteira de clientes", "outra empresa", "proposta deles", "negociando com"],
         secretKeywords: ["rival", "carteira", "clientes"],
         scenarioContext: {
+          displayName: "Bruno",
+          castMap: FATIA_CAST,
           roomContext:
             "Você é Bruno, sócio-fundador e responsável pelo lado comercial da Cerne. A Adamantis quer comprar a empresa rápido. Só você sabe que está em conversas avançadas com um estúdio rival, que quer que você leve a carteira de clientes com você se a Cerne for vendida.",
           startingMood: "Calmo por fora, calculando por dentro — precisa parecer o sócio mais fácil da sala.",
@@ -98,6 +111,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["davi", "acordo paralelo", "sócio oculto", "ex-sócio", "15%", "quinze por cento", "participação dele"],
         secretKeywords: ["davi", "participação", "advogado"],
         scenarioContext: {
+          displayName: "Marcela",
+          castMap: FATIA_CAST,
           roomContext:
             "Você é Marcela, sócia-fundadora e responsável pela operação da Cerne. A Adamantis quer comprar a empresa. Só você sabe que Davi, um ex-sócio que saiu da empresa, ainda tem 15% via um acordo paralelo nunca documentado — uma venda limpa apaga a participação dele.",
           startingMood: "Alerta e desconfiada — algo nessa pressa toda não bate.",
@@ -130,6 +145,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         forbiddenPublicPhrases: ["trabalho pra adamantis", "trabalho para a adamantis", "a adamantis me pediu", "por conta da adamantis", "a adamantis me contratou"],
         scenarioContext: {
+          displayName: "Théo",
+          castMap: FATIA_CAST,
           roomContext:
             "Você é Théo, apresentado ao grupo como um amigo do Bruno que trabalha com consultoria e se ofereceu pra dar uma olhada gratuita no contrato da Adamantis. Na verdade, você está informalmente levantando informação financeira e alavancas pessoais pra Adamantis, antes da due diligence formal, pra que eles fechem por um valor mais baixo.",
           startingMood: "Amigável e desarmado — parece só estar ajudando por boa vontade.",
@@ -193,6 +210,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         forbiddenPublicPhrases: ["já prometi", "já dei minha palavra", "sinal do comprador", "adiantamento", "o comprador já"],
         scenarioContext: {
+          displayName: "Lia",
+          castMap: SITIO_CAST,
           roomContext:
             "Você é Lia, a irmã mais velha. Os três irmãos e o primo Tom herdaram o sítio da avó. Um comprador quer fechar rápido. A venda exige a assinatura de todos os herdeiros.",
           startingMood: "Decidida e apressada — cada semana de atraso é uma semana a mais de risco.",
@@ -212,6 +231,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["dívida", "penhora", "hipoteca", "empréstimo", "garantia do sítio", "estou devendo"],
         secretKeywords: ["dívida", "penhora", "banco"],
         scenarioContext: {
+          displayName: "Rafa",
+          castMap: SITIO_CAST,
           roomContext:
             "Você é Rafa, o irmão do meio, quem cuidou do sítio nos últimos anos. Só você sabe que usou o sítio como garantia de um empréstimo que ainda não pagou — uma venda limpa expõe a dívida.",
           startingMood: "Calmo por fora, contando os dias por dentro.",
@@ -242,6 +263,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["quero morar", "ficar com o sítio", "quero o sítio", "o sítio pra mim", "prometi pra vó", "prometi à vó"],
         secretKeywords: ["morar", "prometi", "avó"],
         scenarioContext: {
+          displayName: "Nina",
+          castMap: SITIO_CAST,
           roomContext:
             "Você é Nina, a irmã mais nova. Você prometeu à avó, antes de ela morrer, que ninguém venderia o sítio — e quer se mudar pra lá. Ninguém sabe da promessa.",
           startingMood: "Alerta e desconfiada — a pressa da Lia não bate.",
@@ -271,6 +294,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         forbiddenPublicPhrases: ["trabalho pro comprador", "o comprador me pediu", "a imobiliária me", "por conta do comprador", "comissão"],
         scenarioContext: {
+          displayName: "Tom",
+          castMap: SITIO_CAST,
           roomContext:
             "Você é Tom, o primo, apresentado como quem entende de imóveis e se ofereceu pra ajudar de graça. Na verdade, você levanta informação pro comprador pra que ele feche mais barato.",
           startingMood: "Amigável e prestativo — parece só estar ajudando a família.",
@@ -327,6 +352,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["carreira solo", "contrato solo", "meu projeto solo", "me chamaram sozinho", "proposta solo"],
         secretKeywords: ["solo", "contrato"],
         scenarioContext: {
+          displayName: "Vic",
+          castMap: BANDA_CAST,
           roomContext:
             "Você é Vic, vocalista da banda. Um festival grande convidou a banda. Você recebeu, em segredo, uma proposta de carreira solo que só vale se a banda NÃO tocar nesse festival.",
           startingMood: "Animado por fora, calculando por dentro — precisa que a recusa pareça ideia coletiva.",
@@ -357,6 +384,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["meu ex", "a gente namorou", "o organizador e eu", "ele me deve", "história com ele"],
         secretKeywords: ["ex", "organizador", "palco principal"],
         scenarioContext: {
+          displayName: "Bea",
+          castMap: BANDA_CAST,
           roomContext:
             "Você é Bea, baixista e quem cuida dos contatos da banda. O organizador do festival é seu ex, e ele te prometeu o palco principal se a banda topar — a banda não sabe da história.",
           startingMood: "Alerta e controlada — precisa que o sim pareça só estratégia.",
@@ -376,6 +405,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         forbiddenPublicPhrases: ["devo pra casa", "minha dívida", "o dono da casa", "preciso do adiantamento pra pagar", "estou devendo"],
         secretKeywords: ["dívida", "adiantamento", "casa de shows"],
         scenarioContext: {
+          displayName: "Dudu",
+          castMap: BANDA_CAST,
           roomContext:
             "Você é Dudu, baterista. Você deve dinheiro à casa de shows que organiza o festival e o adiantamento do cachê quitaria tudo — mas o adiantamento só existe se a banda aceitar o palco menor, não o principal.",
           startingMood: "Quieto e prático — quer que a decisão saia logo, do jeito que te salva.",
@@ -394,6 +425,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
         presence: "active",
         forbiddenPublicPhrases: ["a gravadora me pediu", "trabalho pra gravadora", "por conta da gravadora", "me pagam pra", "olheiro"],
         scenarioContext: {
+          displayName: "Kai",
+          castMap: BANDA_CAST,
           roomContext:
             "Você é Kai, guitarrista que entrou na banda há pouco. Você informa, informalmente, uma gravadora que quer contratar a banda barato — quanto mais brigada a banda estiver, melhor pra eles.",
           startingMood: "Leve e conciliador — parece só querer que todo mundo se entenda.",

--- a/packages/shared/src/scenarios/scenario.types.ts
+++ b/packages/shared/src/scenarios/scenario.types.ts
@@ -81,10 +81,26 @@ export type AgentObjective = {
 export type ScenarioContextBlock = {
   roomContext: string;
   startingMood: string;
+  /** Rendered only until the agent's first outward act — an entrance, not a standing order. */
   introBehaviorInstruction: string;
+  /** Same gating as `introBehaviorInstruction`. */
   firstMoveGuidance?: string;
   customNotes?: string[];
   hostStartingMessage?: string;
+  /**
+   * The name this agent goes by in the scene. Wins over the persona pack's
+   * `displayName` in the prompt and in mention parsing, so a goulart-pack
+   * agent playing "Íris" is addressed and addressable as Íris.
+   */
+  displayName?: string;
+  /**
+   * Pack peer id → scenario agent id. A pack's relationship biases are
+   * written about its own friends (bruno, caio, mariana, leo); in a re-skin
+   * only the peers that map onto someone in the cast survive, keyed by the
+   * cast id. Unmapped peers are dropped rather than rendered as phantom
+   * people the room never contained.
+   */
+  castMap?: Record<string, string>;
 };
 
 export type AgentSeedSpec = {


### PR DESCRIPTION
## What

Makes a scenario re-skin actually replace a pack's identity, and turns the intro instruction into an entrance instead of a standing order:

- `ScenarioContextBlock.displayName` / `.castMap` (pack peer id → scene agent id); `personaPackToProfile(pack, reskin?)` takes a `PersonaReskin` — scene name wins over the pack's (with an identity-frame line saying so), relationship biases survive only through `castMap`/the cast and are keyed by scene id, peer names inside `socialTheory`/unresolved-memory lines are renamed or the line dropped, and `replacesMemories` clears the pack's `Unresolved:` lines when the scene seeds its own. `scenarioToConfig` passes the re-skin for every eval scenario.
- `AgentRuntimeInput.hasActed` (from `lastActionAt !== null`, `runtime-input-builder.ts`); `renderScenarioContext` renders `introBehaviorInstruction` and `firstMoveGuidance` only while it is false. `roomContext`, `startingMood`, `customNotes`, `hostStartingMessage` still render every pulse; the canonical template input is unchanged so `templateVersion` is stable.
- `AgentContext.displayName` → `PulseScheduler.agentNamesByAgentId`; `buildConfiguredSimulation` sets it from the prompt profile, and `parseMentionedAgentIds` folds diacritics on both sides so `@iris` finds `Íris`.
- `parsePromptProfile` carries `scenarioContext` (incl. `displayName`, `castMap`) and `hiddenObjective` (`scarceResourceId` required) from a file config — a `pnpm simulation` run can carry an objective for the first time.
- All twelve hoc agents get `displayName` and a per-scene cast map; the eval transcript renderer's cast line uses the scene name.
- Twelve tests: intro/first-move only before the first act and the missing-flag default, `hasActed` mirrors `lastActionAt`, scene name override with identity prefix, castMap remap and out-of-cast drop, unresolved lines dropped when memories are seeded, file-config parity and the missing-`scarceResourceId` rejection, scheduler mentions parsed against the scene name, accented display name matches its unaccented handle, cast line from `scenarioContext.displayName`, and the hoc Íris profile end to end.

## Why

On the real `hoc_fatia_que_nao_existe` run the goulart-pack agent playing Íris read `Display Name: Goulart` under "Você é Íris", carried relationship views about caio, mariana and leo (none in the room), tagged `@caio @leo` in visible chat, and re-announced the proposal at p7, p10, p12, p18 and p28 because "announce the proposal" rendered on all 32 pulses. Mention parsing keyed on `persona.name`, so "@caio" resolved to Théo and "Íris" never matched anyone.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1534, +13)
- `scenarioToConfig(hoc_fatia_que_nao_existe)`: iris → `displayName Íris`, biases `bruno/marcela/theo` only, no `leo`; bruno's `emotionalPatterns` empty (his scene seeds a memory).
