### PR TITLE
feat(engine): pressure discharge — acting spends the urge

### DIFF
--- a/docs/adr/0016-pressure-discharge.md
+++ b/docs/adr/0016-pressure-discharge.md
@@ -1,0 +1,45 @@
+# ADR-0016: Pressure Discharge
+
+**Status**: Accepted (LOCKED, 2026-09-05) — rationale and rejected alternatives inline in this ADR (decisions **D-55..D-58**).
+
+**Numbering note**: written against ADRs 0001..0015; in-tree decision high-water mark **D-54** (ADR-0015). The D-55..D-58 range is this ADR's.
+
+## Context
+
+`computePressures` recomputes every urge from the agent's emotional state each pulse, with no memory of having acted on it. `computeActionEmotions` carries large baseline terms that do not depend on events: for the goulart calibration (arousal 0.65, stability 0.35) `impulsiveProvocation ≈ 0.49`, which times its pressure weight is a `high urge_to_provoke` on every pulse of every run, with nothing said. No inhibition available to that persona outranks `high`. ADR-0015 removed the ownership defects around `needsLLM`; without a memory of acting, a hot persona still alternates act / cooldown / act.
+
+Issue #119 lists "targeted per-motive accumulator relief — discharge only the accumulator(s) whose source drove the committed action; needs motive→action attribution threaded to the resolver first" as unspecified. Constraint carried in: the engine stays pure and reads persisted state only; the scheduler is the single writer after commit (the `lastActionAt` precedent, #124); no speculative constants without a tuning owner.
+
+## Decision
+
+1. **`AgentState.pressureDischargedAt?: Partial<Record<PressureType, number>>` (D-55)** — the pulse index of the last committed outward act that expressed each urge. Optional: absent means never discharged, so the forty-odd fixtures that build the literal keep compiling and existing rows read back unchanged.
+2. **Discharge is subtractive with linear refill, overwhelming exempt (D-56).** `effective = raw ≥ 0.85 ? raw : max(0, raw − PRESSURE_DISCHARGE · max(0, (PRESSURE_REFRACTORY_PULSES − pulsesSince + 1) / PRESSURE_REFRACTORY_PULSES))`, applied per `ACTION_PRESSURE_MAP` entry and to the private-channel drive before the intensity label; an urge that discharges below `PRESSURE_THRESHOLD` is removed, not clamped. `PRESSURE_DISCHARGE = 0.40`, `PRESSURE_REFRACTORY_PULSES = 6` (`shared/src/constants/pressure-refractory.ts`), provisional, owner #129.
+3. **The scheduler stamps every salient pressure after a committed outward act (D-57)** at the `lastActionAt` site, under the same condition. Not only the top one: the goulart calibration feels provoke, dominate and show-off together, and discharging one would hand the turn to the next.
+4. **Persistence rides the agent-state row (D-58)**: a nullable JSON column `pressure_discharged_at`, added with a guarded `ALTER TABLE` for databases created before it; the in-memory repository needs nothing.
+
+## Rationale
+
+- Follows the `lastActionAt` precedent exactly: engine reads persisted state, scheduler writes once after commit, `persistAndSnapshot` is the single write point, pulse-index based so sim-time deterministic.
+- Delivers #119's "targeted per-motive relief" without the motive→action attribution prerequisite: the discharged set is "what was felt when the act was chosen", which `stepResult.pressures` already is.
+- Subtractive rather than multiplicative so the emotion's shape survives: a `0.73` provoke drops to `0.33` (silent unless addressed) the pulse after, `0.40` at +2, back to `0.73` at +7 — roughly one act per 2–3 pulses for the hottest persona instead of every pulse. The residual `medium` at +2 is the event-independent baseline, a #119 emotion-magnitude item, out of scope here.
+- Overwhelming urges are exempt at read time so ADR-0015's "overwhelming can never be inhibited" stays true.
+
+## Rejected Alternatives
+
+- **Per-pressure decay state inside `Pressure`** — pressures are recomputed, not persisted (D-55).
+- **Stronger attention-side cooldown** — already exists and is bypassed by the salience clause (ADR-0015).
+- **Scheduler LLM cap** — hides the model instead of fixing it (ADR-0015).
+- **Discharging only the top pressure** — hands the turn to the next urge of the same persona (D-57).
+- **A required field** — forty fixtures to touch for identical runtime semantics (D-55).
+
+## Consequences
+
+- Turn cadence for hot personas drops; the eval's `act-share-max` probe and the experiment protocol's decision rule measure it.
+- The 40-pulse two-agent run gains the invariant "no agent commits messages on more than 2 consecutive pulses without being mentioned".
+- The constants are the first tuning knob for #129; `sweep-*` harnesses in the eval package are the place to move them.
+
+## Cross-links
+
+- ADR-0015 (decision owns `needsLLM`), ADR-0013 (scheduler-private state mutation precedent), issue #119 / #124 / #129.
+- Code: `packages/engine/src/pressure/compute-pressures.ts`, `packages/server/src/simulation/pulse-scheduler.ts`, `packages/shared/src/agent/agent.types.ts`, `packages/shared/src/constants/pressure-refractory.ts`, `packages/server/src/persistence/sqlite/{schema,database,agent-state-repository}.ts`.
+- Tests: `compute-pressures.test.ts`, `pulse-scheduler.test.ts` (discharge stamping), `initiative-two-agent-run.test.ts`, shared `schemas.test.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ ADR-0001..0007 pre-date this convention and are historical records: their Status
 | [ADR-0013](0013-memory-formation-and-relational-accretion.md) | Memory Formation And Relational Accretion |
 | [ADR-0014](0014-private-motive-committed-event.md) | Private Motive As A Committed Event |
 | [ADR-0015](0015-decision-owns-needs-llm.md) | The Decision Owns `needsLLM` |
+| [ADR-0016](0016-pressure-discharge.md) | Pressure Discharge |
 
 ## Template
 

--- a/packages/engine/src/__tests__/compute-pressures.test.ts
+++ b/packages/engine/src/__tests__/compute-pressures.test.ts
@@ -63,3 +63,55 @@ describe("computePressures", () => {
     expect(priv?.visibilityPreference).toBe("private");
   });
 });
+
+describe("pressure discharge (ADR-0016)", () => {
+  const felt = (pulseIndex: number, dischargedAt?: number) =>
+    computePressures(
+      makeAgent({
+        socialEmotions: makeSocial(),
+        relationalStates: new Map(),
+        ...(dischargedAt !== undefined ? { pressureDischargedAt: { urge_to_message: dischargedAt } } : {}),
+      }),
+      makeActionEmotions({ warmth: 0.7 }),
+      [],
+      pulseIndex,
+    ).find(p => p.type === "urge_to_message");
+
+  it("demotes a discharged urge on the next pulse and fully recovers after the refractory window", () => {
+    const fresh = felt(10);
+    expect(fresh?.intensity).toBe("high");
+    const next = felt(11, 10);
+    expect(next === undefined || next.intensity === "low" || next.intensity === "medium").toBe(true);
+    expect(next?.intensity).not.toBe("high");
+    expect(felt(17, 10)?.intensity).toBe("high");
+  });
+
+  it("never discharges an overwhelming urge", () => {
+    const overwhelming = computePressures(
+      makeAgent({ socialEmotions: makeSocial(), relationalStates: new Map(), pressureDischargedAt: { urge_to_message: 5 } }),
+      makeActionEmotions({ warmth: 1 }),
+      [],
+      6,
+    ).find(p => p.type === "urge_to_message");
+    expect(overwhelming?.intensity).toBe("overwhelming");
+  });
+
+  it("removes an urge that discharges below the threshold instead of clamping it", () => {
+    const weak = computePressures(
+      makeAgent({ socialEmotions: makeSocial(), relationalStates: new Map(), pressureDischargedAt: { urge_to_message: 3 } }),
+      makeActionEmotions({ warmth: 0.35 }),
+      [],
+      4,
+    ).find(p => p.type === "urge_to_message");
+    expect(weak).toBeUndefined();
+  });
+
+  it("discharges the private-channel drive like any other urge, and ignores the map without a pulse index", () => {
+    const rels = makeRels({ targetAgentId: "b", desireForCloseness: 0.9, curiosity: 0.5, affection: 0.4 });
+    const agent = makeAgent({ socialEmotions: makeSocial(), relationalStates: rels, pressureDischargedAt: { urge_to_create_private_channel: 8 } });
+    const withIndex = computePressures(agent, makeActionEmotions(), [], 9).find(p => p.type === "urge_to_create_private_channel");
+    const without = computePressures(agent, makeActionEmotions(), []).find(p => p.type === "urge_to_create_private_channel");
+    expect(without).toBeDefined();
+    expect(withIndex === undefined || withIndex.intensity !== without?.intensity).toBe(true);
+  });
+});

--- a/packages/engine/src/pressure/compute-pressures.ts
+++ b/packages/engine/src/pressure/compute-pressures.ts
@@ -6,7 +6,7 @@ import type {
   PressureIntensity,
   VisibilityPreference,
 } from "@perfectman/shared";
-import { ACTION_PRESSURE_MAP } from "@perfectman/shared";
+import { ACTION_PRESSURE_MAP, PRESSURE_DISCHARGE, PRESSURE_REFRACTORY_PULSES } from "@perfectman/shared";
 
 const PRESSURE_THRESHOLD = 0.20;
 /**
@@ -17,17 +17,46 @@ const PRESSURE_THRESHOLD = 0.20;
  */
 const MAX_SALIENT_PRESSURES = 3;
 
+/** Raw intensity at or above this is `overwhelming` and exempt from discharge. */
+const OVERWHELMING_FLOOR = 0.85;
+
+/**
+ * Pressure discharge (ADR-0016). Pressures are recomputed statelessly from
+ * emotional baselines every pulse, so a persona whose baseline yields a
+ * `high urge_to_provoke` felt it every pulse forever — the monopoly
+ * mechanism. Acting on an urge now spends it: `PRESSURE_DISCHARGE` is
+ * subtracted on the next pulse and refills linearly over
+ * `PRESSURE_REFRACTORY_PULSES`. Subtractive, not multiplicative, so the
+ * shape of the underlying emotion is preserved; overwhelming urges are
+ * exempt at read time, keeping "overwhelming can never be inhibited".
+ */
+export function dischargedIntensity(
+  raw: number,
+  type: PressureType,
+  agentState: AgentState,
+  pulseIndex: number | undefined,
+): number {
+  if (pulseIndex === undefined || raw >= OVERWHELMING_FLOOR) return raw;
+  const dischargedAt = agentState.pressureDischargedAt?.[type];
+  if (dischargedAt === undefined) return raw;
+  const pulsesSince = pulseIndex - dischargedAt;
+  if (pulsesSince < 1) return raw;
+  const remaining = Math.max(0, (PRESSURE_REFRACTORY_PULSES - pulsesSince + 1) / PRESSURE_REFRACTORY_PULSES);
+  return Math.max(0, raw - PRESSURE_DISCHARGE * remaining);
+}
+
 export function computePressures(
   agentState: AgentState,
   actionEmotions: ActionEmotions,
   sourceEventIds: string[],
+  pulseIndex?: number,
 ): Pressure[] {
   const pressures: Pressure[] = [];
 
   for (const mapping of ACTION_PRESSURE_MAP) {
     const value = actionEmotions[mapping.actionEmotion as keyof ActionEmotions] as number;
     if (value === undefined) continue;
-    const intensity = value * mapping.pressureWeight;
+    const intensity = dischargedIntensity(value * mapping.pressureWeight, mapping.pressureType, agentState, pulseIndex);
     if (intensity < PRESSURE_THRESHOLD) continue;
     pressures.push({
       id:                  `${agentState.agentId}:${mapping.pressureType}`,
@@ -61,7 +90,11 @@ export function computePressures(
   // intimacy-shaped; gossip/status/control/secrecy/alliance are strategic).
   // ACTION_PRESSURE_MAP alone under-fires it (vulnerableRetreat needs a
   // negative state).
-  const privateDrive = privateMotiveIntensity(agentState);
+  const rawPrivateDrive = privateMotiveIntensity(agentState);
+  const privateDrive = {
+    ...rawPrivateDrive,
+    drive: dischargedIntensity(rawPrivateDrive.drive, "urge_to_create_private_channel", agentState, pulseIndex),
+  };
   if (privateDrive.drive >= PRESSURE_THRESHOLD) {
     const existing = unique.find(p => p.type === "urge_to_create_private_channel");
     const targetIds = closestTargets(agentState);

--- a/packages/engine/src/step/run-engine-step.ts
+++ b/packages/engine/src/step/run-engine-step.ts
@@ -167,6 +167,7 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
     agentState,
     emotionResult.actionEmotions,
     newEvents.map(e => e.id),
+    pulseIndex,
   );
 
   const tempAgentForInhibitions: AgentState = {

--- a/packages/server/src/persistence/sqlite/agent-state-repository.ts
+++ b/packages/server/src/persistence/sqlite/agent-state-repository.ts
@@ -21,6 +21,7 @@ type AgentStateRow = {
   last_action_at: number | null;
   last_rumination_pulse: number | null;
   arrival_pulse: number | null;
+  pressure_discharged_at: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -51,6 +52,7 @@ function rowToAgentState(row: AgentStateRow): AgentState {
     lastActionAt: row.last_action_at,
     lastRuminationPulse: row.last_rumination_pulse ?? null,
     arrivalPulse: row.arrival_pulse ?? null,
+    ...(row.pressure_discharged_at ? { pressureDischargedAt: JSON.parse(row.pressure_discharged_at) as AgentState["pressureDischargedAt"] } : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -76,9 +78,9 @@ export class SqliteAgentStateRepository implements IAgentStateRepository {
            (agent_id, simulation_id, persona_id, presence,
             core_mood, social_emotions, relational_states, memories,
             initiative_accumulators, last_processed_event_id, last_action_at,
-            last_rumination_pulse, arrival_pulse,
+            last_rumination_pulse, arrival_pulse, pressure_discharged_at,
             created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(agent_id, simulation_id) DO UPDATE SET
            persona_id                = excluded.persona_id,
            presence                  = excluded.presence,
@@ -91,6 +93,7 @@ export class SqliteAgentStateRepository implements IAgentStateRepository {
            last_action_at            = excluded.last_action_at,
            last_rumination_pulse     = excluded.last_rumination_pulse,
            arrival_pulse             = excluded.arrival_pulse,
+           pressure_discharged_at    = excluded.pressure_discharged_at,
            updated_at                = excluded.updated_at`,
       )
       .run(
@@ -107,6 +110,7 @@ export class SqliteAgentStateRepository implements IAgentStateRepository {
         agentState.lastActionAt,
         agentState.lastRuminationPulse,
         agentState.arrivalPulse,
+        agentState.pressureDischargedAt ? JSON.stringify(agentState.pressureDischargedAt) : null,
         agentState.createdAt,
         agentState.updatedAt ?? now,
       );

--- a/packages/server/src/persistence/sqlite/database.ts
+++ b/packages/server/src/persistence/sqlite/database.ts
@@ -14,12 +14,26 @@ export type DB = Database.Database;
  * Runs schema migration on first open.
  * Use `:memory:` for tests.
  */
+const ADDITIVE_COLUMNS_SQL = [
+  "ALTER TABLE agent_states ADD COLUMN pressure_discharged_at TEXT",
+];
+
 export function openDatabase(path: string): DB {
   const db = new Database(path);
 
   // WAL + foreign keys are set per-connection inside CREATE_TABLES_SQL PRAGMAs.
   // exec() runs multiple statements at once.
   db.exec(CREATE_TABLES_SQL);
+  // Additive columns for databases created before them. SQLite has no
+  // ADD COLUMN IF NOT EXISTS; a duplicate-column error is the "already
+  // migrated" signal and is the only one swallowed here.
+  for (const statement of ADDITIVE_COLUMNS_SQL) {
+    try {
+      db.exec(statement);
+    } catch (err) {
+      if (!(err instanceof Error) || !/duplicate column/i.test(err.message)) throw err;
+    }
+  }
 
   return db;
 }

--- a/packages/server/src/persistence/sqlite/schema.ts
+++ b/packages/server/src/persistence/sqlite/schema.ts
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS agent_states (
   last_action_at          INTEGER,
   last_rumination_pulse   INTEGER,
   arrival_pulse           INTEGER,
+  pressure_discharged_at  TEXT,                                -- JSON {pressureType: pulseIndex}
   created_at              INTEGER NOT NULL,
   updated_at              INTEGER NOT NULL,
   PRIMARY KEY (agent_id, simulation_id)

--- a/packages/server/src/simulation/__tests__/initiative-two-agent-run.test.ts
+++ b/packages/server/src/simulation/__tests__/initiative-two-agent-run.test.ts
@@ -240,4 +240,21 @@ describe("40-pulse two-agent initiative run", () => {
       }
     }
   });
