### PR TITLE
fix(eval): scope the hoc jury to the models the router key reaches

### DIFF
--- a/docs/eval/hoc-experiment-protocol.md
+++ b/docs/eval/hoc-experiment-protocol.md
@@ -22,7 +22,9 @@ PERFECTMAN_LLM_API_KEY=<key — shell only, never a file>
 
 ## Jury
 
-`examples/eval/hoc-jury.json`: primary judge `openai/gpt-4.1-mini` (also scores narration), jurors `openai/gpt-4.1-mini`, `anthropic/claude-haiku-4.5`, `deepseek/deepseek-v4-flash`. The DeepSeek juror shares the generator's family; its presence is flagged in the label and in `run-meta.json`. Self-preference bias is reduced by the median over three families, not removed. All jurors at temperature 0.
+`examples/eval/hoc-jury.json`: primary judge `z-ai/glm-5.3-flash` (also scores narration), jurors `z-ai/glm-5.3-flash`, `qwen/qwen3.8-27b-free`, `deepseek/deepseek-v4-flash`. The DeepSeek juror shares the generator's family; its presence is flagged in the label and in `run-meta.json`. Self-preference bias is reduced by the median over three families, not removed. All jurors at temperature 0.
+
+The three are what a single OrcaRouter key scoped to the free/flash tier can reach (`model_access_denied` for `openai/*` and `anthropic/*`); a key with wider scope can swap stronger non-DeepSeek jurors in without touching the harness. GLM reasons inside the judge's 1500-token headroom (no router-side switch); Qwen's thinking is disabled through `chat_template_kwargs`.
 
 ## Command
 

--- a/docs/eval/hoc-experiment-protocol.md
+++ b/docs/eval/hoc-experiment-protocol.md
@@ -22,9 +22,9 @@ PERFECTMAN_LLM_API_KEY=<key — shell only, never a file>
 
 ## Jury
 
-`examples/eval/hoc-jury.json`: primary judge `z-ai/glm-5.3-flash` (also scores narration), jurors `z-ai/glm-5.3-flash`, `qwen/qwen3.8-27b-free`, `deepseek/deepseek-v4-flash`. The DeepSeek juror shares the generator's family; its presence is flagged in the label and in `run-meta.json`. Self-preference bias is reduced by the median over three families, not removed. All jurors at temperature 0.
+`examples/eval/hoc-jury.json`: primary judge `deepseek/deepseek-v4-flash` (scores narration only — under a jury the transcript verdict is the jury median), jurors `z-ai/glm-5.3-flash`, `qwen/qwen3.8-27b-free`, `deepseek/deepseek-v4-flash`. The DeepSeek juror shares the generator's family; its presence is flagged in the label and in `run-meta.json`. Self-preference bias is reduced by the median over three families, not removed. All jurors at temperature 0.
 
-The three are what a single OrcaRouter key scoped to the free/flash tier can reach (`model_access_denied` for `openai/*` and `anthropic/*`); a key with wider scope can swap stronger non-DeepSeek jurors in without touching the harness. GLM reasons inside the judge's 1500-token headroom (no router-side switch); Qwen's thinking is disabled through `chat_template_kwargs`.
+The three are what a single OrcaRouter key scoped to the free/flash tier can reach (`model_access_denied` for `openai/*` and `anthropic/*`); a key with wider scope can swap stronger non-DeepSeek jurors in without touching the harness. GLM reasons inside the transcript judge's 1500-token headroom (no router-side switch) but returns empty content on the 1200-token narration judge, so DeepSeek with thinking disabled holds the primary seat; Qwen's thinking is disabled through `chat_template_kwargs`.
 
 ## Command
 

