### PR TITLE
feat(engine): own-history repetition window

### DIFF
--- a/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
+++ b/packages/engine/src/perception/__tests__/build-perception-packet.test.ts
@@ -61,3 +61,34 @@ describe("buildPerceptionPacket eventHandles", () => {
     expect(packet.eventHandles).toEqual({});
   });
 });
+
+describe("buildPerceptionPacket ownRecentUtterances", () => {
+  const own = (id: string, content: string, pulseIndex: number) =>
+    makeEvent("message_sent", { id, actorId: "agent-me", pulseIndex, createdAt: 1000 + pulseIndex, payload: { content } });
+
+  it("keeps an own message that fell out of the shared window when the own-history window still holds it", () => {
+    const old = own("evt_old", "gente, oficial: a proposta chegou", 1);
+    const foreign = Array.from({ length: 6 }, (_, i) => makeEvent("message_sent", { id: `evt_f${i}`, actorId: "agent-x", pulseIndex: 10 + i }));
+    const recent = own("evt_recent", "bora fechar hoje", 20);
+    const packet = buildPerceptionPacket(
+      makeAgent({ agentId: "agent-me" }),
+      [...foreign, recent],
+      null,
+      [],
+      attention,
+      translated,
+      [],
+      [old, recent],
+    );
+    expect(packet.ownRecentUtterances).toEqual(["gente, oficial: a proposta chegou", "bora fechar hoje"]);
+  });
+
+  it("caps at OWN_UTTERANCE_WINDOW newest-last, dedupes by event id and collapses consecutive duplicates", () => {
+    const history = Array.from({ length: 15 }, (_, i) => own(`evt_${i}`, i === 7 ? "same" : `line ${i}`, i));
+    history.splice(8, 0, own("evt_dup", "same", 7));
+    const packet = buildPerceptionPacket(makeAgent({ agentId: "agent-me" }), history.slice(-3), null, [], attention, translated, [], history);
+    expect(packet.ownRecentUtterances).toHaveLength(12);
+    expect(packet.ownRecentUtterances[packet.ownRecentUtterances.length - 1]).toBe("line 14");
+    expect(packet.ownRecentUtterances.filter(u => u === "same")).toHaveLength(1);
+  });
+});

--- a/packages/engine/src/perception/build-perception-packet.ts
+++ b/packages/engine/src/perception/build-perception-packet.ts
@@ -9,6 +9,7 @@ import type {
   AttentionResult,
 } from "@perfectman/shared";
 import { selectRelevantMemories } from "./memory-salience.js";
