### PR TITLE
feat(eval): keep the raw head of a no-JSON response on llm_failure and in evidence

### DIFF
--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -469,6 +469,7 @@ export async function runBench(opts: {
             fallbackCount: artifact.fallbackCount,
             fallbackNoOps: artifact.fallbackNoOps,
             recoveredFallbacks: artifact.recoveredFallbacks,
+            llmFailures: artifact.llmFailures ?? [],
           },
         });
       }

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -63,6 +63,8 @@ export type ScenarioRunArtifact = {
   fallbackNoOps?: number;
   /** Operator events by type for the run (mock gateway only). */
   operatorEventCounts?: Partial<Record<OperatorEvent["type"], number>>;
+  /** Every `llm_failure` / `llm_retry_recovered` with its detail and data (raw head, models) — the fallback forensics trail. */
+  llmFailures?: LlmFailureRecord[];
   /** `liveOnly` signals not evaluated because the run was in mock mode; never in `totalSignals`. */
   skippedSignals?: number;
   probeResults: ProbeResult[];
@@ -222,6 +224,7 @@ export class ScenarioRunner {
     const operatorEvents = gateway instanceof MockDeliveryGateway ? gateway.operatorEvents : [];
     const { fallbackCount, fallbackNoOps, operatorEventCounts } = countFallbacks(events, operatorEvents);
     const recoveredFallbacks = operatorEvents.filter(e => e.type === "llm_retry_recovered").length;
+    const llmFailures = collectLlmFailures(operatorEvents);
     const behavioral = eventsToBehavioral(events);
     const probeResults = runAllProbes({
       events: behavioral,
@@ -249,6 +252,7 @@ export class ScenarioRunner {
       fallbackCount,
       fallbackNoOps,
       operatorEventCounts,
+      llmFailures,
       operatorFailures: failures,
       recoveredFallbacks,
       probeResults,
@@ -263,6 +267,30 @@ export class ScenarioRunner {
       providerCalls: tracking?.providerCalls(),
     };
   }
+}
+
+export type LlmFailureRecord = {
+  type: "llm_failure" | "llm_retry_recovered";
+  agentId: string;
+  pulseIndex: number;
+  detail: string;
+  data?: Record<string, unknown>;
+};
+
+/** The forensics trail: what failed, for whom, at which pulse, and what the model returned. */
+export function collectLlmFailures(operatorEvents: readonly OperatorEvent[]): LlmFailureRecord[] {
+  const out: LlmFailureRecord[] = [];
+  for (const e of operatorEvents) {
+    if (e.type !== "llm_failure" && e.type !== "llm_retry_recovered") continue;
+    out.push({
+      type: e.type,
+      agentId: e.agentId ?? "",
+      pulseIndex: e.pulseIndex,
+      detail: e.detail,
+      ...(e.data ? { data: e.data as Record<string, unknown> } : {}),
+    });
+  }
+  return out;
 }
 
 /**

--- a/packages/eval/src/test/bench-hygiene.test.ts
+++ b/packages/eval/src/test/bench-hygiene.test.ts
@@ -41,6 +41,9 @@ function artifact(seed: unknown) {
     promptVersions: ["p1"],
     templateVersions: ["t1"],
     seedEcho: seed,
+    llmFailures: [
+      { type: "llm_failure", agentId: "a", pulseIndex: 3, detail: "LLM parsing failed for agent a: No JSON object found in response", data: { errorDetail: "No JSON object found in response", rawHead: "", rawLength: 0 } },
+    ],
   };
 }
 
@@ -132,6 +135,10 @@ describe("bench hygiene", () => {
     const dir = join(root, "hoc-test");
     expect(existsSync(join(dir, "bench-report.json"))).toBe(true);
     expect(existsSync(join(dir, "scenarios", "motive_gossip__v0__s7.json"))).toBe(true);
+    // The fallback forensics trail rides into the per-run record.
+    const record = JSON.parse(readFileSync(join(dir, "scenarios", "motive_gossip__v0__s7.json"), "utf8")) as { llmFailures?: Array<{ data?: { rawLength?: number } }> };
+    expect(record.llmFailures).toHaveLength(1);
+    expect(record.llmFailures?.[0]?.data?.rawLength).toBe(0);
     const meta = JSON.parse(readFileSync(join(dir, "run-meta.json"), "utf8")) as Record<string, unknown>;
     expect(meta["runId"]).toBe("hoc-test");
     expect(meta["seeds"]).toEqual([7]);

--- a/packages/eval/src/test/fallback-count.test.ts
+++ b/packages/eval/src/test/fallback-count.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { CommittedEvent, OperatorEvent } from "@perfectman/shared";
-import { countFallbacks } from "../run/scenario-runner.js";
+import { countFallbacks, collectLlmFailures } from "../run/scenario-runner.js";
 
 function committed(type: CommittedEvent["type"], motive?: string): CommittedEvent {
   return {
@@ -37,5 +37,20 @@ describe("countFallbacks", () => {
       fallbackNoOps: 2,
       operatorEventCounts: { llm_failure: 2, action_intent: 1 },
     });
+  });
+});
+
+describe("collectLlmFailures", () => {
+  it("keeps every llm_failure and llm_retry_recovered with its raw head, and nothing else", () => {
+    const events: OperatorEvent[] = [
+      { type: "llm_failure", simulationId: "s", agentId: "lia", pulseIndex: 8, detail: "LLM parsing failed: No JSON object found in response", createdAt: 0, data: { errorDetail: "No JSON object found in response", rawHead: "", rawLength: 0 } },
+      { type: "llm_retry_recovered", simulationId: "s", agentId: "nina", pulseIndex: 9, detail: "retry fixed a near-repeat", createdAt: 0 },
+      { type: "prompt_trimmed", simulationId: "s", agentId: "lia", pulseIndex: 8, detail: "trimmed", createdAt: 0 },
+    ];
+    const out = collectLlmFailures(events);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ type: "llm_failure", agentId: "lia", pulseIndex: 8, data: { rawHead: "", rawLength: 0 } });
+    expect(out[1]).toMatchObject({ type: "llm_retry_recovered", agentId: "nina", pulseIndex: 9 });
+    expect(out[1]?.data).toBeUndefined();
   });
 });

--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -424,3 +424,39 @@ Hope you like it!
     });
   });
 });
+
+describe("IntentParser fallback forensics", () => {
+  const actorId = "lia";
+  const availableActions: AvailableAction[] = [
+    { intentType: "send_message", channelTargets: ["ch_familia"], personTargets: [], blocked: false },
+    { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
+  ];
+
+  it("keeps the raw head and length of a response with no JSON object", () => {
+    const raw = "   Desculpa, preciso   pensar melhor antes de responder.\n\n" + "x".repeat(400);
+    const result = IntentParser.parse(raw, actorId, availableActions);
+    expect(result.fallbackApplied).toBe(true);
+    expect(result.errorDetail).toBe("No JSON object found in response");
+    expect(result.rawLength).toBe(raw.length);
+    expect(result.rawHead).toHaveLength(240);
+    expect(result.rawHead?.startsWith("Desculpa, preciso pensar melhor")).toBe(true);
+    expect(result.rawTail).toBe("x".repeat(240));
+  });
+
+  it("records an empty response as rawLength 0", () => {
+    const result = IntentParser.parse("", actorId, availableActions);
+    expect(result.fallbackApplied).toBe(true);
+    expect(result.rawHead).toBe("");
+    expect(result.rawLength).toBe(0);
+  });
+
+  it("carries nothing on a clean parse", () => {
+    const result = IntentParser.parse(
+      JSON.stringify({ intentType: "no_op", privateMotiveSummary: "espero", channelTargets: [], personTargets: [], memoryWrites: [] }),
+      actorId,
+      availableActions,
+    );
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.rawHead).toBeUndefined();
+  });
+});

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -19,6 +19,17 @@ export type IntentParserResult = {
   intent: ActionIntent;
   fallbackApplied: boolean;
   errorDetail?: string;
+  /**
+   * On a parse fallback: the first 240 characters of the raw model response
+   * (whitespace collapsed) and its full length. Two real reads failed the
+   * fallback-rate gate on "No JSON object found" with nothing recording what
+   * the model actually returned — empty content, prose, a reasoning leak
+   * and a truncation all look identical from the fallback alone.
+   */
+  rawHead?: string;
+  /** Last 240 characters — a truncated or runaway response shows its loop here. */
+  rawTail?: string;
+  rawLength?: number;
   // Set when the intent is a reply/react whose target handle could not be
   // resolved against `TargetResolutionContext.eventHandles`. The caller
   // re-prompts once with a targeted note, then applies `floorTargets`.
@@ -207,6 +218,9 @@ export class IntentParser {
         }),
         fallbackApplied: true,
         errorDetail: errorMsg,
+        rawHead: rawText.replace(/\s+/g, " ").trim().slice(0, 240),
+        rawTail: rawText.replace(/\s+/g, " ").trim().slice(-240),
+        rawLength: rawText.length,
       };
     }
   }

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -455,6 +455,11 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         createdAt: Date.now(),
         data: {
           errorDetail: parseResult.errorDetail ?? null,
+          // What the model actually returned, so a no-JSON fallback can be
+          // attributed (empty / prose / reasoning leak / truncation).
+          rawHead: parseResult.rawHead ?? null,
+          rawTail: parseResult.rawTail ?? null,
+          rawLength: parseResult.rawLength ?? null,
           requestedModel: providerResult.requestedModel || llmConfig.modelName,
           routedModel: providerResult.routedModel ?? null,
           fallbackAttempts: providerResult.fallbackAttempts ?? null,


### PR DESCRIPTION
## What

Makes a generator parse failure attributable instead of a bare count:

- `IntentParserResult` gains `rawHead` / `rawTail` (first and last 240 chars of the raw response, whitespace collapsed) and `rawLength` on every parse fallback; `ActionIntentStep` puts both on the `llm_failure` operator event's `data` next to `errorDetail` and the routed model.
- `ScenarioRunArtifact.llmFailures` (`collectLlmFailures`): every `llm_failure` / `llm_retry_recovered` with agent, pulse, detail and data; the bench writes it into each evidence record as `llmFailures`.
- Four tests: no-JSON response keeps a 240-char head, the tail and the full length; empty response records length 0; a clean parse carries nothing; `collectLlmFailures` keeps the two failure kinds with their data and drops the rest; the evidence record carries the trail.

## Why

M0 main Sítio and M1 Fatia/Banda failed the `fallback-rate` gate on "No JSON object found in response" 5, 4 and 6 times; DeepSeek's `max_tokens` is 8000 with thinking disabled, so the cause (empty content, prose, reasoning leak, truncation) is unknown and every read keeps failing on it.

## Validation

- First forensic read (Fatia, `hoc-f0-b3d4559-*`): the one no-JSON failure is a 25,149-character response that opens as valid JSON and never closes — the model ran to the 8000-token cap inside the intent. A runaway, not empty content; the tail capture is what names the loop on the next read.

- `pnpm lint` PASS - `pnpm test:all` PASS (1617, +4)
- Stacked on #178.
