### PR TITLE
fix(agent): rebuild the packet when the model's JSON never closes

### DIFF
--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { IntentParser } from "../intent-parser.js";
+import { IntentParser, repairTruncatedPacket } from "../intent-parser.js";
 import type { AvailableAction } from "@perfectman/shared";
 
 describe("IntentParser", () => {
@@ -458,5 +458,60 @@ describe("IntentParser fallback forensics", () => {
     );
     expect(result.fallbackApplied).toBe(false);
     expect(result.rawHead).toBeUndefined();
+  });
+});
+
+describe("IntentParser truncated-JSON repair", () => {
+  const actorId = "nina";
+  const availableActions: AvailableAction[] = [
+    { intentType: "send_message", channelTargets: ["ch_familia"], personTargets: [], blocked: false },
+    { intentType: "reply_to_message", channelTargets: ["ch_familia"], personTargets: [], blocked: false },
+    { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
+  ];
+  // The shape every forensic no-JSON capture had: valid opening, then a
+  // runaway inside visibleContent until the token cap, never a closing brace.
+  const runaway =
+    '{ "intentType": "send_message", "privateMotiveSummary": "quero que o Rafa responda sobre o cartório na frente da Lia", ' +
+    '"channelTarget": "ch_familia", "personTargets": ["rafa"], "visibleContent": "Rafa, o cartório abre às nove. Você vai comigo amanhã? A Lia quer ver os papéis. ' +
+    "(Parei.)\\n\\n(Ok, tchau.)\\n\\n(To indo.)\\n\\n(Fui.)".repeat(80);
+
+  it("rebuilds the packet from the closed fields and cuts the runaway string at a sentence end", () => {
+    const result = IntentParser.parse(runaway, actorId, availableActions);
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.truncationRepaired).toBe(true);
+    expect(result.rawLength).toBe(runaway.length);
+    expect(result.intent.intentType).toBe("send_message");
+    expect(result.intent.channelTarget).toBe("ch_familia");
+    expect(result.intent.personTargets).toEqual(["rafa"]);
+    expect(result.intent.privateMotiveSummary).toBe("quero que o Rafa responda sobre o cartório na frente da Lia");
+    expect(result.intent.visibleContent?.startsWith("Rafa, o cartório abre às nove.")).toBe(true);
+    expect((result.intent.visibleContent ?? "").length).toBeLessThanOrEqual(700);
+    expect(result.intent.visibleContent).not.toContain("(Fui.)".repeat(3));
+  });
+
+  it("repairs a runaway inside the motive when the content never started", () => {
+    const text = '{ "intentType": "no_op", "privateMotiveSummary": "deixo a pergunta no ar. ' + "kkkk ".repeat(300);
+    const result = IntentParser.parse(text, actorId, availableActions);
+    expect(result.truncationRepaired).toBe(true);
+    expect(result.intent.intentType).toBe("no_op");
+    expect(result.intent.privateMotiveSummary.startsWith("deixo a pergunta no ar.")).toBe(true);
+    expect(result.intent.privateMotiveSummary.length).toBeLessThanOrEqual(400);
+  });
+
+  it("still falls back, with forensics, when the opening has no intentType", () => {
+    const text = "{ " + "🔥".repeat(500);
+    const result = IntentParser.parse(text, actorId, availableActions);
+    expect(result.fallbackApplied).toBe(true);
+    expect(result.errorDetail).toBe("No JSON object found in response");
+    expect(result.rawLength).toBe(text.length);
+    expect(result.truncationRepaired).toBeUndefined();
+    expect(repairTruncatedPacket(text)).toBeNull();
+  });
+
+  it("leaves a well-formed response untouched", () => {
+    const text = JSON.stringify({ intentType: "no_op", privateMotiveSummary: "espero", personTargets: [], memoryWrites: [] });
+    const result = IntentParser.parse(text, actorId, availableActions);
+    expect(result.truncationRepaired).toBeUndefined();
+    expect(result.rawLength).toBeUndefined();
   });
 });

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -30,6 +30,8 @@ export type IntentParserResult = {
   /** Last 240 characters — a truncated or runaway response shows its loop here. */
   rawTail?: string;
   rawLength?: number;
+  /** The JSON never closed (the model ran away inside a string) and the packet was rebuilt from its closed fields. */
+  truncationRepaired?: boolean;
   // Set when the intent is a reply/react whose target handle could not be
   // resolved against `TargetResolutionContext.eventHandles`. The caller
   // re-prompts once with a targeted note, then applies `floorTargets`.
@@ -43,6 +45,68 @@ type TargetResolution =
   | { kind: "floored"; detail: string }
   | { kind: "downgraded"; detail: string }
   | { kind: "dropped"; detail: string };
+
+/** Longest `visibleContent` kept from a runaway response; cut at a sentence end before this. */
+export const TRUNCATION_SALVAGE_MAX_CONTENT = 700;
+const TRUNCATION_SALVAGE_MAX_MOTIVE = 400;
+
+function unescapeJsonString(s: string): string {
+  try {
+    return JSON.parse(`"${s}"`) as string;
+  } catch {
+    return s.replace(/\\n/g, "\n").replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+}
+
+/** Cut a runaway string at the last sentence end before `max`; null when nothing usable remains. */
+function cutAtSentence(text: string, max: number): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed.length >= 2 ? trimmed : null;
+  const head = trimmed.slice(0, max);
+  const lastEnd = Math.max(
+    head.lastIndexOf(". "),
+    head.lastIndexOf("! "),
+    head.lastIndexOf("? "),
+    head.lastIndexOf("\n"),
+    head.lastIndexOf("… "),
+  );
+  const cut = lastEnd >= 40 ? head.slice(0, lastEnd + 1) : head;
+  return cut.trim().length >= 2 ? cut.trim() : null;
+}
+
+/**
+ * Rebuild a packet from a response whose JSON never closed. Forensic reads
+ * (docs/eval/evidence/hoc-f*) showed every "No JSON object found" was a
+ * response that opened as valid JSON and then ran away inside a string —
+ * sign-offs in parentheses, emoji runs, numbered "edit" lines — until the
+ * token cap. The closed fields are real; the open string is cut at a
+ * sentence end. Returns null when even `intentType` is missing.
+ */
+export function repairTruncatedPacket(text: string): Record<string, unknown> | null {
+  const closed = (key: string): string | undefined => {
+    const m = new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(text);
+    return m ? unescapeJsonString(m[1]!) : undefined;
+  };
+  const open = (key: string, max: number): string | undefined => {
+    const m = new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)$`).exec(text);
+    if (!m) return undefined;
+    return cutAtSentence(unescapeJsonString(m[1]!), max) ?? undefined;
+  };
+  const intentType = closed("intentType");
+  if (!intentType) return null;
+  const motive = closed("privateMotiveSummary") ?? open("privateMotiveSummary", TRUNCATION_SALVAGE_MAX_MOTIVE);
+  if (!motive) return null;
+  const packet: Record<string, unknown> = { intentType, privateMotiveSummary: motive, personTargets: [], memoryWrites: [] };
+  const content = closed("visibleContent") ?? open("visibleContent", TRUNCATION_SALVAGE_MAX_CONTENT);
+  if (content !== undefined) packet.visibleContent = cutAtSentence(content, TRUNCATION_SALVAGE_MAX_CONTENT) ?? content;
+  for (const key of ["channelTarget", "replyToEventId", "targetEventId", "emoji", "channelName", "channelType"]) {
+    const v = closed(key);
+    if (v !== undefined) packet[key] = v;
+  }
+  const targets = /"personTargets"\s*:\s*\[([^\]]*)\]/.exec(text);
+  if (targets) packet.personTargets = [...targets[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+  return packet;
+}
 
 export class IntentParser {
   /**
@@ -62,20 +126,29 @@ export class IntentParser {
     targetContext?: TargetResolutionContext,
   ): IntentParserResult {
     let cleanedText = rawText;
+    let truncationRepaired = false;
 
     try {
       // 1. Narrow repair: strip markdown code fences, find the JSON object.
       cleanedText = cleanedText.replace(/```[a-zA-Z]*\s*/g, "").replace(/```\s*$/g, "");
       const firstBrace = cleanedText.indexOf("{");
       const lastBrace = cleanedText.lastIndexOf("}");
-      if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
-        throw new Error("No JSON object found in response");
+      let parsedObject: Record<string, unknown>;
+      if (firstBrace !== -1 && (lastBrace === -1 || lastBrace < firstBrace)) {
+        // The object opened and never closed: a runaway inside a string.
+        const repaired = repairTruncatedPacket(cleanedText.slice(firstBrace));
+        if (!repaired) throw new Error("No JSON object found in response");
+        parsedObject = repaired;
+        truncationRepaired = true;
+      } else {
+        if (firstBrace === -1 || lastBrace === -1) {
+          throw new Error("No JSON object found in response");
+        }
+        let jsonText = cleanedText.substring(firstBrace, lastBrace + 1);
+        // 2. Remove trailing commas (stray token emission).
+        jsonText = jsonText.replace(/,\s*([}\]])/g, "$1");
+        parsedObject = JSON.parse(jsonText) as Record<string, unknown>;
       }
-      let jsonText = cleanedText.substring(firstBrace, lastBrace + 1);
-      // 2. Remove trailing commas (stray token emission).
-      jsonText = jsonText.replace(/,\s*([}\]])/g, "$1");
-
-      const parsedObject = JSON.parse(jsonText) as Record<string, unknown>;
 
       // 3. Narrow structural repair on the packet fields. Engine fields
       // (id/actorId) no longer belong to the packet — extra keys are stripped
@@ -188,7 +261,7 @@ export class IntentParser {
         }
       }
 
-      return { intent, fallbackApplied: false };
+      return { intent, fallbackApplied: false, ...(truncationRepaired ? { truncationRepaired: true, rawLength: rawText.length } : {}) };
     } catch (error: any) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const fallbackReason = `Fallback applied: ${errorMsg}`;

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -411,6 +411,19 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
     if (trimEvent) operatorEvents.push(trimEvent);
     operatorEvents.push(...retryTrimEvents);
     operatorEvents.push(...retryRecoveryEvents);
+    if (parseResult.truncationRepaired && !fallbackApplied) {
+      // The response ran away inside a string and was cut back to a packet:
+      // a real intent, not a fallback, but recorded — the cap was hit.
+      operatorEvents.push({
+        type: "llm_retry_recovered",
+        simulationId,
+        agentId,
+        pulseIndex: ctx.pulseIndex,
+        detail: `Agent ${agentId}'s response never closed its JSON (${parseResult.rawLength ?? "?"} chars); packet rebuilt from the closed fields.`,
+        createdAt: Date.now(),
+        data: { violations: ["truncated_json"], retriesAttempted: 0 },
+      });
+    }
     operatorEvents.push({
       type: "pulse_metrics",
       simulationId,


### PR DESCRIPTION
## What

Turns a runaway response into the intent it started as instead of a fallback:

- `repairTruncatedPacket` in `intent-parser.ts`: when the object opens and never closes, `intentType`, `privateMotiveSummary`, `channelTarget`, `replyToEventId`, `targetEventId`, `emoji`, `channelName`, `channelType` and `personTargets` are read from their closed fields; the one open string (`visibleContent` or the motive) is cut at the last sentence end before `TRUNCATION_SALVAGE_MAX_CONTENT` (700) / 400 chars. The packet then goes through the normal validation, allow-list and target resolution. `IntentParserResult.truncationRepaired` + `rawLength` mark it.
- `ActionIntentStep` records a repaired turn as `llm_retry_recovered` (`violations: ["truncated_json"]`): a real intent, not a fallback, but not free — the cap was hit.
- Four tests: runaway inside `visibleContent` rebuilds the packet with targets and cuts the content at a sentence end under 700 chars; runaway inside the motive; an opening with no `intentType` still falls back with forensics; a well-formed response is untouched.

## Why

The forensic reads (`hoc-f0`, `hoc-f1`, `hoc-f2`, M2 Fatia) show the loop pattern — sign-offs in parentheses, emoji runs, numbered "edit" lines — appended after a complete message. With the 2500-token cap (#182) the responses still failed to parse 2–4 times per scene and kept tripping the `fallback-rate` gate (0.034–0.09 against 0.05), discarding a message the model had already finished writing.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1627, +4)
- Stacked on #183. The next three-scene read carries the recovery count.