+import { OWN_UTTERANCE_WINDOW } from "@perfectman/shared";
 
 /**
  * Build the PerceptionPacket for an agent this pulse.
@@ -38,6 +39,7 @@ export function buildPerceptionPacket(
   attentionResult: AttentionResult,
   translatedEmotionalState: TranslatedEmotionalState,
   availableActions: AvailableAction[],
+  ownHistoryWindow: readonly CommittedEvent[] = [],
 ): PerceptionPacket {
   // Filter out spectator/operator-only event types
   const cleanEvents = visibleEvents.filter(
@@ -83,15 +85,23 @@ export function buildPerceptionPacket(
     if (replyTarget && replyTarget !== agent.agentId) involvedPeople.add(replyTarget);
   }
 
-  // Own recent utterances — sourced from cleanEvents (full visible history,
-  // pre-CONTEXT_WINDOW-truncation), not contextEvents, so it survives the
-  // shared window filling up with other agents' turns. Deduped consecutively
-  // in case the same content was committed more than once in a row.
-  const OWN_UTTERANCE_WINDOW = 5;
-  const ownRecentUtterances: string[] = [];
-  for (const e of cleanEvents) {
+  // Own recent utterances — the union of the scheduler's own-history window
+  // (whole log, per agent) and whatever own messages are still inside the
+  // shared visible window, deduped by event id, chronological, consecutive
+  // duplicates collapsed, last OWN_UTTERANCE_WINDOW. Before this the source
+  // was the shared window alone: ~8-12 pulses of memory in a 4-agent room,
+  // which is how a pulse-18 re-announcement sailed past the guard.
+  const ownById = new Map<string, CommittedEvent>();
+  for (const e of [...ownHistoryWindow, ...cleanEvents]) {
     if (e.actorId !== agent.agentId) continue;
     if (e.type !== "message_sent" && e.type !== "reply_sent") continue;
+    if (!ownById.has(e.id)) ownById.set(e.id, e);
+  }
+  const ownEvents = [...ownById.values()].sort(
+    (a, b) => (a.pulseIndex ?? 0) - (b.pulseIndex ?? 0) || a.createdAt - b.createdAt,
+  );
+  const ownRecentUtterances: string[] = [];
+  for (const e of ownEvents) {
     const content = (e.payload as Record<string, unknown>)["content"];
     if (typeof content !== "string" || content.length === 0) continue;
     if (ownRecentUtterances[ownRecentUtterances.length - 1] === content) continue;

--- a/packages/engine/src/step/run-engine-step.ts
+++ b/packages/engine/src/step/run-engine-step.ts
@@ -277,6 +277,7 @@ export function runEngineStep(snapshot: EngineSnapshot): EngineStepResult {
     attentionResults,
     translatedEmotionalState,
     availableActions,
+    snapshot.ownHistoryWindow ?? [],
   );
 
   // ── 14. Updated agent state ───────────────────────────────────────────────

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { PromptBuilder } from "../prompt-builder.js";
 import { EXAMPLE_PROMPT_PROFILE } from "../persona-prompt-profile.js";
+import { makeAgentRuntimeInput } from "./agent-input-test-helpers.js";
 import type { AgentRuntimeInput, CommittedEvent } from "@perfectman/shared";
 
 describe("PromptBuilder", () => {
@@ -370,5 +371,17 @@ describe("PromptBuilder", () => {
       expect(built.system).not.toContain("Tonal/register guide");
       expect(built.system).toContain('"consolidations"');
     });
+  });
+});
+
+describe("no_repeat — earlier utterances", () => {
+  it("renders the newest five own utterances verbatim and older ones as truncated reminders", () => {
+    const utterances = Array.from({ length: 8 }, (_, i) => `utterance number ${i} ${"x".repeat(90)}`);
+    const built = PromptBuilder.build(makeAgentRuntimeInput({ ownRecentUtterances: utterances }), EXAMPLE_PROMPT_PROFILE, "action_intent");
+    for (let i = 3; i < 8; i++) expect(built.system).toContain(`"utterance number ${i} ${"x".repeat(90)}"`);
+    expect(built.system).toContain("Earlier you already said");
+    expect(built.system).toContain("utterance number 0 ");
+    expect(built.system).not.toContain(`"utterance number 0 ${"x".repeat(90)}"`);
+    expect(built.system).toContain("…");
   });
 });

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -514,10 +514,23 @@ export class ActionIntentPromptBuilder {
 
   // Verbatim list of the agent's own last messages, wrapped as literal content
   // the model must not imitate (fence keeps it from reading as instructions).
+  /** Newest own utterances rendered verbatim; older ones as one truncated line each. */
+  private static readonly VERBATIM_UTTERANCES = 5;
+  private static readonly EARLIER_UTTERANCE_CHARS = 80;
+
   private static renderNoRepeat(s: PromptSection, ownRecentUtterances: string[]): void {
+    const verbatim = ownRecentUtterances.slice(-this.VERBATIM_UTTERANCES);
+    const earlier = ownRecentUtterances.slice(0, -this.VERBATIM_UTTERANCES);
     s.heading("Do not repeat yourself");
     s.raw("These are your OWN exact prior messages from earlier in this conversation. Cite-check your draft answer against them and do NOT repeat any of them or send a near-variation:");
-    s.fence(ownRecentUtterances.map((u) => `  - "${u}"`).join("\n"));
+    s.fence(verbatim.map((u) => `  - "${u}"`).join("\n"));
+    if (earlier.length > 0) {
+      s.raw("Earlier you already said (do not raise these again unless something changed):");
+      s.list(
+        undefined,
+        earlier.map((u) => (u.length > this.EARLIER_UTTERANCE_CHARS ? `${u.slice(0, this.EARLIER_UTTERANCE_CHARS)}…` : u)),
+      );
+    }
   }
 
   private static addList(s: PromptSection, title: string, items: string[]): void {

--- a/packages/server/src/simulation/__tests__/engine-snapshot-projection.test.ts
+++ b/packages/server/src/simulation/__tests__/engine-snapshot-projection.test.ts
@@ -112,4 +112,18 @@ describe("EngineSnapshotProjection", () => {
     expect(snapshot.rng).toBe(rng);
     expect(snapshot.channelMembership).toEqual([]);
   });
+
+  it("passes ownHistoryWindow through and leaves it absent when not supplied", () => {
+    const projection = new EngineSnapshotProjection();
+    const base = {
+      pulseIndex: 1, simulation: SIMULATION, recentEventsWindow: [], now: Date.now(), agentState: makeAgentState(), persona: PERSONA,
+      channels: [], membership: [], relationalStates: new Map(),
+      worldSignals: { highArousalNearby: false, averageChannelArousal: 0.5, activeAgentCount: 1, timeSinceLastPublicMessage: 60, channelMessageRatePerMinute: 0, recentTopicShift: false },
+      rateLimitStatus: { agentId: "agent_1", messagesThisMinute: 0, privateChannelsCreated: 0, lastActionAt: null, blocked: false },
+      dt: 1, rng: createSeededRng(1),
+    };
+    expect(projection.build(base).ownHistoryWindow).toBeUndefined();
+    const own = { ...base, ownHistoryWindow: [] as import("@perfectman/shared").CommittedEvent[] };
+    expect(projection.build(own).ownHistoryWindow).toEqual([]);
+  });
 });

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -898,4 +898,22 @@ describe("PulseScheduler", () => {
     });
   });
 
