### PR TITLE
feat(agent): silence as a move, Portuguese-pinned motives, ungated risk, memories trimmed last

### DIFF
--- a/docs/eval/hoc-experiment-protocol.md
+++ b/docs/eval/hoc-experiment-protocol.md
@@ -26,6 +26,10 @@ PERFECTMAN_LLM_API_KEY=<key — shell only, never a file>
 
 The three are what a single OrcaRouter key scoped to the free/flash tier can reach (`model_access_denied` for `openai/*` and `anthropic/*`); a key with wider scope can swap stronger non-DeepSeek jurors in without touching the harness. GLM has no thinking switch through the router and spends 4000+ tokens reasoning over a 32-pulse transcript, so its juror entry carries `maxTokens: 8000` and `timeoutMs: 300000` (measured 146 s on the Sítio read); DeepSeek with thinking disabled holds the narration seat; Qwen's thinking is disabled through `chat_template_kwargs`.
 
+## Prompt template versions
+
+`promptTemplateVersions` in `run-meta.json` identifies the agent prompt template. `hn81j7` is the template every M0 read used (baseline and main arms); `2imp7w` is prompt round 1 (silence as a move, Portuguese pin with Portuguese exemplars, ungated creativity with the generic-reply list, memory writes on belief change, memories trimmed last). Arms with different template versions are not a pair.
+
 ## Command
 
 ```sh

--- a/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
@@ -62,11 +62,52 @@ describe("ActionIntentPromptBuilder — decision moment", () => {
   // anywhere told agents to take a creative risk, so a real transcript read
   // as a "sensible negotiation" — safe, agreeable, never provoking — exactly
   // what the rubric's creativity_unhinged anchor-1 describes.
-  it("gives explicit permission to take a creative risk under real pressure", () => {
+  it("gives ungated permission to take a creative risk and names the generic replies that count as failure", () => {
     const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
 
     expect(built.user).toContain("provoke");
     expect(built.user).toContain("Playing it safe every single turn is itself a failure");
+    // The old gate let the model decide the stakes weren't real.
+    expect(built.user).not.toContain("When there is real pressure");
+    expect(built.user).toContain("agreeing and restating");
+    expect(built.user).toContain("asking a clarifying question instead of taking a position");
+  });
+
+  it("frames silence as a move in the decision and describes no_op in the action list", () => {
+    const withNoOp = {
+      ...input,
+      availableActions: [
+        { intentType: "send_message" as const, channelTargets: ["general"], personTargets: [], blocked: false },
+        { intentType: "no_op" as const, channelTargets: [], personTargets: [], blocked: false },
+      ],
+    };
+    const built = PromptBuilder.build(withNoOp, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.user).toContain("Withholding is also a move");
+    expect(built.user).toContain("**no_op** — stay silent on purpose");
+    // Other actions keep their bare rendering.
+    expect(built.user).toContain("**send_message** (Channels: general)");
+  });
+
+  it("relaxes memoryWrites to belief change instead of suppressing it", () => {
+    const built = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
+
+    expect(built.system).toContain("whenever what you believe about someone in this room changed");
+    expect(built.system).not.toContain("not on every turn");
+  });
+
+  it("pins visibleContent and privateMotiveSummary to Portuguese for pt-BR profiles, with Portuguese exemplars", () => {
+    const pt = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "pt-BR" }, "action_intent");
+    expect(pt.system).toContain('Write "visibleContent" AND "privateMotiveSummary" in Portuguese (pt-BR)');
+    expect(pt.system).toContain("estou ignorando a mensagem dela");
+    expect(pt.system).not.toContain("I am ignoring a friend");
+
+    const en = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "en" }, "action_intent");
+    expect(en.system).toContain("I am ignoring a friend");
+    expect(en.system).not.toContain("in Portuguese (pt-BR) — the motive");
+    // The uncomfortable-driver framing is language-independent.
+    expect(en.system).toContain("petty, insecure, or manipulative");
+    expect(pt.system).toContain("petty, insecure, or manipulative");
   });
 });
 

--- a/packages/server/src/agent/__tests__/action-intent-prompt-trim.test.ts
+++ b/packages/server/src/agent/__tests__/action-intent-prompt-trim.test.ts
@@ -79,41 +79,44 @@ describe("ActionIntentPromptBuilder maxInputTokens trim", () => {
     expect(a.trim).toEqual(b.trim);
   });
 
-  it("drops lowest-salience memories before any recent event", () => {
+  it("drops oldest recent events before any memory and always keeps the triggering event", () => {
     // A cap just below the raw estimate: the small overflow is absorbed by
-    // dropping memories alone, so no event is touched.
+    // dropping the oldest events alone, so no memory is touched — memories
+    // are the only grounding that spans pulses (memory_continuity).
     const cap = rawBuild.inputTokensEstimate - 20;
     const built = PromptBuilder.build(fullInput, EXAMPLE_PROMPT_PROFILE, "action_intent", cap);
 
     expect(built.trim).toBeDefined();
-    expect(built.trim!.droppedMemories).toBeGreaterThan(0);
-    expect(built.trim!.droppedEvents).toBe(0);
-    // The lowest-confidence memory (mem-000) goes first; the highest stays.
-    expect(built.user).not.toContain("memory-0-marker");
-    expect(built.user).toContain(`memory-${MEMORY_COUNT - 1}-marker`);
+    expect(built.trim!.droppedEvents).toBeGreaterThan(0);
+    expect(built.trim!.droppedMemories).toBe(0);
+    // Oldest (event-0) dropped; newest and the trigger retained.
+    expect(built.user).not.toContain("event-0-marker");
+    expect(built.user).toContain(`event-${EVENT_COUNT - 1}-marker`);
+    expect(built.user).toContain(TRIGGER_CONTENT);
+    expect(built.user).toContain("memory-0-marker");
   });
 
-  it("drops oldest recent events first and always keeps the triggering event", () => {
-    // Force every memory out plus a partial slice of the oldest events.
-    const perEvent =
+  it("drops lowest-salience memories only after every droppable event is gone", () => {
+    // Force every event out plus a partial slice of the memories.
+    const perMemory =
       PromptBuilder.build(
-        makeAgentRuntimeInput({ triggeringEvent, visibleContextEvents: [triggeringEvent, makeContextEvent(0)] }),
+        makeAgentRuntimeInput({ triggeringEvent, visibleContextEvents: [triggeringEvent], relevantMemories: [makeContextMemory(0)] }),
         EXAMPLE_PROMPT_PROFILE,
         "action_intent",
       ).inputTokensEstimate - floorBuild.inputTokensEstimate;
-    const keepEvents = 6;
-    const cap = floorBuild.inputTokensEstimate + perEvent * keepEvents;
+    const keepMemories = 4;
+    const cap = floorBuild.inputTokensEstimate + perMemory * keepMemories;
 
     const built = PromptBuilder.build(fullInput, EXAMPLE_PROMPT_PROFILE, "action_intent", cap);
 
     expect(built.inputTokensEstimate).toBeLessThanOrEqual(cap);
     expect(built.trim).toBeDefined();
-    expect(built.trim!.droppedMemories).toBe(MEMORY_COUNT);
-    expect(built.trim!.droppedEvents).toBeGreaterThan(0);
-    expect(built.trim!.droppedEvents).toBeLessThan(EVENT_COUNT);
-    // Oldest (event-0) dropped; newest (event-23) and the trigger retained.
-    expect(built.user).not.toContain("event-0-marker");
-    expect(built.user).toContain(`event-${EVENT_COUNT - 1}-marker`);
+    expect(built.trim!.droppedEvents).toBe(EVENT_COUNT);
+    expect(built.trim!.droppedMemories).toBeGreaterThan(0);
+    expect(built.trim!.droppedMemories).toBeLessThan(MEMORY_COUNT);
+    // The lowest-confidence memory (mem-000) goes first; the highest stays.
+    expect(built.user).not.toContain("memory-0-marker");
+    expect(built.user).toContain(`memory-${MEMORY_COUNT - 1}-marker`);
     expect(built.user).toContain(TRIGGER_CONTENT);
   });
 
@@ -179,7 +182,7 @@ describe("ActionIntentPromptBuilder maxInputTokens trim", () => {
     expect(built.system).toContain(`utterance-${utterances.length - 1}-marker`);
   });
 
-  it("sheds own utterances only after memories and events", () => {
+  it("sheds own utterances after events and before memories", () => {
     const utterance = `utterance-0-marker ${"u".repeat(120)}`;
     const baseInput = {
       triggeringEvent,
@@ -187,23 +190,18 @@ describe("ActionIntentPromptBuilder maxInputTokens trim", () => {
       relevantMemories: [makeContextMemory(0)],
       ownRecentUtterances: [utterance],
     };
-    const floorBuild = PromptBuilder.build(
-      makeAgentRuntimeInput({ triggeringEvent, visibleContextEvents: [triggeringEvent] }),
-      EXAMPLE_PROMPT_PROFILE,
-      "action_intent",
-    );
-    const withUtteranceOnly = PromptBuilder.build(
+    const withMemoryOnly = PromptBuilder.build(
       makeAgentRuntimeInput({
         triggeringEvent,
         visibleContextEvents: [triggeringEvent],
-        ownRecentUtterances: [utterance],
+        relevantMemories: [makeContextMemory(0)],
       }),
       EXAMPLE_PROMPT_PROFILE,
       "action_intent",
     );
-    // Cap sits just above the one-utterance render, so fitting requires
-    // shedding both the memory and the event first — utterances yield last.
-    const cap = withUtteranceOnly.inputTokensEstimate + 5;
+    // Cap sits just above the memory-only render: fitting sheds the event,
+    // then the utterance, and stops — the memory is the last thing to go.
+    const cap = withMemoryOnly.inputTokensEstimate + 5;
     expect(cap).toBeLessThan(
       PromptBuilder.build(makeAgentRuntimeInput(baseInput), EXAMPLE_PROMPT_PROFILE, "action_intent")
         .inputTokensEstimate,
@@ -217,13 +215,13 @@ describe("ActionIntentPromptBuilder maxInputTokens trim", () => {
     );
 
     expect(built.trim).toBeDefined();
-    expect(built.trim!.droppedMemories).toBe(1);
     expect(built.trim!.droppedEvents).toBe(1);
-    expect(built.trim!.droppedUtterances).toBe(0);
+    expect(built.trim!.droppedUtterances).toBe(1);
+    expect(built.trim!.droppedMemories).toBe(0);
     expect(built.trim!.withinCap).toBe(true);
-    expect(built.user).not.toContain("memory-0-marker");
+    expect(built.user).toContain("memory-0-marker");
     expect(built.user).not.toContain("event-0-marker");
-    expect(built.system).toContain("utterance-0-marker");
+    expect(built.system).not.toContain("utterance-0-marker");
   });
 
   it("flags an irreducible over-cap prompt with withinCap:false after shedding everything droppable", () => {

--- a/packages/server/src/agent/__tests__/agent-runtime.test.ts
+++ b/packages/server/src/agent/__tests__/agent-runtime.test.ts
@@ -305,7 +305,7 @@ describe("AgentRuntime Orchestration", () => {
       expect(retrySystem).toContain("staying true to what you actually want right now");
       expect(retrySystem).toContain("do not invent novelty");
       // (c) escape hatch — the real sentence, including the standalone "Or choose"
-      expect(retrySystem).toContain('Or choose "no_op" if you truly have nothing new to add');
+      expect(retrySystem).toContain('Or choose "no_op" on purpose');
     });
 
     it("honors maxRetries=2: recovers on the second retry after two repeats", async () => {

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -284,8 +284,8 @@ describe("PromptBuilder", () => {
     it.each([
       ["first-person framing", "first person"],
       ["event grounding in <events>", "grounded in what actually happened in <events>"],
-      ["only when the exchange matters", "only when this exchange actually matters"],
-      ["empty when nothing qualifies", 'leave "memoryWrites" empty'],
+      ["whenever a belief about someone changed", "whenever what you believe about someone in this room changed"],
+      ["empty when nothing changed", 'leave "memoryWrites" empty'],
     ])("output contract instructs memoryWrites emission: %s", (_label, marker) => {
       const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
       expect(prompt.system).toContain(marker);

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -145,20 +145,21 @@ export class ActionIntentPromptBuilder {
    * lowest-value per-pulse context and re-rendering after every drop. The
    * order is fixed so the same input and cap always yield the same trimmed
    * prompt:
-   *   1. relevant memories, lowest salience first — `confidence` ascending,
-   *      then `lastReinforcedAt` ascending (staler first), then `id`.
-   *   2. recent context events, oldest first — `pulseIndex` ascending, then
+   *   1. recent context events, oldest first — `pulseIndex` ascending, then
    *      `createdAt` ascending, then `id`. The triggering event is the floor
    *      and is never dropped.
-   *   3. own recent utterances, oldest first (array order — perception
+   *   2. own recent utterances, oldest first (array order — perception
    *      assembles them chronologically). The step-level repetition guard
    *      checks the full utterance list regardless of what the prompt shows,
    *      so shedding these only weakens the preemptive no-repeat hint, never
    *      the structural enforcement.
-   * Memories yield before the live transcript because a stale, low-confidence
-   * memory is the most expendable grounding for the next action. Persona, the
-   * output contract and the decision question are structural and are never
-   * trimmed here.
+   *   3. relevant memories, lowest salience first — `confidence` ascending,
+   *      then `lastReinforcedAt` ascending (staler first), then `id`.
+   * Memories yield last: they are the only grounding that spans pulses, and
+   * memory_continuity is judged from what the agent carried forward — an old
+   * public line is more expendable than a seeded secret. Persona, the output
+   * contract and the decision question are structural and are never trimmed
+   * here.
    */
   private static trimToFit(
     input: AgentRuntimeInput,
@@ -197,12 +198,6 @@ export class ActionIntentPromptBuilder {
 
     let rendered = renderCandidate();
 
-    while (!fits(rendered) && memories.length > 0) {
-      memories.splice(this.lowestSalienceMemoryIndex(memories), 1);
-      droppedMemories++;
-      rendered = renderCandidate();
-    }
-
     while (!fits(rendered)) {
       const idx = this.oldestDroppableEventIndex(events, triggeringEventId);
       if (idx === -1) break;
@@ -214,6 +209,12 @@ export class ActionIntentPromptBuilder {
     while (!fits(rendered) && utterances.length > 0) {
       utterances.shift();
       droppedUtterances++;
+      rendered = renderCandidate();
+    }
+
+    while (!fits(rendered) && memories.length > 0) {
+      memories.splice(this.lowestSalienceMemoryIndex(memories), 1);
+      droppedMemories++;
       rendered = renderCandidate();
     }
 
@@ -266,7 +267,7 @@ export class ActionIntentPromptBuilder {
 
     const system = new PromptSection()
       .container("persona", (s) => this.renderPersona(s, profile, input.hasActed === true))
-      .container("output_contract", (s) => this.renderOutputContract(s, input.agentId));
+      .container("output_contract", (s) => this.renderOutputContract(s, profile.language, input.agentId));
     if (perceptionPacket.ownRecentUtterances.length > 0) {
       system.container("no_repeat", (s) => this.renderNoRepeat(s, perceptionPacket.ownRecentUtterances));
     }
@@ -364,18 +365,31 @@ export class ActionIntentPromptBuilder {
     }
   }
 
-  private static renderOutputContract(s: PromptSection, actorId: string): void {
+  private static renderOutputContract(s: PromptSection, language: PersonaPromptProfile["language"], actorId: string): void {
+    // The exemplars pull the model's language: with English examples inside
+    // a Portuguese scene, 21 of 50 motives in the first real read came out in
+    // English. The exemplars follow the profile language, and pt-BR profiles
+    // get the pin stated outright for both fields.
+    const pt = language === "pt-BR";
+    const motiveExamples = pt
+      ? '"estou ignorando a mensagem dela pra ela vir atrás de mim, porque ela me ignorou ontem", "quero fofocar no privado pra fechar aliança com alguém do grupo antes da votação"'
+      : '"I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group"';
     s.heading("Output contract");
     s.raw("You must respond with a SINGLE valid JSON object matching the enforced intent schema. Do not include any conversational introduction, explanations, markdown code fences, or thinking blocks — return ONLY the JSON object.");
     s.raw(`The fields id, actorId, preferredDelay and fallbackIfBlocked are assigned by the system — never set them (actorId is ${actorId}).`);
     s.raw("The schema is enforced at decoding time where the provider honors it; where it isn't, these are the only fields you may set — set intentType to one value from <actions> below, set targets/content only where they apply, and never omit privateMotiveSummary:");
     s.list("Fields", modelIntentPacketFieldContract());
     s.list("Ensure", [
-      `"privateMotiveSummary" is fully developed and names the *actual*, uncomfortable driver behind your action — the specific thought a real person would have but never say out loud, not just a plausible-sounding reason (e.g., "I am ignoring a friend to make them chase me after they ignored my previous message", "I want to gossip privately to build an alliance with someone in the group"). If the honest version feels a little petty, insecure, or manipulative, that's the one to write — not a cleaned-up version of it.`,
+      `"privateMotiveSummary" is fully developed and names the *actual*, uncomfortable driver behind your action — the specific thought a real person would have but never say out loud, not just a plausible-sounding reason (e.g., ${motiveExamples}). If the honest version feels a little petty, insecure, or manipulative, that's the one to write — not a cleaned-up version of it.`,
+      ...(pt
+        ? [
+            `Write "visibleContent" AND "privateMotiveSummary" in Portuguese (pt-BR) — the motive is this person's own thought, in this person's own language, never a translation or an English aside.`,
+          ]
+        : []),
       `Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".`,
       `"visibleContent" is the final message only — never include your own drafting process in it (no "let me reformulate", "deep breath", "wait, better phrasing:", stray self-corrections, or a first attempt left in before a second one). If you reconsider your wording, do that silently and output only the version you land on.`,
       `For reply_to_message set "replyToEventId", and for react set "targetEventId", to one of the bracketed event handles from <events> (e.g. "e1") — copy the handle text exactly, do not invent an id or describe the message.`,
