### PR TITLE
fix(eval): cap deepseek-v4 intent output at 2500 tokens, frequency penalty floor 0.6

### DIFF
--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -518,8 +518,14 @@ export function localLLMConfig(
     // off the model name (an earlier version of this fix) starved every
     // other reasoning-capable cloud model instead. Every cloud endpoint
     // gets the large reasoning-headroom ceiling except Groq specifically.
+    // deepseek-v4 with thinking disabled (below) emits the intent JSON and
+    // nothing else, so the reasoning headroom is pure runaway room: every
+    // "No JSON object found" on the first forensic reads was a 25–27k-char
+    // response that opened as valid JSON and never closed — the model
+    // looped inside a string until the 8000-token cap. 2500 tokens is 3–5×
+    // a real intent and cuts the loop at a third of the cost.
     maxOutputTokens: isDeepseek
-      ? (isGroq ? 2000 : 8000)
+      ? (isGroq ? 2000 : isDeepseekV4 ? 2500 : 8000)
       : Math.max(600, sampling.maxTokens * 2),
     temperature: sampling.temperature,
     timeoutMs: isDeepseek ? 180000 : 120000,
@@ -531,7 +537,11 @@ export function localLLMConfig(
           top_p: sampling.topP,
           // DeepSeek has no repetition_penalty — map to frequency_penalty
           // (stronger for hot personas) plus presence_penalty to kill loops.
-          frequency_penalty: Math.min(2, (sampling.repetitionPenalty - 1) * 2.5),
+          // deepseek-v4 loops inside long string fields at the pack default
+          // (0.25); a floor of 0.6 is the second half of the runaway fix.
+          frequency_penalty: isDeepseekV4
+            ? Math.max(0.6, Math.min(2, (sampling.repetitionPenalty - 1) * 2.5))
+            : Math.min(2, (sampling.repetitionPenalty - 1) * 2.5),
           presence_penalty: 0.4,
           // deepseek-v4-* models reason by default at effort `high`, spending
           // the output-token budget on a thinking block before the intent

--- a/packages/eval/src/test/bench-seed.test.ts
+++ b/packages/eval/src/test/bench-seed.test.ts
@@ -52,6 +52,18 @@ describe("bench seed wiring (#45)", () => {
     expect(config.extraBody?.["thinking"]).toBeUndefined();
   });
 
+  it("caps deepseek-v4 output at 2500 tokens with a 0.6 frequency-penalty floor; other cloud models keep 8000", () => {
+    process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
+    process.env.PERFECTMAN_LLM_MODEL = "deepseek/deepseek-v4-flash";
+    const v4 = localLLMConfig(undefined);
+    expect(v4.maxOutputTokens).toBe(2500);
+    expect(v4.extraBody?.["frequency_penalty"]).toBe(0.6);
+    process.env.PERFECTMAN_LLM_MODEL = "z-ai/glm-5.3-flash";
+    const other = localLLMConfig(undefined);
+    expect(other.maxOutputTokens).toBe(8000);
+    expect(other.extraBody?.["frequency_penalty"]).toBeLessThan(0.6);
+  });
+
   it("disables `thinking` only for deepseek-v4-* models, not other openai-compatible endpoints", () => {
     process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
     process.env.PERFECTMAN_LLM_MODEL = "deepseek-v4-flash";
@@ -90,13 +102,21 @@ describe("bench seed wiring (#45)", () => {
   // tokens to complete — the openai-compatible path needs a ceiling an
   // order of magnitude above the local-model tuning, plus a timeout that
   // accommodates the extra generation time.
-  it("gives a deepseek-v4 model a much larger maxOutputTokens ceiling than the local-model tuning, to survive its hidden thinking tokens", () => {
+  // Since `thinking: {type: "disabled"}` (below) deepseek-v4 no longer spends
+  // the budget on a reasoning block, so its ceiling is sized for the intent
+  // JSON alone (2500); the reasoning headroom stays for cloud models that
+  // cannot switch reasoning off.
+  it("gives cloud models a much larger maxOutputTokens ceiling than the local-model tuning; deepseek-v4 (thinking off) sits in between", () => {
     const localConfig = localLLMConfig(undefined);
     process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
-    process.env.PERFECTMAN_LLM_MODEL = "deepseek-v4-flash";
+    process.env.PERFECTMAN_LLM_MODEL = "z-ai/glm-5.3-flash";
     const cloudConfig = localLLMConfig(undefined);
     expect(cloudConfig.maxOutputTokens).toBeGreaterThanOrEqual(6000);
     expect(cloudConfig.maxOutputTokens).toBeGreaterThan(localConfig.maxOutputTokens);
+    process.env.PERFECTMAN_LLM_MODEL = "deepseek-v4-flash";
+    const v4 = localLLMConfig(undefined);
+    expect(v4.maxOutputTokens).toBe(2500);
+    expect(v4.maxOutputTokens).toBeGreaterThan(localConfig.maxOutputTokens);
   });
 
   // Root-caused via a live capture against Groq specifically: its free


### PR DESCRIPTION
## What

Stops deepseek-v4 from running to the output cap inside an intent:

- `localLLMConfig`: `maxOutputTokens` 2500 for deepseek-v4 models (thinking disabled since #158), 8000 stays for cloud models that cannot switch reasoning off, 2000 for Groq.
- `frequency_penalty` floor 0.6 on deepseek-v4 (pack default mapped to 0.25); `presence_penalty` 0.4 unchanged.
- Tests: deepseek-v4 gets 2500 and 0.6, `z-ai/glm-5.3-flash` keeps 8000 and the pack-derived penalty; the older ceiling test now pins the cloud ceiling on a non-v4 model and the v4 value explicitly.

## Why

Forensic reads on #181 (`hoc-f0-*`, `hoc-f1-*`): every "No JSON object found" fallback was a 25,149–27,234-character response that opened as valid JSON (`{"intentType": "reply_to_message", "privateMotiveSummary": "…`) and never closed — the model looped in a string field until the 8000-token cap. Those fallbacks tripped the `fallback-rate` gate on three of the last six reads (0.07–0.08 against 0.05) and cost ~8000 tokens each.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1618, +1)
- Stacked on #181. Live check follows in the next evidence PR.