+
+  describe("own-history window", () => {
+    it("hands the engine the agent's own messages from the whole log even when the 40-event shared window has scrolled past them", async () => {
+      const mk = (actorId: string, content: string): import("@perfectman/shared").SimulationEvent => ({
+        simulationId: "sim_test", channelId: "ch_public", actorId, type: "message_sent", payload: { content },
+        sourceEventIds: [], emotionalSalience: "low",
+        visibility: { visibleToAgents: [], visibleToSpectators: true, visibleToOperators: true, visibilityReason: "public" },
+      });
+      await eventRepo.append("sim_test", [mk("agent_1", "gente, oficial: a proposta chegou")]);
+      await eventRepo.append("sim_test", Array.from({ length: 50 }, (_, i) => mk("agent_2", `foreign ${i}`)));
+      let seen: import("@perfectman/shared").EngineSnapshot | undefined;
+      scheduler = buildScheduler((snap) => { seen = snap; return makeCannedStep(); });
+      await scheduler.runPulse();
+      expect(seen?.recentEventsWindow.some((e) => e.actorId === "agent_1")).toBe(false);
+      expect(seen?.ownHistoryWindow?.map((e) => e.payload["content"])).toEqual(["gente, oficial: a proposta chegou"]);
+    });
+  });
+
 });