+
+  it("no agent commits messages on more than 2 consecutive pulses without being mentioned", async () => {
+    const { eventRepo } = await runTwoAgentSimulation();
+    const events = await eventRepo.getAfter(SIM.id);
+    for (const agentId of SIM.agentIds) {
+      const pulses = new Set(events.filter(e => e.type === "message_sent" && e.actorId === agentId).map(e => e.pulseIndex));
+      let run = 0;
+      let longest = 0;
+      for (let pulse = 0; pulse < PULSES; pulse++) {
+        run = pulses.has(pulse) ? run + 1 : 0;
+        longest = Math.max(longest, run);
+      }
+      // The canned runtime never mentions anyone, so the bound is strict.
+      expect(longest, `${agentId} longest run of consecutive message pulses`).toBeLessThanOrEqual(2);
+    }
+  });
+
 });

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -869,4 +869,33 @@ describe("PulseScheduler", () => {
       expect(runReview).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe("pressure discharge stamping (ADR-0016)", () => {
+    it("stamps pressureDischargedAt for every salient pressure after a committed outward act, never for a genuine no_op", async () => {
+      const pressure = {
+        id: "agent_1:urge_to_message", agentId: "agent_1", type: "urge_to_message" as const, targetAgentIds: [],
+        intensity: "high" as const, sourceEventIds: [], sourceMotivations: [], sourceEmotions: [], visibilityPreference: "either" as const, decayRate: 0.15,
+      };
+      scheduler = buildScheduler(() => ({
+        ...makeCannedStep(),
+        pressures: [pressure, { ...pressure, id: "agent_1:urge_to_provoke", type: "urge_to_provoke" as const }],
+        decision: { outcome: "act", needsLLM: true, initiativeProceed: false, privateMotiveSeed: "x" },
+        noOpRecord: null,
+        availableActions: [{ intentType: "send_message", channelTargets: ["ch_public"], personTargets: [], blocked: false }],
+      }));
+      mockAgentRuntime.generateIntent = vi.fn().mockResolvedValue({
+        intent: { ...makeNoOpIntent("agent_1"), intentType: "send_message", visibleContent: "spending the urge" },
+        llmUsage: null, latencyMs: 10, fallbackApplied: false, operatorEvents: [],
+      });
+      await scheduler.runPulse();
+      const acted = await agentStateRepo.get("sim_test", "agent_1");
+      expect(acted?.pressureDischargedAt).toEqual({ urge_to_message: 0, urge_to_provoke: 0 });
+
+      scheduler = buildScheduler(() => ({ ...makeCannedStep(), pressures: [pressure] }));
+      await scheduler.runPulse();
+      const silent = await agentStateRepo.get("sim_test", "agent_1");
+      expect(silent?.pressureDischargedAt ?? {}).toEqual({});
+    });
+  });
+
 });

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -379,6 +379,13 @@ export class PulseScheduler {
         const attemptedRealAct = resolved.outcome === "committed" && runtimeOutput.fallbackApplied;
         if ((committedActType && OUTWARD_SOCIAL_ACT_TYPES.has(committedActType)) || attemptedRealAct) {
           stepResult.updatedAgentState.lastActionAt = now;
+          // Pressure discharge (ADR-0016): every urge felt when the act was
+          // chosen is spent by it — not only the top one, since a hot
+          // persona feels provoke/dominate/show_off together and discharging
+          // one would just hand the turn to the next.
+          const discharged = { ...(stepResult.updatedAgentState.pressureDischargedAt ?? {}) };
+          for (const pressure of stepResult.pressures) discharged[pressure.type] = this.pulseIndex;
+          stepResult.updatedAgentState.pressureDischargedAt = discharged;
         }
       }
 