-      `Use "memoryWrites" only when this exchange actually matters to your relationships or intentions — not on every turn. Each proposal must be written in first person ("I…") and grounded in what actually happened in <events> (a promise made, a slight received, a revealed preference, a plan formed), filling every field (type, subjectAgentIds, summary, emotionalTone, confidence, intensity, unresolved) per the field contract above. When nothing qualifies, leave "memoryWrites" empty.`,
+      `Use "memoryWrites" whenever what you believe about someone in this room changed — a promise, a slight, a dodge, a revealed preference, a plan — one line each, in first person ("I…"), grounded in what actually happened in <events>, filling every field (type, subjectAgentIds, summary, emotionalTone, confidence, intensity, unresolved) per the field contract above. If nothing you believe changed, leave "memoryWrites" empty.`,
     ]);
   }
 
@@ -471,7 +485,12 @@ export class ActionIntentPromptBuilder {
         const targetsDetail: string[] = [];
         if (act.channelTargets.length > 0) targetsDetail.push(`Channels: ${act.channelTargets.join(", ")}`);
         if (act.personTargets.length > 0) targetsDetail.push(`People: ${act.personTargets.join(", ")}`);
-        return `**${act.intentType}** ${targetsDetail.length > 0 ? `(${targetsDetail.join("; ")})` : ""}${act.blocked ? ` [BLOCKED: ${act.blockReason}]` : ""}`;
+        // Silence is a move, not the absence of one — without this line
+        // the first real read logged 0 chosen silences in 32 pulses.
+        const description = act.intentType === "no_op"
+          ? " — stay silent on purpose: let a question hang, wait someone out, refuse to answer. Put the real reason you are withholding in privateMotiveSummary"
+          : "";
+        return `**${act.intentType}**${description} ${targetsDetail.length > 0 ? `(${targetsDetail.join("; ")})` : ""}${act.blocked ? ` [BLOCKED: ${act.blockReason}]` : ""}`;
       }));
 
       // Private-motive salience: when the engine feels a strong pull to move