--- a/packages/server/src/simulation/projections/engine-snapshot-projection.ts
+++ b/packages/server/src/simulation/projections/engine-snapshot-projection.ts
@@ -16,6 +16,8 @@ export type EngineSnapshotInput = {
   pulseIndex: number;
   simulation: Simulation;
   recentEventsWindow: CommittedEvent[];
+  /** See EngineSnapshot.ownHistoryWindow. */
+  ownHistoryWindow?: CommittedEvent[];
   now: number;
   agentState: AgentState;
   persona: PersonaConfig;
@@ -34,6 +36,7 @@ export class EngineSnapshotProjection {
       pulseIndex: input.pulseIndex,
       simulation: input.simulation,
       recentEventsWindow: input.recentEventsWindow,
+      ...(input.ownHistoryWindow ? { ownHistoryWindow: input.ownHistoryWindow } : {}),
       now: input.now,
       agentState: input.agentState,
       persona: input.persona,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -14,7 +14,7 @@ import type {
   EndingOffer,
   Memory,
 } from "@perfectman/shared";
-import { createId, createSeededRng, STAGNATION_WINDOW_PULSES } from "@perfectman/shared";
+import { createId, createSeededRng, STAGNATION_WINDOW_PULSES, OWN_HISTORY_LIMIT } from "@perfectman/shared";
 import { runEngineStep, computeStagnationMetrics, detectAttractorStates, filterVisibleEventsForAgent } from "@perfectman/engine";
 import type { IEventRepository, IAgentStateRepository } from "../persistence/repositories.js";
 import type { ChannelRegistry } from "./channel-registry.js";
@@ -254,6 +254,15 @@ export class PulseScheduler {
         recentEventsWindow: contextEvents
           .filter((event) => event.visibility.visibilityReason !== "operator_only")
           .slice(-PulseScheduler.CONTEXT_WINDOW_PULSES_LIMIT),
+        // The agent's own recent messages from the whole log: the shared
+        // window is the wrong source for a per-agent repetition memory.
+        ownHistoryWindow: contextEvents
+          .filter(
+            (event) =>
+              event.actorId === agent.id &&
+              (event.type === "message_sent" || event.type === "reply_sent"),
+          )
+          .slice(-OWN_HISTORY_LIMIT),
         now,
         agentState,
         persona: agent.persona,

--- a/packages/shared/src/constants/repetition-window.ts
+++ b/packages/shared/src/constants/repetition-window.ts
@@ -1,0 +1,12 @@
+/**
+ * How far back an agent remembers what it already said. Both are owned by
+ * the eval's sweep-repetition harness (`packages/eval/src/cli/sweep-repetition.ts`).
+ *
+ * OWN_HISTORY_LIMIT: own messages the scheduler hands the engine from the
+ * full committed log, independent of the 40-event shared context window.
+ * OWN_UTTERANCE_WINDOW: own utterances the perception packet keeps (was 5,
+ * drawn from the shared window only — ~8-12 pulses in a 4-agent room, which
+ * is why a re-announcement at pulse 18 sailed past the guard).
+ */
+export const OWN_HISTORY_LIMIT = 12;
+export const OWN_UTTERANCE_WINDOW = 12;

--- a/packages/shared/src/engine/engine.types.ts
+++ b/packages/shared/src/engine/engine.types.ts
@@ -41,6 +41,14 @@ export type EngineSnapshot = {
   pulseIndex: number;
   simulation: Simulation;
   recentEventsWindow: CommittedEvent[]; // sliding context window — MUST include the event at agentState.lastProcessedEventId
+  /**
+   * This agent's own recent messages/replies drawn from the whole committed
+   * log (last OWN_HISTORY_LIMIT), independent of the shared window above.
+   * The repetition guard and the prompt's no_repeat block read their own
+   * utterances from here; in a 4-agent room the 40-event shared window only
+   * remembered ~8-12 pulses of them. Optional: absent means "window only".
+   */
+  ownHistoryWindow?: CommittedEvent[];
   now: number; // wall-clock ms at pulse start — pass from scheduler for determinism
   agentState: AgentState;
   persona: PersonaConfig;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -89,6 +89,7 @@ export * from "./constants/circumplex.js";
 export * from "./constants/personas.js";
 export * from "./constants/emotion-rules.js";
 export * from "./constants/pressure-refractory.js";
+export * from "./constants/repetition-window.js";
 export * from "./constants/action-pressure-map.js";
 export * from "./constants/stagnation.js";
 


### PR DESCRIPTION
## What

Gives the repetition guard and the prompt's `no_repeat` block a real memory of what the agent said:

- `EngineSnapshot.ownHistoryWindow?` — the agent's own last `OWN_HISTORY_LIMIT` messages/replies from the whole committed log, built by `PulseScheduler` from the `allCommitted` it already loads (no repository change) and passed through `EngineSnapshotProjection`.
- `buildPerceptionPacket` takes it as an eighth argument and assembles `ownRecentUtterances` from the union of that window and whatever own messages are still inside the shared window: deduped by event id, chronological, consecutive duplicates collapsed, last `OWN_UTTERANCE_WINDOW`. Before this the source was the 40-event shared window alone — ~8–12 pulses of memory in a 4-agent room, which is how a pulse-18 re-announcement sailed past a guard that had seen the pulse-7 original.
- `renderNoRepeat` shows the newest `VERBATIM_UTTERANCES` (5) verbatim, as before, and older ones as one 80-char line each under "Earlier you already said (do not raise these again unless something changed)"; the token-cap trim still sheds utterances oldest-first and the step-level guard still checks the full list.
- `OWN_HISTORY_LIMIT = 12`, `OWN_UTTERANCE_WINDOW = 12` (was 5) in `shared/src/constants/repetition-window.ts`, owned by `sweep-repetition`. `single_topic_lock` stays declared-not-implemented; it belongs with the #119 stagnation re-tune.
- Five tests: an own message that fell out of the shared window is present via the own-history window; cap, newest-last, id dedupe and consecutive-duplicate collapse; the prompt renders five verbatim and the rest truncated; the scheduler hands the engine the own message after 50 foreign ones scrolled the shared window; the projection passes the field through and leaves it absent when not supplied.

## Why

On the real `hoc_fatia_que_nao_existe` run the same agent re-posted near-verbatim announcements at p7, p10, p12, p18 and p28. The Jaccard guard caught the close ones and missed p18 and p28 because its own-utterance list came from a shared 40-event window that had already scrolled past p7.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1561, +5)
- Golden mock bench `check-bench-gate.mjs` PASS at 100% signals; `content-repetition` probe unchanged at 0 on the golden slice.