--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { AgentStateSchema } from "../agent/agent.schema.js";
+import { makeAgentState as makeFixtureAgentState } from "../fixtures/helpers.js";
 import {
   SimulationSchema,
   SimulationSettingsSchema,
@@ -628,5 +630,14 @@ describe("Math utils", () => {
     const result = dampedSpring(0, 1, 0.5, 1);
     expect(result).toBeGreaterThan(0);
     expect(result).toBeLessThan(1);
+  });
+});
+
+describe("AgentStateSchema — pressure discharge map", () => {
+  it("accepts a state with and without pressureDischargedAt", () => {
+    const base = makeFixtureAgentState("a1", "sim", "caio");
+    expect(AgentStateSchema.parse(base).pressureDischargedAt).toBeUndefined();
+    const parsed = AgentStateSchema.parse({ ...base, pressureDischargedAt: { urge_to_provoke: 3 } });
+    expect(parsed.pressureDischargedAt).toEqual({ urge_to_provoke: 3 });
   });
 });

--- a/packages/shared/src/agent/agent.schema.ts
+++ b/packages/shared/src/agent/agent.schema.ts
@@ -48,6 +48,7 @@ export const AgentStateSchema = z.object({
   lastActionAt:          z.number().nullable(),
   lastRuminationPulse:   z.number().nullable(),
   arrivalPulse:          z.number().nullable(),
+  pressureDischargedAt:  z.record(z.number()).optional(),
   createdAt:             z.number(),
   updatedAt:             z.number(),
 });