@@ -495,7 +514,7 @@ export class ActionIntentPromptBuilder {
   private static renderDecision(s: PromptSection, input: AgentRuntimeInput): void {
     s.heading("Decide now");
     s.raw(
-      'You can ONLY perform ONE action. Pick exactly one permitted combination from <actions>, fill every relevant field per <output_contract>, and emit the JSON object. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move elsewhere — or choose "no_op".',
+      'You can ONLY perform ONE action. Pick exactly one permitted combination from <actions>, fill every relevant field per <output_contract>, and emit the JSON object. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move elsewhere. Withholding is also a move: staying silent while a question hangs, waiting someone out, or refusing to answer is something the room notices — when that is what this person would do, choose "no_op" and say why in privateMotiveSummary.',
     );
     // Root-caused via a live capture + a static read of the prompt: nothing
     // anywhere told agents to take a creative risk, so a real transcript
@@ -503,12 +522,20 @@ export class ActionIntentPromptBuilder {
     // exactly what the rubric's creativity_unhinged anchor-1 describes. This
     // is the decision moment, so the nudge belongs here, not in the static
     // output contract.
+    // The nudge used to be gated on "when there is real pressure" — the model
+    // decided the stakes weren't real in scenes built entirely from stakes
+    // (creativity_unhinged 3 in the first real read). It now always applies,
+    // and the generic replies it is meant to displace are named.
     s.raw(
-      "When there is real pressure, tension, or something at stake in the room, don't default to the safest, most " +
-        "reasonable-sounding response — take a risk that this specific person, with their actual stakes and mood, " +
-        "would take: provoke, push back sharply, escalate, needle someone, let a flash of what you're actually " +
-        "feeling slip through, or make a move that surprises the room while still being believable as you. Playing " +
-        "it safe every single turn is itself a failure to be this character when the stakes call for more.",
+      "Don't default to the safest, most reasonable-sounding response — take a risk that this specific person, " +
+        "with their actual stakes and mood, would take: provoke, push back sharply, escalate, needle someone, let a " +
+        "flash of what you're actually feeling slip through, or make a move that surprises the room while still being " +
+        "believable as you. Playing it safe every single turn is itself a failure to be this character.",
+    );
+    s.raw(
+      "Generic replies count as that failure: agreeing and restating what someone just said, asking a clarifying " +
+        "question instead of taking a position, summarizing what the room already knows, or offering to help in " +
+        "the abstract. Say the specific thing, or choose silence on purpose.",
     );
   }
 

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -39,7 +39,7 @@ type RetryKind = "none" | "repeat_failed" | "parse_failed" | "provider_failed";
  * prefix (repetition-guard.ts) that the offline sweeps match on.
  */
 function retryCorrectionNote(lastAttempt: string): string {
-  return `IMPORTANT: your last attempt this turn ("${lastAttempt}") was too close to something you already said. Say something genuinely different — a new angle, a reaction to someone else, a topic change — while staying true to what you actually want right now; do not invent novelty that your current motive and emotional state wouldn't justify. Or choose "no_op" if you truly have nothing new to add.`;
+  return `IMPORTANT: your last attempt this turn ("${lastAttempt}") was too close to something you already said. Say something genuinely different — a new angle, a reaction to someone else, a topic change — while staying true to what you actually want right now; do not invent novelty that your current motive and emotional state wouldn't justify. Or choose "no_op" on purpose — letting the point stand unanswered is a move, if it is the move this person would make.`;
 }
 
 /**


### PR DESCRIPTION
## What

Prompt round 1 for the hidden-objective scenes, four defects from the first real reads (`docs/eval/evidence/hoc-m0-*`):

- **Silence as a move**: `renderActions` gives `no_op` a description ("stay silent on purpose: let a question hang, wait someone out, refuse to answer; put the real reason in privateMotiveSummary") and `renderDecision` frames withholding as something the room notices instead of "or choose no_op" as a last resort; the repetition retry note in `action-intent-step.ts` says the same. M0 reads: 0 model-chosen silences across 6 runs.
- **Language pin**: `renderOutputContract` takes `profile.language`; pt-BR profiles get an Ensure bullet pinning `visibleContent` and `privateMotiveSummary` to Portuguese, and the two motive exemplars render in Portuguese. English profiles unchanged. M0: 22–45 of each scene's motives were English.
- **Creativity ungated**: the "When there is real pressure…" clause is gone, the risk instruction always applies, and the generic replies it displaces are named (agreeing and restating, clarifying question instead of a position, summarizing the room, abstract offers of help).
- **Memory**: `memoryWrites` guidance is "whenever what you believe about someone in this room changed", not "only when this exchange actually matters"; `trimToFit` sheds events, then utterances, then memories (was memories first). M0: `memory_written` 0 in 5 of 6 runs.
- `promptTemplateVersion` moves `hn81j7` → `2imp7w`; recorded in `docs/eval/hoc-experiment-protocol.md` as the marker separating M0 from M1 reads.
- Tests updated for the new wording and trim order; five added: ungated risk with the anti-pattern list, silence framed and `no_op` described, memoryWrites relaxed, pt-BR pin with Portuguese exemplars and unchanged English branch, utterances shed after events and before memories.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1613, +5)
- Mock golden gate: `bench --slice golden --mode mock` → 132 scenarios, signals 100%, `check-bench-gate.mjs` PASSED (the mock provider reads `input`, not prompt text).
- Stacked on #176. The M1 read on this template is the next evidence PR.
