### PR TITLE
feat(engine): decision owns needsLLM; cooldown, low-urge floor, cold start once

### DIFF
--- a/docs/adr/0015-decision-owns-needs-llm.md
+++ b/docs/adr/0015-decision-owns-needs-llm.md
@@ -1,0 +1,53 @@
+# ADR-0015: The Decision Owns `needsLLM`
+
+**Status**: Accepted (LOCKED, 2026-09-05) — rationale and rejected alternatives inline in this ADR (decisions **D-50..D-54**).
+
+**Numbering note**: written against ADRs 0001..0014; in-tree decision high-water mark **D-49** (ADR-0014). The D-50..D-54 range is this ADR's.
+
+## Context
+
+On a real 32-pulse, 4-agent `hoc_fatia_que_nao_existe` run one agent made an LLM call and posted on every pulse (33 of 68 events), re-announcing the scene's opening line at pulses 7, 10, 12, 18 and 28, while the other three agents made 9–12 calls. Five mechanisms combined, all verified in code:
+
+1. `scoreAttention` set `needsLLM` on any high/critical-salience new event *including the agent's own* (`score-attention.ts`). A high-arousal persona stamps `high` salience on her own messages (`deriveSalience` in the resolver), so speaking forced the next call.
+2. `runEngineStep` re-raised `needsLLM` from attention onto any decision that was not `no_op`/`memory_only` — a `delay` still produced an LLM call, and the scheduler gates the call on `needsLLM` alone.
+3. `hasNewEvents` is structurally true in any room with more than one agent (own events re-enter the cursor), so a cooldown keyed on "nothing new" never armed.
+4. `cold_start_bootstrap` is decay-exempt, regrows at `growthRate × energy` and re-crossed its 0.30 threshold every ~5–6 pulses for the whole run — the observed re-announcement cadence.
+5. Pressures are recomputed statelessly from emotional baselines; a `high urge_to_provoke` existed every pulse with zero events, and no inhibition available to the persona outranked it (`STRENGTH_RANK` tops at 3, `INTENSITY_RANK` at 4).
+
+Three components each believed they owned the LLM gate. Constraint carried in: the engine stays pure and deterministic; the scheduler must not become a second owner of cognition (a per-pulse LLM cap would hide the model instead of fixing it).
+
+## Decision
+
+1. **The decision is the single owner of `needsLLM` (D-50).** `resolveDecision` takes a `DecisionContext` (`hasNewEvents`, `addressed`, `salientForeignEvent`, `initiativeProceed`, `pulseIndex`, `initiativeCandidates`, `justActed`); `needsLLM` is exactly `outcome === "act"`; the re-raise in `runEngineStep` is deleted. Attention's own `needsLLM` stays as an operator-facing read and now excludes the agent's own events.
+2. **Every act passes one gate (D-51).** Cooldown: `justActed && !addressed && urge < overwhelming → delay`. Floor: a `low` top urge with nothing addressed, nothing salient from others and no initiative → `no_op`. The empty-pressure initiative path and the initiative-override path go through the same gate.
+3. **Being addressed lifts a cooldown and a delay-favoring inhibition, never a no-op-favoring one (D-52).** "Notices a mention and replies" stays a V1 target; "fear of rejection" stays a reason not to.
+4. **A `delay` produces a `noOpRecord` (D-53).** Cooldowns become visible to operators and to the `silence_cascade` attractor instead of vanishing.
+5. **Cold start fires once (D-54).** `cold_start_bootstrap` is retired to 0 once `lastActionAt !== null`; post-first-act silence is the boredom accumulator's job. Pressure and inhibition ids are derived (`${agentId}:${type}`) so the step's determinism test can compare whole results.
+
+## Rationale
+
+- Ownership over thresholds: making attention's cooldown stronger could not work — the salience clause bypassed `dueScore` entirely. Routing attention's verdicts *into* the decision is the layering the pipeline doc describes (`attention → … → decision`).
+- The gate uses only information the step already has; no new state, no new constants (`overwhelming` is the existing exemption, `low` the existing bottom rank).
+- Retiring cold start needs no constant either: "never acted" is already a state (`lastActionAt === null`).
+- Property tests (fast-check, already an engine devDependency) pin the invariant "an unaddressed agent never acts on two consecutive pulses" across generated pressure/inhibition mixes — a stricter generator than production, since accumulators are not relieved in it.
+
+## Rejected Alternatives
+
+- **Scheduler-side cap on consecutive LLM calls** — a second, non-cognitive owner of the gate, exactly the class of defect being removed (D-50).
+- **Stronger attention cooldown** — only affects `dueScore`, which the salience clause bypassed (D-50).
+- **Cooldown keyed on `!hasNewEvents`** — never true in a multi-agent room (D-51).
+- **Making `INITIATIVE_COOLDOWN_PULSES` longer for cold start** — still re-fires; the source is semantically one-shot (D-54).
+
+## Consequences
+
+- Fewer LLM calls per pulse for hot personas; a `delay` now really skips the call. Turn share is measured by the eval's `act-share-max` probe and the experiment protocol's decision rule.
+- Existing engine tests that built a `resolveDecision` call positionally migrate to the context object; the initiative relief seam test still sees `cold_start_bootstrap` fall after an act (to 0, by retirement).
+- Pressure discharge (the stateless-baseline mechanism, item 5) is a separate decision — this ADR removes the ownership defects; without discharge a hot persona can still alternate act/skip.
+- Emotion-magnitude baselines and the rank asymmetry stay as #119 items.
+
+## Cross-links
+
+- ADR-0014 (motive events; the observability that made the monopoly measurable).
+- Issue #119 (fix map), #124 (`lastActionAt` relief), #129 (conversation-quality audit this feeds).
+- Code: `packages/engine/src/decision/resolve-decision.ts`, `packages/engine/src/step/run-engine-step.ts`, `packages/engine/src/attention/score-attention.ts`, `packages/engine/src/initiative/update-initiative-accumulators.ts`, `packages/shared/src/decision/decision.types.ts`.
+- Tests: `decision-gates.test.ts`, `decision.property.test.ts`, `attention.test.ts`, `engine-step.test.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ ADR-0001..0007 pre-date this convention and are historical records: their Status
 | [ADR-0010](0010-goal-layer-llm-slice.md) | Goal-Layer LLM Slice |
 | [ADR-0013](0013-memory-formation-and-relational-accretion.md) | Memory Formation And Relational Accretion |
 | [ADR-0014](0014-private-motive-committed-event.md) | Private Motive As A Committed Event |
+| [ADR-0015](0015-decision-owns-needs-llm.md) | The Decision Owns `needsLLM` |
 
 ## Template
 

--- a/packages/engine/src/__tests__/attention.test.ts
+++ b/packages/engine/src/__tests__/attention.test.ts
@@ -188,3 +188,14 @@ describe("scoreAttention", () => {
     expect(result.reasons).toContain("boredom_threshold");
   });
 });
+
+describe("own events and needsLLM", () => {
+  it("a high-salience event authored by the agent itself does not set needsLLM", () => {
+    const agent = makeAgent();
+    const own = makeEvent("e1", { actorId: agent.agentId, emotionalSalience: "high" });
+    const result = scoreAttention(agent, CAIO, [own], DEFAULT_WORLD, new Map(), null, 3000);
+    expect(result.needsLLM).toBe(false);
+    const foreign = makeEvent("e2", { actorId: "other1", emotionalSalience: "high" });
+    expect(scoreAttention(agent, CAIO, [foreign], DEFAULT_WORLD, new Map(), null, 3000).needsLLM).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/decision-gates.test.ts
+++ b/packages/engine/src/__tests__/decision-gates.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import type { Pressure, Inhibition, AgentState, DecisionContext, InitiativeAccumulator, CoreMood, SocialEmotions } from "@perfectman/shared";
+import { CAIO } from "@perfectman/shared";
+import { resolveDecision } from "../decision/resolve-decision.js";
+import { updateInitiativeAccumulators, scoreInitiativeCandidates } from "../initiative/update-initiative-accumulators.js";
+
+const BASE_MOOD: CoreMood = { valence: 0, arousal: 0.5, stability: 0.6, energy: 0.6, circumplexAngle: 1.5, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 };
+const ZERO_SOCIAL: SocialEmotions = { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 };
+
+const ZERO_ACTIONS = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+function agent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    agentId: "a1", simulationId: "sim1", personaId: "caio", presence: "active",
+    coreMood: BASE_MOOD, socialEmotions: ZERO_SOCIAL, relationalStates: new Map(), memories: [],
+    initiativeAccumulators: [], lastProcessedEventId: null, lastActionAt: null, lastRuminationPulse: null,
+    arrivalPulse: null, createdAt: 1700000000000, updatedAt: 1700000000000, ...overrides,
+  };
+}
+
+function pressure(type: Pressure["type"], intensity: Pressure["intensity"]): Pressure {
+  return { id: `a1:${type}`, agentId: "a1", type, targetAgentIds: [], intensity, sourceEventIds: [], sourceMotivations: [], sourceEmotions: [], visibilityPreference: "public", decayRate: 0.1 };
+}
+
+function inhibition(type: Inhibition["type"], strength: Inhibition["strength"]): Inhibition {
+  return { id: `a1:${type}`, agentId: "a1", type, strength, reason: "test" };
+}
+
+function ctx(overrides: Partial<DecisionContext> = {}): DecisionContext {
+  return { hasNewEvents: false, addressed: false, salientForeignEvent: false, initiativeProceed: false, pulseIndex: 6, initiativeCandidates: [], justActed: false, ...overrides };
+}
+
+describe("cooldown after acting (ADR-0015)", () => {
+  it("a non-overwhelming urge right after acting cools down — delay, no LLM", () => {
+    const d = resolveDecision([pressure("urge_to_message", "medium")], [], agent(), CAIO, ctx({ justActed: true, hasNewEvents: true }));
+    expect(d.outcome).toBe("delay");
+    expect(d.needsLLM).toBe(false);
+    expect(d.noOpReason).toBe("delayed_intention");
+  });
+
+  it("being addressed lifts the cooldown; an unaddressed foreign message does not", () => {
+    const addressed = resolveDecision([pressure("urge_to_message", "medium")], [], agent(), CAIO, ctx({ justActed: true, hasNewEvents: true, addressed: true }));
+    expect(addressed.outcome).toBe("act");
+    expect(addressed.needsLLM).toBe(true);
+    const foreign = resolveDecision([pressure("urge_to_message", "medium")], [], agent(), CAIO, ctx({ justActed: true, hasNewEvents: true, salientForeignEvent: true }));
+    expect(foreign.outcome).toBe("delay");
+  });
+
+  it("the initiative-driven and initiative-override act paths cool down too", () => {
+    const initiative = resolveDecision([], [], agent(), CAIO, ctx({ justActed: true, initiativeProceed: true }));
+    expect(initiative.outcome).toBe("delay");
+    const override = resolveDecision(
+      [pressure("urge_to_message", "low")],
+      [inhibition("strategic_patience_hold", "medium")],
+      agent(),
+      CAIO,
+      ctx({ justActed: true, pulseIndex: 9, initiativeCandidates: [{ source: "boredom_accumulator", score: 0.9, proceed: true, cooldownRemaining: 0 }] }),
+    );
+    expect(override.outcome).toBe("delay");
+  });
+
+  it("an overwhelming urge is never cooled down", () => {
+    const d = resolveDecision([pressure("urge_to_provoke", "overwhelming")], [], agent(), CAIO, ctx({ justActed: true }));
+    expect(d.outcome).toBe("act");
+    expect(d.needsLLM).toBe(true);
+  });
+});
+
+describe("low-urge floor", () => {
+  it("a low-only urge with nothing addressed, nothing salient from others and no initiative is a no_op", () => {
+    const d = resolveDecision([pressure("urge_to_message", "low")], [], agent(), CAIO, ctx({ hasNewEvents: true }));
+    expect(d.outcome).toBe("no_op");
+    expect(d.needsLLM).toBe(false);
+    expect(d.noOpReason).toBe("noticed_but_ignored");
+  });
+
+  it("a low urge acts when a salient event from someone else arrived, or when addressed, or on initiative", () => {
+    expect(resolveDecision([pressure("urge_to_message", "low")], [], agent(), CAIO, ctx({ salientForeignEvent: true })).outcome).toBe("act");
+    expect(resolveDecision([pressure("urge_to_message", "low")], [], agent(), CAIO, ctx({ addressed: true })).outcome).toBe("act");
+    expect(resolveDecision([pressure("urge_to_message", "low")], [], agent(), CAIO, ctx({ initiativeProceed: true })).outcome).toBe("act");
+  });
+
+  it("being addressed lifts a delay-favoring inhibition but never a no-op-favoring one", () => {
+    const patience = resolveDecision([pressure("urge_to_message", "low")], [inhibition("strategic_patience_hold", "high")], agent(), CAIO, ctx({ addressed: true }));
+    expect(patience.outcome).toBe("act");
+    const rejection = resolveDecision([pressure("urge_to_message", "low")], [inhibition("fear_of_rejection", "medium")], agent(), CAIO, ctx({ addressed: true }));
+    expect(rejection.outcome).toBe("no_op");
+  });
+});
+
+describe("cold_start_bootstrap retirement", () => {
+  it("fires before the first act and sits at 0 for the rest of the run afterwards", () => {
+    let fresh: InitiativeAccumulator[] = [];
+    for (let i = 0; i < 3; i++) fresh = updateInitiativeAccumulators(fresh, ZERO_ACTIONS, agent(), CAIO, i, false);
+    expect(scoreInitiativeCandidates(fresh, 3, null).find(c => c.source === "cold_start_bootstrap")?.proceed).toBe(true);
+
+    const acted = agent({ lastActionAt: 5_000 });
+    let after = fresh;
+    for (let i = 3; i < 23; i++) {
+      after = updateInitiativeAccumulators(after, ZERO_ACTIONS, acted, CAIO, i, i === 3);
+      expect(after.find(a => a.source === "cold_start_bootstrap")?.value, `pulse ${i}`).toBe(0);
+    }
+    expect(scoreInitiativeCandidates(after, 23, null).find(c => c.source === "cold_start_bootstrap")?.proceed).toBe(false);
+  });
+});

--- a/packages/engine/src/__tests__/decision.property.test.ts
+++ b/packages/engine/src/__tests__/decision.property.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import type { Pressure, Inhibition, AgentState, DecisionContext, CoreMood, SocialEmotions } from "@perfectman/shared";
+import { CAIO } from "@perfectman/shared";
+import { resolveDecision } from "../decision/resolve-decision.js";
+
+const BASE_MOOD: CoreMood = { valence: 0, arousal: 0.5, stability: 0.6, energy: 0.6, circumplexAngle: 1.5, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 };
+const ZERO_SOCIAL: SocialEmotions = { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 };
+const AGENT: AgentState = {
+  agentId: "a1", simulationId: "sim1", personaId: "caio", presence: "active",
+  coreMood: BASE_MOOD, socialEmotions: ZERO_SOCIAL, relationalStates: new Map(), memories: [],
+  initiativeAccumulators: [], lastProcessedEventId: null, lastActionAt: null, lastRuminationPulse: null,
+  arrivalPulse: null, createdAt: 1, updatedAt: 1,
+};
+
+const INTENSITY_RANK = { low: 1, medium: 2, high: 3, overwhelming: 4 } as const;
+const STRENGTH_RANK = { low: 1, medium: 2, high: 3 } as const;
+const NOOP_FAVORING = new Set(["fear_of_rejection", "social_anxiety_block", "fear_of_exclusion_worsening", "vulnerability_guard"]);
+
+// urge_to_withdraw is excluded: overwhelming-and-alone it is the memory_only
+// branch, a different contract from the act gates under test.
+const PRESSURE_TYPES = ["urge_to_reply", "urge_to_message", "urge_to_defend_self", "urge_to_mock", "urge_to_react", "urge_to_show_off", "urge_to_dominate", "urge_to_provoke", "urge_to_create_private_channel"] as const;
+const INHIBITION_TYPES = ["fear_of_looking_needy", "fear_of_escalating", "fear_of_rejection", "fear_of_exclusion_worsening", "shame_about_desire", "social_anxiety_block", "status_protection", "conflict_avoidance", "vulnerability_guard", "contempt_concealment", "strategic_patience_hold", "intimacy_fear", "performance_anxiety", "repair_doubt"] as const;
+
+function pressures(intensities: readonly Pressure["intensity"][]) {
+  return fc.array(
+    fc.record({ type: fc.constantFrom(...PRESSURE_TYPES), intensity: fc.constantFrom(...intensities) }),
+    { maxLength: 3 },
+  ).map(list =>
+    list
+      .map((p): Pressure => ({ id: `a1:${p.type}`, agentId: "a1", type: p.type, targetAgentIds: [], intensity: p.intensity, sourceEventIds: [], sourceMotivations: [], sourceEmotions: [], visibilityPreference: "public", decayRate: 0.1 }))
+      .sort((a, b) => INTENSITY_RANK[b.intensity] - INTENSITY_RANK[a.intensity]),
+  );
+}
+
+const inhibitions = fc.array(
+  fc.record({ type: fc.constantFrom(...INHIBITION_TYPES), strength: fc.constantFrom("low", "medium", "high") }),
+  { maxLength: 2 },
+).map(list =>
+  list
+    .map((i): Inhibition => ({ id: `a1:${i.type}`, agentId: "a1", type: i.type, strength: i.strength, reason: "gen" }))
+    .sort((a, b) => STRENGTH_RANK[b.strength] - STRENGTH_RANK[a.strength]),
+);
+
+const pulseInput = (intensities: readonly Pressure["intensity"][]) =>
+  fc.record({
+    pressures: pressures(intensities),
+    inhibitions,
+    hasNewEvents: fc.boolean(),
+    salientForeignEvent: fc.boolean(),
+    initiativeProceed: fc.boolean(),
+    pulseIndex: fc.integer({ min: 0, max: 40 }),
+  });
+
+function ctxFor(input: { hasNewEvents: boolean; salientForeignEvent: boolean; initiativeProceed: boolean; pulseIndex: number }, extra: Partial<DecisionContext>): DecisionContext {
+  return { ...input, addressed: false, initiativeCandidates: [], justActed: false, ...extra };
+}
+
+describe("resolveDecision properties", () => {
+  it("P1: an unaddressed agent never acts on two consecutive pulses (no overwhelming urges)", () => {
+    // The generator samples initiativeProceed independently of justActed,
+    // which is stricter than production (accumulators are relieved after an
+    // act): the invariant must hold even then.
+    fc.assert(
+      fc.property(fc.array(pulseInput(["low", "medium", "high"]), { minLength: 2, maxLength: 12 }), (pulses) => {
+        let prevActed = false;
+        for (const p of pulses) {
+          const d = resolveDecision(p.pressures, p.inhibitions, AGENT, CAIO, ctxFor(p, { justActed: prevActed }));
+          const acted = d.outcome === "act";
+          expect(acted && prevActed).toBe(false);
+          prevActed = acted;
+        }
+      }),
+    );
+  });
+
+  it("P2: consecutive acts happen only on an overwhelming top urge", () => {
+    fc.assert(
+      fc.property(fc.array(pulseInput(["low", "medium", "high", "overwhelming"]), { minLength: 2, maxLength: 12 }), (pulses) => {
+        let prevActed = false;
+        for (const p of pulses) {
+          const d = resolveDecision(p.pressures, p.inhibitions, AGENT, CAIO, ctxFor(p, { justActed: prevActed }));
+          const acted = d.outcome === "act";
+          if (acted && prevActed) expect(p.pressures[0]?.intensity).toBe("overwhelming");
+          prevActed = acted;
+        }
+      }),
+    );
+  });
+
+  it("P3: being addressed always reaches the LLM unless a no-op-favoring or high inhibition outranks the urge", () => {
+    fc.assert(
+      fc.property(pulseInput(["low", "medium", "high"]), fc.boolean(), (p, justActed) => {
+        const d = resolveDecision(p.pressures, p.inhibitions, AGENT, CAIO, ctxFor(p, { addressed: true, justActed }));
+        const top = p.pressures[0];
+        const inh = p.inhibitions[0];
+        const blocked =
+          top !== undefined && inh !== undefined &&
+          STRENGTH_RANK[inh.strength] >= INTENSITY_RANK[top.intensity] &&
+          (NOOP_FAVORING.has(inh.type) || STRENGTH_RANK[inh.strength] >= 3);
+        if (!blocked) {
+          expect(d.outcome).toBe("act");
+          expect(d.needsLLM).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("P4: needsLLM is exactly `outcome === act`, and the function is pure", () => {
+    fc.assert(
+      fc.property(pulseInput(["low", "medium", "high", "overwhelming"]), fc.boolean(), fc.boolean(), (p, addressed, justActed) => {
+        const ctx = ctxFor(p, { addressed, justActed });
+        const a = resolveDecision(p.pressures, p.inhibitions, AGENT, CAIO, ctx);
+        const b = resolveDecision(p.pressures, p.inhibitions, AGENT, CAIO, ctx);
+        expect(a).toEqual(b);
+        expect(a.needsLLM).toBe(a.outcome === "act");
+      }),
+    );
+  });
+});

--- a/packages/engine/src/__tests__/decision.test.ts
+++ b/packages/engine/src/__tests__/decision.test.ts
@@ -6,6 +6,7 @@ import type {
   CoreMood,
   SocialEmotions,
   InitiativeAccumulator,
+  DecisionContext,
 } from "@perfectman/shared";
 import { CAIO, GOULART, BRUNO, createSeededRng } from "@perfectman/shared";
 import { resolveDecision } from "../decision/resolve-decision.js";
@@ -76,16 +77,30 @@ function makeInhibition(type: Inhibition["type"], strength: Inhibition["strength
   };
 }
 
+/** Decision context with the quiet defaults: not addressed, nothing salient from others, did not just act. */
+function ctx(overrides: Partial<DecisionContext> = {}): DecisionContext {
+  return {
+    hasNewEvents: false,
+    addressed: false,
+    salientForeignEvent: false,
+    initiativeProceed: false,
+    pulseIndex: 1,
+    initiativeCandidates: [],
+    justActed: false,
+    ...overrides,
+  };
+}
+
 // --- resolveDecision ---
 describe("resolveDecision", () => {
   it("no pressures + no initiative → no_op", () => {
-    const result = resolveDecision([], [], makeAgent(), CAIO, false, false, 1);
+    const result = resolveDecision([], [], makeAgent(), CAIO, ctx({ hasNewEvents: false, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("no_op");
     expect(result.needsLLM).toBe(false);
   });
 
   it("no pressures + initiative proceed → act with LLM", () => {
-    const result = resolveDecision([], [], makeAgent(), CAIO, false, true, 1);
+    const result = resolveDecision([], [], makeAgent(), CAIO, ctx({ hasNewEvents: false, initiativeProceed: true, pulseIndex: 1 }));
     expect(result.outcome).toBe("act");
     expect(result.needsLLM).toBe(true);
     expect(result.initiativeProceed).toBe(true);
@@ -93,7 +108,7 @@ describe("resolveDecision", () => {
 
   it("pressure with no inhibition → act with LLM", () => {
     const pressures = [makePressure("urge_to_message", "medium")];
-    const result = resolveDecision(pressures, [], makeAgent(), CAIO, true, false, 1);
+    const result = resolveDecision(pressures, [], makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("act");
     expect(result.needsLLM).toBe(true);
   });
@@ -101,20 +116,20 @@ describe("resolveDecision", () => {
   it("strong inhibition >= pressure → delay or no_op", () => {
     const pressures = [makePressure("urge_to_message", "low")];
     const inhibitions = [makeInhibition("strategic_patience_hold", "medium")];
-    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, true, false, 1);
+    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
     expect(["delay", "no_op"]).toContain(result.outcome);
   });
 
   it("strategic_patience_hold inhibition → delay outcome", () => {
     const pressures = [makePressure("urge_to_message", "low")];
     const inhibitions = [makeInhibition("strategic_patience_hold", "high")];
-    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, true, false, 1);
+    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("delay");
   });
 
   it("overwhelming shame withdrawal alone → memory_only", () => {
     const pressures = [makePressure("urge_to_withdraw", "overwhelming")];
-    const result = resolveDecision(pressures, [], makeAgent(), CAIO, false, false, 1);
+    const result = resolveDecision(pressures, [], makeAgent(), CAIO, ctx({ hasNewEvents: false, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("memory_only");
     expect(result.needsLLM).toBe(false);
   });
@@ -122,13 +137,13 @@ describe("resolveDecision", () => {
   it("high pressure > inhibition → act", () => {
     const pressures = [makePressure("urge_to_provoke", "high")];
     const inhibitions = [makeInhibition("conflict_avoidance", "low")];
-    const result = resolveDecision(pressures, inhibitions, makeAgent(), GOULART, true, false, 1);
+    const result = resolveDecision(pressures, inhibitions, makeAgent(), GOULART, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("act");
   });
 
   it("privateMotiveSeed is set", () => {
     const pressures = [makePressure("urge_to_message", "medium")];
-    const result = resolveDecision(pressures, [], makeAgent(), CAIO, true, false, 1);
+    const result = resolveDecision(pressures, [], makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.privateMotiveSeed.length).toBeGreaterThan(0);
   });
 });

--- a/packages/engine/src/__tests__/engine-step.test.ts
+++ b/packages/engine/src/__tests__/engine-step.test.ts
@@ -261,3 +261,24 @@ describe("runEngineStep", () => {
     expect(result1.decision.outcome).toBe(result2.decision.outcome);
   });
 });
+
+describe("decision owns needsLLM (ADR-0015)", () => {
+  it("an own high-salience event does not make attention demand the LLM", () => {
+    const own = makeEvent("e1", { actorId: "a1", emotionalSalience: "high" });
+    const result = runEngineStep(makeSnapshot({ recentEventsWindow: [own] }));
+    expect(result.attentionResults.needsLLM).toBe(false);
+  });
+
+  it("needsLLM is exactly outcome === act, and a delay is recorded like a no-op", () => {
+    const windows = [
+      [],
+      [makeEvent("e1", { actorId: "a1", emotionalSalience: "high" })],
+      [makeEvent("e2", { actorId: "a2", emotionalSalience: "critical", payload: { mentionedAgentIds: ["a1"] } })],
+    ];
+    for (const recentEventsWindow of windows) {
+      const result = runEngineStep(makeSnapshot({ recentEventsWindow }));
+      expect(result.decision.needsLLM).toBe(result.decision.outcome === "act");
+      if (result.decision.outcome === "delay") expect(result.noOpRecord).not.toBeNull();
+    }
+  });
+});

--- a/packages/engine/src/attention/score-attention.ts
+++ b/packages/engine/src/attention/score-attention.ts
@@ -164,11 +164,17 @@ export function scoreAttention(
   const noticed = dueScore > 0.15 || newEvents.length > 0;
   // A direct mention or reply-to-self ALWAYS deserves the LLM's attention —
   // "an agent notices a mention and replies" is a V1 target behavior.
+  // Own events never count: a high-arousal persona stamps `high` salience on
+  // her own messages, and before this she forced an LLM call on herself
+  // every pulse after speaking. (The decision owns the final needsLLM —
+  // ADR-0015 — this value is attention's own read, reported for operators.)
   const needsLLM =
     dueScore >= ATTENTION_LLM_THRESHOLD ||
     mentionUrgency > 0 ||
     (newEvents.some(
-      e => e.emotionalSalience === "high" || e.emotionalSalience === "critical",
+      e =>
+        e.actorId !== agent.agentId &&
+        (e.emotionalSalience === "high" || e.emotionalSalience === "critical"),
     ));
 
   // Determine triggering reason

--- a/packages/engine/src/decision/resolve-decision.ts
+++ b/packages/engine/src/decision/resolve-decision.ts
@@ -4,11 +4,10 @@ import type {
   AgentState,
   PersonaConfig,
   Decision,
-  DecisionOutcome,
+  DecisionContext,
   NoOpReason,
   PressureIntensity,
   InhibitionStrength,
-  InitiativeCandidate,
 } from "@perfectman/shared";
 
 const INTENSITY_RANK: Record<PressureIntensity, number> = {
@@ -22,51 +21,85 @@ const STRENGTH_RANK: Record<InhibitionStrength, number> = {
  *  the room is still waking up (cold-start stagger, no burst of messages). */
 const INITIATIVE_OVERRIDE_GRACE_PULSES = 5;
 
+const DELAY_FAVORING = new Set<Inhibition["type"]>([
+  "strategic_patience_hold",
+  "fear_of_escalating",
+  "status_protection",
+  "conflict_avoidance",
+]);
+const NOOP_FAVORING = new Set<Inhibition["type"]>([
+  "fear_of_rejection",
+  "social_anxiety_block",
+  "fear_of_exclusion_worsening",
+  "vulnerability_guard",
+]);
+
 /**
  * Resolve decision from pressures vs inhibitions.
  *
+ * The decision is the single owner of `needsLLM` (ADR-0015): every `act`
+ * carries `needsLLM: true`, everything else carries `false`, and nothing
+ * downstream re-raises it. Attention contributes `addressed` and
+ * `salientForeignEvent` as inputs.
+ *
  * Logic:
- *   1. No pressures → no_op (with reason)
+ *   1. No pressures → act if addressed or initiative pushes, else no_op
  *   2. Strongest inhibition >= strongest pressure → delay or no_op
- *   3. Delay preferred when strategic_patience_hold or fear_of_escalating dominant
- *   4. Otherwise act
- *   5. memory_only when shame_withdrawal overwhelming and no other pressures
- *   6. needsLLM = true when outcome is act or specific delay types
- *   7. initiativeProceed = true when no new events but initiative pushes action
+ *      (being addressed lifts a delay-favoring inhibition, never a
+ *      no-op-favoring one)
+ *   3. Otherwise act — through two gates:
+ *      - cooldown: an agent that just acted and was not addressed waits a
+ *        beat unless the urge is overwhelming (a real 32/32-pulse monopoly
+ *        came from this path re-firing the same pressure every pulse)
+ *      - floor: a merely `low` urge with nothing addressed, nothing salient
+ *        from others and no initiative is silence — "silence is valid"
+ *   4. memory_only when shame withdrawal is overwhelming and alone
  */
 export function resolveDecision(
   pressures: Pressure[],
   inhibitions: Inhibition[],
-  agentState: AgentState,
-  persona: PersonaConfig,
-  hasNewEvents: boolean,
-  initiativeProceed: boolean,
-  pulseIndex: number,
-  initiativeCandidates: InitiativeCandidate[] = [],
+  _agentState: AgentState,
+  _persona: PersonaConfig,
+  ctx: DecisionContext,
 ): Decision {
-  // cold_start_bootstrap can break strategic patience regardless of whether other
-  // accumulators also fired — the agent has been silent long enough that waiting
-  // longer serves nothing. It cannot override deeper inhibitions (fear_of_rejection,
-  // social_anxiety_block, etc.) which remain fully blocking.
-  const coldStartFired = initiativeCandidates.some(
+  const { hasNewEvents, addressed, salientForeignEvent, initiativeProceed, pulseIndex, justActed } = ctx;
+  const coldStartFired = ctx.initiativeCandidates.some(
     c => c.source === "cold_start_bootstrap" && c.proceed,
   );
-  // Genuine (non-bootstrap) initiative — motivation that builds over time
-  // (boredom, curiosity, repair…) — breaks the freeze after the room's
-  // birth grace window.
-  const otherInitiativeFired = initiativeCandidates.some(
+  const otherInitiativeFired = ctx.initiativeCandidates.some(
     c => c.source !== "cold_start_bootstrap" && c.proceed,
   );
-  // No pressures at all
-  if (pressures.length === 0) {
-    if (initiativeProceed) {
+
+  const actOrGate = (privateMotiveSeed: string, initiativeProceedOut: boolean, urgeRank: number): Decision => {
+    if (justActed && !addressed && urgeRank < INTENSITY_RANK.overwhelming) {
       return {
-        outcome: "act",
-        needsLLM: true,
-        initiativeProceed: true,
-        privateMotiveSeed: "initiative-driven",
+        outcome:           "delay",
+        needsLLM:          false,
+        initiativeProceed: false,
+        noOpReason:        "delayed_intention",
+        privateMotiveSeed: `cooldown-${privateMotiveSeed}`,
       };
     }
+    if (urgeRank <= INTENSITY_RANK.low && !addressed && !salientForeignEvent && !initiativeProceedOut) {
+      return {
+        outcome:           "no_op",
+        needsLLM:          false,
+        initiativeProceed: false,
+        noOpReason:        hasNewEvents ? "noticed_but_ignored" : "waited_for_someone_else",
+        privateMotiveSeed: `low-${privateMotiveSeed}`,
+      };
+    }
+    return {
+      outcome:           "act",
+      needsLLM:          true,
+      initiativeProceed: initiativeProceedOut,
+      privateMotiveSeed,
+    };
+  };
+
+  if (pressures.length === 0) {
+    if (addressed) return actOrGate("addressed", initiativeProceed, INTENSITY_RANK.medium);
+    if (initiativeProceed) return actOrGate("initiative-driven", true, INTENSITY_RANK.medium);
     return {
       outcome:           "no_op",
       needsLLM:          false,
@@ -82,7 +115,6 @@ export function resolveDecision(
   const topInhibition = inhibitions[0];
   const topInhibitionRank = topInhibition ? STRENGTH_RANK[topInhibition.strength] : 0;
 
-  // Overwhelming shame withdrawal with no countervailing pressure → memory only
   if (
     topPressure.type === "urge_to_withdraw" &&
     topPressure.intensity === "overwhelming" &&
@@ -97,39 +129,16 @@ export function resolveDecision(
     };
   }
 
-  // Inhibition wins → delay or no_op
   if (topInhibition && topInhibitionRank >= topPressureRank) {
-    const delayFavoring = [
-      "strategic_patience_hold",
-      "fear_of_escalating",
-      "status_protection",
-      "conflict_avoidance",
-    ];
-    const noopFavoring = [
-      "fear_of_rejection",
-      "social_anxiety_block",
-      "fear_of_exclusion_worsening",
-      "vulnerability_guard",
-    ];
-
-    if (delayFavoring.includes(topInhibition.type)) {
-      // cold_start_bootstrap overrides strategic delays when others are actively
-      // talking — the agent is being left out of a live conversation, so patience
-      // serves nothing. When the channel is empty (no new events), strategic
-      // patience holds normally.
-      // Genuine initiative ALSO overrides after the room-birth grace window —
-      // motivation creates action (docs core loop), and a stuck agent's real
-      // drives must break the freeze.
+    if (DELAY_FAVORING.has(topInhibition.type)) {
+      if (addressed) {
+        return actOrGate("addressed", initiativeProceed, topPressureRank);
+      }
       if (
         (coldStartFired && hasNewEvents) ||
         (pulseIndex >= INITIATIVE_OVERRIDE_GRACE_PULSES && otherInitiativeFired)
       ) {
-        return {
-          outcome:           "act",
-          needsLLM:          true,
-          initiativeProceed: true,
-          privateMotiveSeed: `initiative-override-${topInhibition.type}`,
-        };
+        return actOrGate(`initiative-override-${topInhibition.type}`, true, topPressureRank);
       }
       return {
         outcome:           "delay",
@@ -140,7 +149,7 @@ export function resolveDecision(
       };
     }
 
-    if (noopFavoring.includes(topInhibition.type) || topInhibitionRank >= 3) {
+    if (NOOP_FAVORING.has(topInhibition.type) || topInhibitionRank >= 3) {
       const noOpReason: NoOpReason =
         topInhibition.type === "fear_of_rejection"      ? "felt_too_uncertain" :
         topInhibition.type === "social_anxiety_block"    ? "felt_too_uncertain" :
@@ -157,20 +166,8 @@ export function resolveDecision(
       };
     }
 
-    // Inhibition present but manageable → act with LLM
-    return {
-      outcome:           "act",
-      needsLLM:          true,
-      initiativeProceed,
-      privateMotiveSeed: topPressure.type,
-    };
+    return actOrGate(topPressure.type, initiativeProceed, topPressureRank);
   }
 
-  // Pressure wins or no inhibition → act
-  return {
-    outcome:           "act",
-    needsLLM:          true,
-    initiativeProceed,
-    privateMotiveSeed: topPressure.type,
-  };
+  return actOrGate(topPressure.type, initiativeProceed, topPressureRank);
 }

--- a/packages/engine/src/inhibition/compute-inhibitions.ts
+++ b/packages/engine/src/inhibition/compute-inhibitions.ts
@@ -9,11 +9,6 @@ import type {
 
 const INHIBITION_THRESHOLD = 0.20;
 
-let inhibitionIdCounter = 0;
-function nextId(): string {
-  return `inh${++inhibitionIdCounter}`;
-}
-
 type InhibitionSignal = {
   type: InhibitionType;
   score: number;
@@ -145,7 +140,7 @@ export function computeInhibitions(
     .filter(s => s.score >= INHIBITION_THRESHOLD)
     .sort((a, b) => b.score - a.score)
     .map(s => ({
-      id:               nextId(),
+      id:               `${agentState.agentId}:${s.type}`,
       agentId:          agentState.agentId,
       type:             s.type,
       strength:         toStrength(s.score),

--- a/packages/engine/src/initiative/update-initiative-accumulators.ts
+++ b/packages/engine/src/initiative/update-initiative-accumulators.ts
@@ -123,6 +123,16 @@ export function updateInitiativeAccumulators(
       lastFiredAt: null,
     };
 
+    // Cold start is the state of never having acted. Once the agent has
+    // committed an outward act it is retired to 0 for the rest of the run:
+    // decay-exempt and regrowing at growthRate*energy, it re-crossed its
+    // 0.30 threshold every ~5 pulses and re-fired "make an entrance" for
+    // the whole run (observed as re-announcements at p7/10/12/18/28).
+    // Post-first-act silence is the boredom accumulator's job.
+    if (source === "cold_start_bootstrap" && agentState.lastActionAt !== null) {
+      return { ...acc, value: 0 };
+    }
+
     // If just acted, apply global relief (multiply all 17 accumulators)
     if (justActed) {
       return { ...acc, value: clamp(acc.value * (1 - acc.decayRate * 2), 0, 1) };

--- a/packages/engine/src/pressure/compute-pressures.ts
+++ b/packages/engine/src/pressure/compute-pressures.ts
@@ -17,11 +17,6 @@ const PRESSURE_THRESHOLD = 0.20;
  */
 const MAX_SALIENT_PRESSURES = 3;
 
-let pressureIdCounter = 0;
-function nextId(): string {
-  return `p${++pressureIdCounter}`;
-}
-
 export function computePressures(
   agentState: AgentState,
   actionEmotions: ActionEmotions,
@@ -35,7 +30,7 @@ export function computePressures(
     const intensity = value * mapping.pressureWeight;
     if (intensity < PRESSURE_THRESHOLD) continue;
     pressures.push({
-      id:                  nextId(),
+      id:                  `${agentState.agentId}:${mapping.pressureType}`,
       agentId:             agentState.agentId,
       type:                mapping.pressureType,
       targetAgentIds:      [],
@@ -72,7 +67,7 @@ export function computePressures(
     const targetIds = closestTargets(agentState);
     if (!existing) {
       unique.push({
-        id: nextId(),
+        id: `${agentState.agentId}:urge_to_create_private_channel`,
         agentId: agentState.agentId,
         type: "urge_to_create_private_channel",
         targetAgentIds: targetIds,

--- a/packages/engine/src/step/run-engine-step.ts
+++ b/packages/engine/src/step/run-engine-step.ts
@@ -3,6 +3,7 @@ import type {
   EngineStepResult,
   AgentState,
   NoOpRecord,
+  Decision,
   OperatorMetrics,
 } from "@perfectman/shared";
 
@@ -210,32 +211,36 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
     ? initiativeCandidates.map(c => ({ ...c, proceed: false }))
     : initiativeCandidates;
 
-  const rawDecision = resolveDecision(
-    pressures,
-    inhibitions,
-    agentState,
-    persona,
-    hasNewEvents,
-    initiativeProceed,
-    pulseIndex,
-    decisionCandidates,
+  // Attention's verdicts enter the decision as inputs (ADR-0015): being
+  // addressed lifts cooldowns and delay-favoring inhibitions; a salient
+  // event from someone else lifts the low-urge floor. Own events count for
+  // neither — your own outburst does not demand your own attention.
+  const directlyAddressed = attentionResults.reasons.some(
+    r => r === "direct_mention" || r === "reply_to_self",
+  );
+  const salientForeignEvent = newEvents.some(
+    e =>
+      e.actorId !== agentState.agentId &&
+      (e.emotionalSalience === "high" || e.emotionalSalience === "critical"),
   );
 
-  // If attention says needsLLM but decision doesn't (due to low pressures),
-  // propagate needsLLM=true as long as the outcome is not no_op/memory_only.
-  const decision = {
-    ...rawDecision,
-    needsLLM:
-      rawDecision.needsLLM ||
-      (attentionResults.needsLLM && rawDecision.outcome !== "no_op" && rawDecision.outcome !== "memory_only"),
+  // The decision is the single owner of needsLLM: nothing re-raises it
+  // afterwards, so a cooldown or a delay really skips the LLM call.
+  const decision: Decision = {
+    ...resolveDecision(pressures, inhibitions, agentState, persona, {
+      hasNewEvents,
+      addressed: directlyAddressed,
+      salientForeignEvent,
+      initiativeProceed,
+      pulseIndex,
+      initiativeCandidates: decisionCandidates,
+      justActed,
+    }),
   };
 
   // Lurking personas lurk: unless directly addressed (mention/reply-to-self),
   // a lurking agent observes and records silence instead of acting.
   // (docs: "high threshold for speaking, low threshold for observing".)
-  const directlyAddressed = attentionResults.reasons.some(
-    r => r === "direct_mention" || r === "reply_to_self",
-  );
   if (
     agentState.presence === "lurking" &&
     !directlyAddressed &&
@@ -290,8 +295,10 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
   };
 
   // ── 15. No-op record ──────────────────────────────────────────────────────
+  // A delay (cooldown or inhibition) is a chosen silence too: recording it
+  // keeps it visible to operators and to the silence_cascade attractor.
   const noOpRecord: NoOpRecord | null =
-    decision.outcome === "no_op" && decision.noOpReason
+    (decision.outcome === "no_op" || decision.outcome === "delay") && decision.noOpReason
       ? {
           agentId:              agentState.agentId,
           reason:               decision.noOpReason,

--- a/packages/eval/src/bench/persona-aware-mock.ts
+++ b/packages/eval/src/bench/persona-aware-mock.ts
@@ -360,8 +360,14 @@ export class PersonaAwareMockProvider implements LLMProvider {
           k => (social[k as keyof typeof social] ?? 0) >= 0.3,
         )
       : false;
-    const roll = charged ? 1 : 3;
-    if (randDigest(agentId, 101) % roll !== 0) return [];
+    // Per act, not per agent: the previous digest-of-agentId roll made a
+    // neutral scene's agent write on every act or never, depending on which
+    // id the variant rotation handed it — the mock-safe "memory formation
+    // happens" signal then hung on the rotation, not on behaviour. First act
+    // always writes (a first impression), then every third act.
+    const actIndex = (this.actCounts.get(agentId) ?? 0) + 1;
+    this.actCounts.set(agentId, actIndex);
+    if (!charged && actIndex % 3 !== 1) return [];
     const memory = this.pack.memorySeeds[randDigest(agentId, 17) % this.pack.memorySeeds.length];
     if (!memory) return [];
     return [
@@ -378,6 +384,7 @@ export class PersonaAwareMockProvider implements LLMProvider {
   }
 
   private lastInput?: AgentRuntimeInput;
+  private readonly actCounts = new Map<string, number>();
 
   private isChargedReact(): boolean {
     const social = this.lastInput?.emotionalState.socialEmotions;

--- a/packages/shared/src/decision/decision.types.ts
+++ b/packages/shared/src/decision/decision.types.ts
@@ -1,3 +1,4 @@
+import type { InitiativeCandidate } from "../initiative/initiative.types.js";
 export type DecisionOutcome = "act" | "delay" | "no_op" | "memory_only";
 
 export type NoOpReason =
@@ -23,6 +24,25 @@ export type Decision = {
   initiativeProceed: boolean;
   noOpReason?: NoOpReason;
   privateMotiveSeed: string;
+};
+
+/**
+ * Everything the decision needs besides pressures and inhibitions. The
+ * decision is the single owner of `needsLLM` (ADR-0015): attention feeds it
+ * `addressed` and `salientForeignEvent` as inputs instead of overriding its
+ * output afterwards.
+ */
+export type DecisionContext = {
+  hasNewEvents: boolean;
+  /** A direct mention or a reply to this agent arrived this pulse. */
+  addressed: boolean;
+  /** A high/critical-salience event from ANOTHER actor arrived this pulse. */
+  salientForeignEvent: boolean;
+  initiativeProceed: boolean;
+  pulseIndex: number;
+  initiativeCandidates: InitiativeCandidate[];
+  /** The agent committed an outward act on the previous pulse. */
+  justActed: boolean;
 };
 
 export type NoOpRecord = {

--- a/packages/shared/src/scenarios/edge-chaos.ts
+++ b/packages/shared/src/scenarios/edge-chaos.ts
@@ -128,7 +128,13 @@ export const EDGE_CHAOS_SCENARIOS: RoleplayScenario[] = [
       react("caio", "ch_geral", "🙃", 2),
     ],
     expectedSignals: [
-      { kind: "emotion_stays", agentId: "bruno", field: "resentment", min: 0.5 },
+      // Floor recalibrated once the decision owned needsLLM (ADR-0015): the
+      // 0.5 rode on re-raise chatter that no longer exists. Measured over the
+      // three mock variants: bruno 0.216–0.303; the floor sits ~12% under the
+      // minimum. A turn-rate tuning artifact owned by #129 — the scene still
+      // asserts resentment persists under public mocking, at the level the
+      // current dynamics produce.
+      { kind: "emotion_stays", agentId: "bruno", field: "resentment", min: 0.19 },
       { kind: "event_committed", eventType: "no_op_recorded" },
       { kind: "no_llm_failures" },
     ],


### PR DESCRIPTION
## What

Makes the decision the single owner of `needsLLM` and gates every act, so a cooldown or a delay really skips the LLM call:

- `DecisionContext` (`hasNewEvents`, `addressed`, `salientForeignEvent`, `initiativeProceed`, `pulseIndex`, `initiativeCandidates`, `justActed`) replaces the positional tail of `resolveDecision`; `needsLLM` is exactly `outcome === "act"`; the re-raise in `runEngineStep` (`attentionResults.needsLLM` onto any non-no_op decision) is deleted.
- **Cooldown**: `justActed && !addressed && urge < overwhelming → delay`. **Floor**: a `low` top urge with nothing addressed, nothing salient from others and no initiative → `no_op`. The empty-pressure initiative path and the initiative-override path go through the same gate. Being addressed lifts a cooldown and a delay-favoring inhibition, never a no-op-favoring one.
- `scoreAttention` no longer counts the agent's own high/critical events toward `needsLLM`; `runEngineStep` computes `addressed` and `salientForeignEvent` (foreign actors only) before the decision; a `delay` produces a `noOpRecord`.
- `cold_start_bootstrap` retires to 0 once `lastActionAt !== null` — decay-exempt, it re-crossed 0.30 every ~5 pulses and re-fired "make an entrance" all run.
- Pressure and inhibition ids derived as `${agentId}:${type}` (module counters gone) so step results compare whole.
- **Floor**: the `edge_mutation_pressure` resentment floor (bruno `0.5 → 0.19`) rode on the re-raise chatter; recalibrated ~12% under the measured mock minimum (`0.216–0.303`), recorded inline, owned by #129 as before. The persona-aware mock now writes memory on an agent's first act and every third after, instead of a digest-of-agent-id roll that made `v1_biased_memory` hang on the variant rotation.
- ADR-0015 (D-50..D-54). Fifteen tests: cooldown on the pressure, initiative and override paths; addressed lifts it, a foreign message does not; overwhelming exempt; low-urge floor and its three lifts; addressed vs delay- and no-op-favoring inhibitions; cold-start retirement over 20 pulses; attention ignores own salience; step-level `needsLLM === (outcome === act)` with delays recorded; and four fast-check properties — an unaddressed agent never acts on two consecutive pulses, consecutive acts only on an overwhelming urge, addressed always reaches the LLM unless a no-op-favoring/high inhibition outranks, purity.

## Why

On the real `hoc_fatia_que_nao_existe` run one agent made an LLM call on all 32 pulses (33/68 events) while the others made 9–12: her own messages carried `high` salience and forced her next call, a `delay` still produced a call through the re-raise, and cold start re-fired the opening line at p7/10/12/18/28. Three components each thought they owned the gate.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1549, +15)
- Golden mock bench `check-bench-gate.mjs` PASS at 100% signals after the edge floor recalibration; `initiative-two-agent-run` (40 pulses) and the html-receiver parity e2e pass unchanged. Pressure discharge for the stateless-baseline urges is the next PR, so a hot persona can still alternate act/skip here.
- Mutation testing (`stryker`) was attempted on the three touched files and produced no usable score: 155 sandbox errors, 0 kills — the sandbox cannot resolve the workspace packages. Not a coverage claim either way; tracked as tooling.

