### PR TITLE
feat(simulation): seeded per-pulse turn order

### DIFF
--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -916,4 +916,49 @@ describe("PulseScheduler", () => {
     });
   });
 
+
+  describe("seeded turn order", () => {
+    const FOUR = ["agent_1", "agent_2", "agent_3", "agent_4"].map((id) => ({ id, state: makeAgentState(id), persona: AGENT.persona }));
+
+    async function orderTrace(seed: number, pulses: number): Promise<string[][]> {
+      const trace: string[][] = [];
+      let current: string[] = [];
+      const local = new PulseScheduler({
+        simulation: { ...SIM, seed, agentIds: FOUR.map((a) => a.id) },
+        agents: FOUR,
+        defaultPublicChannelId: "ch_public",
+        eventRepo: new InMemoryEventRepository(),
+        agentStateRepo: new InMemoryAgentStateRepository(),
+        channelRegistry,
+        rateLimitGate: new RateLimitGate(SETTINGS),
+        intentResolver,
+        engineSnapshotProjection: new EngineSnapshotProjection(),
+        deliveryProjection: new DeliveryProjection(gateway),
+        spectatorProjection: new SpectatorProjection(gateway),
+        operatorProjection: new OperatorProjection(gateway),
+        engineEventBuilder,
+        agentRuntime: mockAgentRuntime,
+        llmBudget: mockLLMBudget,
+        pulseIntervalMs: SETTINGS.pulseIntervalMs,
+        stepResolver: (snap) => { current.push(snap.agentState.agentId); return makeCannedStep({ agentId: snap.agentState.agentId }); },
+      });
+      for (let p = 0; p < pulses; p++) {
+        current = [];
+        await local.runPulse();
+        trace.push([...current]);
+      }
+      return trace;
+    }
+
+    it("is a pure function of (seed, pulseIndex) and is not constant across pulses", async () => {
+      const a = await orderTrace(11, 8);
+      const b = await orderTrace(11, 8);
+      expect(a).toEqual(b);
+      for (const order of a) expect([...order].sort()).toEqual([...FOUR.map((x) => x.id)].sort());
+      expect(new Set(a.map((o) => o.join(","))).size).toBeGreaterThan(1);
+      const other = await orderTrace(12, 8);
+      expect(other).not.toEqual(a);
+    });
+  });
+
 });

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -169,6 +169,24 @@ export class PulseScheduler {
     return this.inFlight;
   }
 
+  /**
+   * Per-pulse agent order, a pure function of (seed, pulseIndex). Later
+   * agents in a pulse see earlier agents' commits (the window refresh in
+   * the loop), so a fixed config order gave agent 0 a permanent first-mover
+   * slot and everyone else a permanent reactor slot. A separate rng stream
+   * (seed mixed with the pulse index by a golden-ratio constant) keeps the
+   * per-agent snapshot rng values unchanged.
+   */
+  private turnOrder(seed: number): AgentContext[] {
+    const rng = createSeededRng((seed ^ Math.imul(this.pulseIndex + 1, 0x9e3779b1)) >>> 0);
+    const order = [...this.config.agents];
+    for (let i = order.length - 1; i > 0; i--) {
+      const j = rng.nextInt(i + 1);
+      [order[i], order[j]] = [order[j]!, order[i]!];
+    }
+    return order;
+  }
+
   private async executePulse(): Promise<PulseResult> {
     this.simTime += this.config.pulseIntervalMs;
     const now = this.simTime;
@@ -221,7 +239,7 @@ export class PulseScheduler {
       }
     }
 
-    for (const agent of this.config.agents) {
+    for (const agent of this.turnOrder(sim.seed)) {
       // Refresh event window so this agent sees actions taken by prior agents this pulse.
       try {
         newEvents = await this.config.eventRepo.getAfter(sim.id, pulseStartEventId);


### PR DESCRIPTION
## What

Makes the per-pulse agent order a seeded shuffle instead of config order:

- `PulseScheduler.turnOrder(seed)` — Fisher–Yates over `config.agents` with `createSeededRng((seed ^ Math.imul(pulseIndex + 1, 0x9e3779b1)) >>> 0)`, a separate rng stream so the per-agent snapshot rng values are unchanged. Later agents in a pulse already see earlier agents' commits (the window refresh inside the loop), so a fixed order gave agent 0 a permanent first-mover slot and everyone else a permanent reactor slot.
- No per-pulse cap on consecutive acts here: that invariant is pinned in the engine by ADR-0015's property tests and ADR-0016's 40-pulse run; a scheduler cap would be a second owner of the gate.
- One test: the order trace over 8 pulses with 4 agents is identical for the same seed, a permutation of the cast on every pulse, not constant across pulses, and different for a different seed.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1562, +1)
- Golden mock bench `check-bench-gate.mjs` PASS at 100% signals; html-receiver parity e2e passes (recorder and receiver observe the same order).