--- a/packages/shared/src/agent/agent.types.ts
+++ b/packages/shared/src/agent/agent.types.ts
@@ -3,7 +3,7 @@ import type { Memory } from "../memory/memory.types.js";
 import type { InitiativeAccumulator } from "../initiative/initiative.types.js";
 import type { PerceptionPacket } from "../perception/perception.types.js";
 import type { Motivation } from "../motivation/motivation.types.js";
-import type { Pressure } from "../pressure/pressure.types.js";
+import type { Pressure, PressureType } from "../pressure/pressure.types.js";
 import type { Inhibition } from "../inhibition/inhibition.types.js";
 import type { AvailableAction } from "../action/action.types.js";
 import type { TriggeringReason } from "../attention/attention.types.js";
@@ -33,6 +33,12 @@ export type AgentState = {
   lastActionAt: number | null;
   lastRuminationPulse: number | null;
   arrivalPulse: number | null;       // pulse index when agent joins; null = present from start
+  /**
+   * Pulse index of the last committed outward act that expressed each urge
+   * (ADR-0016 pressure discharge). Acting spends the urge; it refills over
+   * PRESSURE_REFRACTORY_PULSES. Optional: absent means never discharged.
+   */
+  pressureDischargedAt?: Partial<Record<PressureType, number>>;
   createdAt: number;
   updatedAt: number;
 };