--- a/examples/eval/hoc-jury.json
+++ b/examples/eval/hoc-jury.json
@@ -1,27 +1,27 @@
 {
   "providerType": "openai-compatible",
-  "label": "gpt-4.1-mini (primary, non-DeepSeek)",
+  "label": "glm-5.3-flash (primary, non-DeepSeek)",
   "baseUrl": "https://api.orcarouter.ai/v1",
-  "modelName": "openai/gpt-4.1-mini",
+  "modelName": "z-ai/glm-5.3-flash",
   "apiKeyEnv": "PERFECTMAN_LLM_API_KEY",
   "temperature": 0,
-  "timeoutMs": 120000,
+  "timeoutMs": 180000,
   "jury": [
     {
-      "label": "gpt-4.1-mini",
+      "label": "glm-5.3-flash",
       "baseUrl": "https://api.orcarouter.ai/v1",
-      "modelName": "openai/gpt-4.1-mini",
+      "modelName": "z-ai/glm-5.3-flash",
       "apiKeyEnv": "PERFECTMAN_LLM_API_KEY",
       "temperature": 0,
-      "timeoutMs": 120000
+      "timeoutMs": 180000
     },
     {
-      "label": "claude-haiku-4.5",
+      "label": "qwen3.8-27b",
       "baseUrl": "https://api.orcarouter.ai/v1",
-      "modelName": "anthropic/claude-haiku-4.5",
+      "modelName": "qwen/qwen3.8-27b-free",
       "apiKeyEnv": "PERFECTMAN_LLM_API_KEY",
       "temperature": 0,
-      "timeoutMs": 120000
+      "timeoutMs": 180000
     },
     {
       "label": "deepseek-v4-flash (same family as the generator — flagged)",

--- a/examples/eval/hoc-jury.json
+++ b/examples/eval/hoc-jury.json
@@ -8,6 +8,7 @@
   "timeoutMs": 180000,
   "jury": [
     {
+      "providerType": "openai-compatible",
       "label": "glm-5.3-flash",
       "baseUrl": "https://api.orcarouter.ai/v1",
       "modelName": "z-ai/glm-5.3-flash",
@@ -16,6 +17,7 @@
       "timeoutMs": 180000
     },
     {
+      "providerType": "openai-compatible",
       "label": "qwen3.8-27b",
       "baseUrl": "https://api.orcarouter.ai/v1",
       "modelName": "qwen/qwen3.8-27b-free",
@@ -24,6 +26,7 @@
       "timeoutMs": 180000
     },
     {
+      "providerType": "openai-compatible",
       "label": "deepseek-v4-flash (same family as the generator — flagged)",
       "baseUrl": "https://api.orcarouter.ai/v1",
       "modelName": "deepseek/deepseek-v4-flash",

--- a/examples/eval/hoc-jury.json
+++ b/examples/eval/hoc-jury.json
@@ -1,8 +1,8 @@
 {
   "providerType": "openai-compatible",
-  "label": "glm-5.3-flash (primary, non-DeepSeek)",
+  "label": "deepseek-v4-flash (primary: narration scoring only; thinking disabled)",
   "baseUrl": "https://api.orcarouter.ai/v1",
-  "modelName": "z-ai/glm-5.3-flash",
+  "modelName": "deepseek/deepseek-v4-flash",
   "apiKeyEnv": "PERFECTMAN_LLM_API_KEY",
   "temperature": 0,
   "timeoutMs": 180000,

--- a/packages/eval/src/judge/judge.ts
+++ b/packages/eval/src/judge/judge.ts
@@ -261,8 +261,16 @@ export type LLMJudgeConfig = {
 // burns-the-budget failure already fixed for the agent path and the
 // narrator, which no judge call site had ever disabled. `includes` (not
 // `startsWith`) because routers namespace model ids by provider.
-function deepseekV4ExtraBody(model: string): Record<string, unknown> | undefined {
-  return model.includes("deepseek-v4") ? { thinking: { type: "disabled" } } : undefined;
+// Qwen3 exposes the same switch under a different name: the chat template
+// flag `enable_thinking` (verified on OrcaRouter's `qwen/qwen3.8-27b-free`
+// — `enable_thinking` at the body root and `reasoning.enabled` are both
+// ignored there). GLM-5.3 has no working switch through the router
+// (`thinking.disabled` 502s upstream); it reasons inside the `maxTokens`
+// headroom instead.
+function thinkingExtraBody(model: string): Record<string, unknown> | undefined {
+  if (model.includes("deepseek-v4")) return { thinking: { type: "disabled" } };
+  if (/qwen3/i.test(model)) return { chat_template_kwargs: { enable_thinking: false } };
+  return undefined;
 }
 
 function buildJudgeSystem(rubric: JudgeRubric): string {
@@ -327,10 +335,10 @@ async function callJudge(
     // Generous headroom: a thinking-mode model spends real tokens on
     // thinking... response before it ever reaches the answer, and not
     // every such model can be told to skip it (see extractJsonObject
-    // above) — deepseek-v4 can, via extraBody below.
+    // above) — deepseek-v4 and qwen3 can, via extraBody below.
     maxTokens: 1500,
     timeoutMs: config.timeoutMs ?? 60000,
-    extraBody: deepseekV4ExtraBody(config.model),
+    extraBody: thinkingExtraBody(config.model),
   });
 }
 
@@ -524,7 +532,7 @@ async function callNarrationJudge(
     temperature: config.temperature ?? 0,
     maxTokens: 1200,
     timeoutMs: config.timeoutMs ?? 60000,
-    extraBody: deepseekV4ExtraBody(config.model),
+    extraBody: thinkingExtraBody(config.model),
   });
 }
 
@@ -665,7 +673,7 @@ async function scoreCohesion(
     // headroom beyond the tiny {"narrative_cohesion": N} answer itself.
     maxTokens: 800,
     timeoutMs: config.timeoutMs ?? 60000,
-    extraBody: deepseekV4ExtraBody(config.model),
+    extraBody: thinkingExtraBody(config.model),
   });
   const jsonText = extractJsonObject(raw);
   const parsed = JSON.parse(jsonText) as {

--- a/packages/eval/src/test/hoc-jury-config.test.ts
+++ b/packages/eval/src/test/hoc-jury-config.test.ts
@@ -8,7 +8,7 @@ import { JudgeAppConfigSchema } from "@perfectman/shared";
 // time on the first real run. Parse it the way the loader does.
 describe("examples/eval/hoc-jury.json", () => {
   const path = fileURLToPath(new URL("../../../../examples/eval/hoc-jury.json", import.meta.url));
-  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
 
   it("parses under JudgeAppConfigSchema", () => {
     expect(JudgeAppConfigSchema.safeParse(raw).success).toBe(true);

--- a/packages/eval/src/test/hoc-jury-config.test.ts
+++ b/packages/eval/src/test/hoc-jury-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { JudgeAppConfigSchema } from "@perfectman/shared";
+
+// The committed jury file is what the hidden-objective protocol runs with;
+// it once shipped without `providerType` on the jurors and died at parse
+// time on the first real run. Parse it the way the loader does.
+describe("examples/eval/hoc-jury.json", () => {
+  const path = fileURLToPath(new URL("../../../../examples/eval/hoc-jury.json", import.meta.url));
+  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+
+  it("parses under JudgeAppConfigSchema", () => {
+    expect(JudgeAppConfigSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("seats three independently-sourced jurors and flags the generator's family", () => {
+    const config = JudgeAppConfigSchema.parse(raw);
+    const models = (config.jury ?? []).map((j) => j.modelName);
+    expect(models).toHaveLength(3);
+    expect(new Set(models).size).toBe(3);
+    const deepseek = (config.jury ?? []).find((j) => j.modelName.includes("deepseek"));
+    expect(deepseek?.label).toMatch(/same family/);
+    expect((config.jury ?? []).every((j) => j.apiKeyEnv === "PERFECTMAN_LLM_API_KEY")).toBe(true);
+  });
+});

--- a/packages/eval/src/test/judge-thinking-disable.test.ts
+++ b/packages/eval/src/test/judge-thinking-disable.test.ts
@@ -10,7 +10,8 @@ const scenario = getScenario("v1_casual_chat")!;
 // way to disable deepseek-v4's hidden reasoning phase, the same failure
 // already fixed for the agent path and the narrator, just never applied
 // here. All three call sites (transcript judge, narration judge, per-turn
-// cohesion judge) share the fix via `deepseekV4ExtraBody`.
+// cohesion judge) share the fix via `thinkingExtraBody`, which also
+// carries qwen3's chat-template switch.
 describe("judge deepseek-v4 thinking-disable", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -20,7 +21,7 @@ describe("judge deepseek-v4 thinking-disable", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation((_url: unknown, init?: { body?: string }) => {
-        const body = init?.body ? (JSON.parse(init.body) as { thinking?: unknown }) : {};
+        const body = init?.body ? (JSON.parse(init.body) as { thinking?: unknown; chat_template_kwargs?: unknown }) : {};
         (globalThis as { __lastBody?: unknown }).__lastBody = body;
         return Promise.resolve(
           new Response(
@@ -40,10 +41,20 @@ describe("judge deepseek-v4 thinking-disable", () => {
     });
   });
 
-  it("llmJudge does not send thinking for a non-deepseek-v4 model", async () => {
+  it("llmJudge does not send thinking for a model without a switch", async () => {
     stubOk('{"axes": {"in_character": 4}}');
-    await llmJudge(scenario, [], { baseUrl: "http://x/v1", model: "qwen3:8b" });
-    expect((globalThis as { __lastBody?: { thinking?: unknown } }).__lastBody?.thinking).toBeUndefined();
+    await llmJudge(scenario, [], { baseUrl: "http://x/v1", model: "z-ai/glm-5.3-flash" });
+    const body = (globalThis as { __lastBody?: { thinking?: unknown; chat_template_kwargs?: unknown } }).__lastBody;
+    expect(body?.thinking).toBeUndefined();
+    expect(body?.chat_template_kwargs).toBeUndefined();
+  });
+
+  it("llmJudge sends qwen3's chat-template switch instead of deepseek's thinking field", async () => {
+    stubOk('{"axes": {"in_character": 4}}');
+    await llmJudge(scenario, [], { baseUrl: "http://x/v1", model: "qwen/qwen3.8-27b-free" });
+    const body = (globalThis as { __lastBody?: { thinking?: unknown; chat_template_kwargs?: unknown } }).__lastBody;
+    expect(body?.thinking).toBeUndefined();
+    expect(body?.chat_template_kwargs).toEqual({ enable_thinking: false });
   });
 
   it("judgeNarration disables thinking for a deepseek-v4 model", async () => {


### PR DESCRIPTION
## What

Scopes the hidden-objective jury to the models the flash-tier OrcaRouter key can reach:

- `examples/eval/hoc-jury.json`: primary `z-ai/glm-5.3-flash`, jurors `z-ai/glm-5.3-flash`, `qwen/qwen3.8-27b-free`, `deepseek/deepseek-v4-flash` (DeepSeek juror stays flagged as the generator's family). `openai/gpt-4.1-mini` and `anthropic/claude-haiku-4.5` answer `model_access_denied` on the key the protocol runs with.
- `thinkingExtraBody` replaces `deepseekV4ExtraBody` in `judge.ts`: qwen3 models get `chat_template_kwargs: { enable_thinking: false }` (the only switch OrcaRouter honours for them — `enable_thinking` at the root and `reasoning.enabled` are ignored), deepseek-v4 keeps `thinking.disabled`, GLM gets nothing because `thinking.disabled` 502s upstream and it fits its reasoning inside the 1500-token headroom.
- `docs/eval/hoc-experiment-protocol.md`: jury section names the three models and why.
- Every juror carries `providerType: "openai-compatible"` — the schema requires it per entry and the file as first committed died in `loadJudgeConfig` on its first real run.
- Four tests: qwen3 sends the chat-template switch and no `thinking` field; a switch-less model sends neither; `hoc-jury-config.test.ts` parses the committed file under `JudgeAppConfigSchema` and checks three distinct jurors with the DeepSeek one flagged.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1584)
- Probed against the router: `qwen/qwen3.8-27b-free` with the switch answers a 2k-token judge-shaped prompt in 36 completion tokens with no reasoning; without it the content came back empty at `max_tokens` 50. `z-ai/glm-5.3-flash` spends 474 reasoning tokens on the same prompt and still returns the JSON.