--- a/packages/shared/src/constants/pressure-refractory.ts
+++ b/packages/shared/src/constants/pressure-refractory.ts
@@ -1,0 +1,13 @@
+/**
+ * Pressure discharge (ADR-0016): acting on an urge spends it. Both values are
+ * provisional and owned by the #129 conversation-quality rerun with the
+ * eval sweeps as the harness.
+ *
+ * PRESSURE_DISCHARGE is subtracted from the raw urge on the pulse after the
+ * act and refills linearly over PRESSURE_REFRACTORY_PULSES. One intensity
+ * band is 0.25 wide, so 0.40 drops a `high` urge to `low` for a beat; six
+ * pulses matches the re-announcement period observed in the monopoly
+ * capture, so the fix is measurable against that baseline.
+ */
+export const PRESSURE_DISCHARGE = 0.4;
+export const PRESSURE_REFRACTORY_PULSES = 6;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -88,6 +88,7 @@ export * from "./engine/engine.types.js";
 export * from "./constants/circumplex.js";
 export * from "./constants/personas.js";
 export * from "./constants/emotion-rules.js";
+export * from "./constants/pressure-refractory.js";
 export * from "./constants/action-pressure-map.js";
 export * from "./constants/stagnation.js";
 


### PR DESCRIPTION
## What

Gives an urge a memory of having been acted on, so a hot persona stops feeling the same `high` pressure on every pulse:

- `AgentState.pressureDischargedAt?: Partial<Record<PressureType, number>>` — pulse index of the last committed outward act that expressed each urge (optional; absent means never discharged, so the forty fixtures that build the literal are untouched and old rows read back unchanged).
- `dischargedIntensity` in `computePressures`: `effective = raw ≥ 0.85 ? raw : max(0, raw − PRESSURE_DISCHARGE · max(0, (PRESSURE_REFRACTORY_PULSES − pulsesSince + 1) / PRESSURE_REFRACTORY_PULSES))`, applied per `ACTION_PRESSURE_MAP` entry and to the private-channel drive before the intensity label; an urge that discharges below `PRESSURE_THRESHOLD` is removed. Overwhelming urges are exempt, so ADR-0015's "overwhelming can never be inhibited" holds. `computePressures` takes `pulseIndex` (optional; `runEngineStep` passes it).
- `PulseScheduler` stamps every salient pressure at the `lastActionAt` site after a committed outward act — not only the top one, since the goulart calibration feels provoke, dominate and show-off together.
- `PRESSURE_DISCHARGE = 0.40`, `PRESSURE_REFRACTORY_PULSES = 6` (`shared/src/constants/pressure-refractory.ts`), provisional, owner #129. Worked goulart cadence: `0.73 → 0.33` the pulse after (silent unless addressed), `0.40` at +2, `0.73` again at +7.
- Persistence: nullable JSON column `pressure_discharged_at` with a guarded `ALTER TABLE` for databases created before it (only a duplicate-column error is swallowed); `AgentStateSchema` accepts the optional map.
- ADR-0016 (D-55..D-58). Seven tests: demoted next pulse and recovered after the window, overwhelming never discharged, below-threshold removal, private-channel drive discharged and the map ignored without a pulse index, scheduler stamps every salient pressure after a committed act and never for a genuine no_op, the 40-pulse two-agent run never commits messages on more than 2 consecutive pulses, schema round-trip.

## Why

`computePressures` recomputes every urge from emotional baselines each pulse; for the goulart calibration `impulsiveProvocation ≈ 0.49` is a `high urge_to_provoke` on every pulse of every run with nothing said, and no inhibition that persona has outranks it. ADR-0015 removed the ownership defects around `needsLLM`; without a memory of acting a hot persona still alternates act / cooldown / act.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1556, +7)
- Golden mock bench and the full-registry mock bench pass `check-bench-gate.mjs` at 100% signals on this branch (after the ADR-0015 floor recalibration on the base PR); `act-share-max` mean on the golden slice drops relative to the base.
