### PR TITLE
feat(agent): short memory proposals — summary and about, server fills the rest

### DIFF
--- a/docs/eval/hoc-experiment-protocol.md
+++ b/docs/eval/hoc-experiment-protocol.md
@@ -28,7 +28,7 @@ The three are what a single OrcaRouter key scoped to the free/flash tier can rea
 
 ## Prompt template versions
 
-`promptTemplateVersions` in `run-meta.json` identifies the agent prompt template. `hn81j7` is the template every M0 read used (baseline and main arms); `2imp7w` is prompt round 1 (silence as a move, Portuguese pin with Portuguese exemplars, ungated creativity with the generic-reply list, memory writes on belief change, memories trimmed last). Arms with different template versions are not a pair.
+`promptTemplateVersions` in `run-meta.json` identifies the agent prompt template. `hn81j7` is the template every M0 read used (baseline and main arms); `2imp7w` is prompt round 1 (silence as a move, Portuguese pin with Portuguese exemplars, ungated creativity with the generic-reply list, memory writes on belief change, memories trimmed last); `1bd8a0` is the short memory proposal (`{summary, about}`), the M4 marker. Arms with different template versions are not a pair.
 
 ## Command
 

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -470,6 +470,7 @@ export async function runBench(opts: {
             fallbackNoOps: artifact.fallbackNoOps,
             recoveredFallbacks: artifact.recoveredFallbacks,
             llmFailures: artifact.llmFailures ?? [],
+            memoryProposals: artifact.memoryProposals ?? { accepted: 0, dropped: 0 },
           },
         });
       }

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -65,6 +65,8 @@ export type ScenarioRunArtifact = {
   operatorEventCounts?: Partial<Record<OperatorEvent["type"], number>>;
   /** Every `llm_failure` / `llm_retry_recovered` with its detail and data (raw head, models) — the fallback forensics trail. */
   llmFailures?: LlmFailureRecord[];
+  /** Memory proposals: committed `memory_written` events vs proposals the parser dropped as malformed. */
+  memoryProposals?: { accepted: number; dropped: number };
   /** `liveOnly` signals not evaluated because the run was in mock mode; never in `totalSignals`. */
   skippedSignals?: number;
   probeResults: ProbeResult[];
@@ -225,6 +227,10 @@ export class ScenarioRunner {
     const { fallbackCount, fallbackNoOps, operatorEventCounts } = countFallbacks(events, operatorEvents);
     const recoveredFallbacks = operatorEvents.filter(e => e.type === "llm_retry_recovered").length;
     const llmFailures = collectLlmFailures(operatorEvents);
+    const memoryProposals = {
+      accepted: events.filter(e => e.type === "memory_written").length,
+      dropped: operatorEvents.reduce((n, e) => n + (e.type === "pulse_metrics" ? Number((e.data as { memoryWritesDropped?: unknown } | undefined)?.memoryWritesDropped ?? 0) : 0), 0),
+    };
     const behavioral = eventsToBehavioral(events);
     const probeResults = runAllProbes({
       events: behavioral,
@@ -253,6 +259,7 @@ export class ScenarioRunner {
       fallbackNoOps,
       operatorEventCounts,
       llmFailures,
+      memoryProposals,
       operatorFailures: failures,
       recoveredFallbacks,
       probeResults,

--- a/packages/eval/src/test/bench-hygiene.test.ts
+++ b/packages/eval/src/test/bench-hygiene.test.ts
@@ -44,6 +44,7 @@ function artifact(seed: unknown) {
     llmFailures: [
       { type: "llm_failure", agentId: "a", pulseIndex: 3, detail: "LLM parsing failed for agent a: No JSON object found in response", data: { errorDetail: "No JSON object found in response", rawHead: "", rawLength: 0 } },
     ],
+    memoryProposals: { accepted: 2, dropped: 1 },
   };
 }
 
@@ -139,6 +140,7 @@ describe("bench hygiene", () => {
     const record = JSON.parse(readFileSync(join(dir, "scenarios", "motive_gossip__v0__s7.json"), "utf8")) as { llmFailures?: Array<{ data?: { rawLength?: number } }> };
     expect(record.llmFailures).toHaveLength(1);
     expect(record.llmFailures?.[0]?.data?.rawLength).toBe(0);
+    expect((record as { memoryProposals?: unknown }).memoryProposals).toEqual({ accepted: 2, dropped: 1 });
     const meta = JSON.parse(readFileSync(join(dir, "run-meta.json"), "utf8")) as Record<string, unknown>;
     expect(meta["runId"]).toBe("hoc-test");
     expect(meta["seeds"]).toEqual([7]);

--- a/packages/server/src/agent/__tests__/intent-parser-memory-writes.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser-memory-writes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { IntentParser } from "../intent-parser.js";
+import { MEMORY_TONE_UNSPECIFIED, type AvailableAction } from "@perfectman/shared";
+
+// Twelve real DeepSeek runs answered the seven-field memoryWrites contract
+// with nothing at all. The model now sends `{summary, about?}`; the parser
+// fills structure, the resolver fills tone/intensity, and a malformed
+// proposal is dropped instead of sinking the whole intent into a fallback.
+describe("IntentParser memoryWrites — short form", () => {
+  const actorId = "nina";
+  const availableActions: AvailableAction[] = [
+    { intentType: "send_message", channelTargets: ["ch_familia"], personTargets: [], blocked: false },
+  ];
+  const packet = (memoryWrites: unknown) =>
+    JSON.stringify({
+      intentType: "send_message",
+      channelTarget: "ch_familia",
+      visibleContent: "Rafa, o cartório abre às nove.",
+      privateMotiveSummary: "quero ver ele desviar de novo",
+      memoryWrites,
+    });
+
+  it("normalizes a short proposal about someone into a relationship memory with the placeholder tone", () => {
+    const result = IntentParser.parse(packet([{ summary: "o Rafa desviou do cartório de novo", about: ["Rafa"] }]), actorId, availableActions);
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.droppedMemoryWrites).toBeUndefined();
+    expect(result.intent.memoryWrites).toEqual([
+      {
+        type: "relationship",
+        subjectAgentIds: ["Rafa"],
+        summary: "o Rafa desviou do cartório de novo",
+        emotionalTone: MEMORY_TONE_UNSPECIFIED,
+        confidence: 0.7,
+        intensity: 0.5,
+        unresolved: true,
+      },
+    ]);
+  });
+
+  it("a short proposal about no one becomes a self memory", () => {
+    const result = IntentParser.parse(packet([{ summary: "não tenho pra onde ir se venderem" }]), actorId, availableActions);
+    expect(result.intent.memoryWrites[0]?.type).toBe("self");
+    expect(result.intent.memoryWrites[0]?.subjectAgentIds).toEqual([]);
+  });
+
+  it("keeps the seven-field form exactly as sent", () => {
+    const full = { type: "emotional_residue", subjectAgentIds: ["lia"], summary: "aquilo doeu", emotionalTone: "hurt", confidence: 0.8, intensity: 0.9, unresolved: true };
+    const result = IntentParser.parse(packet([full]), actorId, availableActions);
+    expect(result.intent.memoryWrites).toEqual([full]);
+  });
+
+  it("drops a malformed proposal, keeps the good one and the intent, and counts the drop", () => {
+    const result = IntentParser.parse(
+      packet([{ type: "episodic", subjectAgentIds: [], summary: "x", emotionalTone: "neutral", confidence: 0.5, intensity: 1.5, unresolved: false }, { summary: "a Lia já falou com o comprador", about: ["lia"] }, 42]),
+      actorId,
+      availableActions,
+    );
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.intentType).toBe("send_message");
+    expect(result.intent.memoryWrites).toHaveLength(1);
+    expect(result.intent.memoryWrites[0]?.summary).toBe("a Lia já falou com o comprador");
+    expect(result.droppedMemoryWrites).toBe(2);
+  });
+
+  it("an empty or missing memoryWrites stays empty", () => {
+    expect(IntentParser.parse(packet([]), actorId, availableActions).intent.memoryWrites).toEqual([]);
+    expect(IntentParser.parse(packet(null), actorId, availableActions).intent.memoryWrites).toEqual([]);
+  });
+});

--- a/packages/server/src/agent/__tests__/intent-parser.test.ts
+++ b/packages/server/src/agent/__tests__/intent-parser.test.ts
@@ -81,7 +81,7 @@ describe("IntentParser", () => {
     expect(result.intent.memoryWrites[0]?.intensity).toBe(0.9);
   });
 
-  it("applies safe fallback when a memory-write proposal's intensity is out of range", () => {
+  it("drops a memory-write proposal with out-of-range intensity and keeps the intent", () => {
     const rawText = JSON.stringify({
       intentType: "send_message",
       channelTarget: "general-id",
@@ -105,7 +105,11 @@ describe("IntentParser", () => {
 
     const result = IntentParser.parse(rawText, actorId, availableActions);
 
-    expect(result.fallbackApplied).toBe(true);
+    // One bad proposal used to fail the whole packet into a no_op fallback.
+    expect(result.fallbackApplied).toBe(false);
+    expect(result.intent.intentType).toBe("send_message");
+    expect(result.intent.memoryWrites).toEqual([]);
+    expect(result.droppedMemoryWrites).toBe(1);
   });
 
   it("should successfully parse fenced markdown codeblock JSON", () => {

--- a/packages/server/src/agent/__tests__/prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/prompt-builder.test.ts
@@ -286,6 +286,7 @@ describe("PromptBuilder", () => {
       ["event grounding in <events>", "grounded in what actually happened in <events>"],
       ["whenever a belief about someone changed", "whenever what you believe about someone in this room changed"],
       ["empty when nothing changed", 'leave "memoryWrites" empty'],
+      ["the short shape the model is asked for", '"memoryWrites": [{"summary":'],
     ])("output contract instructs memoryWrites emission: %s", (_label, marker) => {
       const prompt = PromptBuilder.build(input, EXAMPLE_PROMPT_PROFILE, "action_intent");
       expect(prompt.system).toContain(marker);

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -389,7 +389,7 @@ export class ActionIntentPromptBuilder {
       `Never leak numeric values or technical code metrics in "visibleContent" or "privateMotiveSummary".`,
       `"visibleContent" is the final message only — never include your own drafting process in it (no "let me reformulate", "deep breath", "wait, better phrasing:", stray self-corrections, or a first attempt left in before a second one). If you reconsider your wording, do that silently and output only the version you land on.`,
       `For reply_to_message set "replyToEventId", and for react set "targetEventId", to one of the bracketed event handles from <events> (e.g. "e1") — copy the handle text exactly, do not invent an id or describe the message.`,
-      `Use "memoryWrites" whenever what you believe about someone in this room changed — a promise, a slight, a dodge, a revealed preference, a plan — one line each, in first person ("I…"), grounded in what actually happened in <events>, filling every field (type, subjectAgentIds, summary, emotionalTone, confidence, intensity, unresolved) per the field contract above. If nothing you believe changed, leave "memoryWrites" empty.`,
+      `Use "memoryWrites" whenever what you believe about someone in this room changed — a promise, a slight, a dodge, a revealed preference, a plan — one line each, in first person ("I…"), grounded in what actually happened in <events>. Shape: "memoryWrites": [{"summary": ${pt ? '"o Rafa desviou de novo quando falei em cartório"' : '"Rafa dodged again when I brought up the notary"'}, "about": ["rafa"]}] — "about" lists who it is about, as their ids or names appear in <events>; the system fills the rest. If nothing you believe changed, leave "memoryWrites" empty.`,
     ]);
   }
 

--- a/packages/server/src/agent/intent-parser.ts
+++ b/packages/server/src/agent/intent-parser.ts
@@ -1,4 +1,4 @@
-import { ModelIntentPacketSchema, composeIntentPacket } from "@perfectman/shared";
+import { ModelIntentPacketSchema, composeIntentPacket, MemoryWriteProposalSchema, MemoryWriteShortSchema, normalizeMemoryWriteProposal } from "@perfectman/shared";
 import type { ActionIntent, AvailableAction, CommittedEvent, IntentType } from "@perfectman/shared";
 
 type TargetField = "replyToEventId" | "targetEventId";
@@ -32,6 +32,8 @@ export type IntentParserResult = {
   rawLength?: number;
   /** The JSON never closed (the model ran away inside a string) and the packet was rebuilt from its closed fields. */
   truncationRepaired?: boolean;
+  /** Memory proposals that matched neither the short nor the full shape and were dropped (the intent survives). */
+  droppedMemoryWrites?: number;
   // Set when the intent is a reply/react whose target handle could not be
   // resolved against `TargetResolutionContext.eventHandles`. The caller
   // re-prompts once with a targeted note, then applies `floorTargets`.
@@ -127,6 +129,7 @@ export class IntentParser {
   ): IntentParserResult {
     let cleanedText = rawText;
     let truncationRepaired = false;
+    let droppedMemoryWrites = 0;
 
     try {
       // 1. Narrow repair: strip markdown code fences, find the JSON object.
@@ -159,6 +162,20 @@ export class IntentParser {
       if (!Array.isArray(parsedObject.emotionDrivers)) parsedObject.emotionDrivers = [];
       if (!Array.isArray(parsedObject.motivationDrivers)) parsedObject.motivationDrivers = [];
       if (!Array.isArray(parsedObject.memoryWrites)) parsedObject.memoryWrites = [];
+      // Memory proposals are normalized per element: the full form passes
+      // through, the short form `{summary, about?}` becomes a full proposal
+      // with structural defaults (tone/intensity are filled by the resolver
+      // from the agent's action emotions), anything else is dropped. One bad
+      // proposal used to fail the whole packet into a no_op fallback.
+      const normalizedWrites: unknown[] = [];
+      for (const element of parsedObject.memoryWrites as unknown[]) {
+        const full = MemoryWriteProposalSchema.safeParse(element);
+        if (full.success) { normalizedWrites.push(full.data); continue; }
+        const short = MemoryWriteShortSchema.safeParse(element);
+        if (short.success) { normalizedWrites.push(normalizeMemoryWriteProposal(short.data)); continue; }
+        droppedMemoryWrites++;
+      }
+      parsedObject.memoryWrites = normalizedWrites;
       for (const optional of [
         "channelTarget", "visibleContent", "replyToEventId", "emoji", "targetEventId",
         "channelName", "channelType", "invitedAgentIds", "spectatorSummary",
@@ -261,7 +278,12 @@ export class IntentParser {
         }
       }
 
-      return { intent, fallbackApplied: false, ...(truncationRepaired ? { truncationRepaired: true, rawLength: rawText.length } : {}) };
+      return {
+        intent,
+        fallbackApplied: false,
+        ...(truncationRepaired ? { truncationRepaired: true, rawLength: rawText.length } : {}),
+        ...(droppedMemoryWrites > 0 ? { droppedMemoryWrites } : {}),
+      };
     } catch (error: any) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const fallbackReason = `Fallback applied: ${errorMsg}`;

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -439,6 +439,8 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         latencyMs: totalLatencyMs,
         inputTokens: totalInputTokens,
         outputTokens: totalOutputTokens,
+        // Memory proposals that matched neither shape; the intent survived.
+        memoryWritesDropped: parseResult.droppedMemoryWrites ?? 0,
       },
     });
 

--- a/packages/server/src/simulation/__tests__/intent-resolver.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver.test.ts
@@ -10,7 +10,7 @@ import type {
   ActionEmotions,
   AvailableAction,
 } from "@perfectman/shared";
-import { createId } from "@perfectman/shared";
+import { MEMORY_TONE_UNSPECIFIED, createId } from "@perfectman/shared";
 import { REPETITION_GUARD_MARKER } from "../../agent/repetition-guard.js";
 
 const SIM_ID = "sim_test";
@@ -197,6 +197,55 @@ describe("IntentResolver", () => {
     expect(memoryEvent).toBeDefined();
     expect(memoryEvent!.payload["intensity"]).toBe(0.9);
     expect(memoryEvent!.payload["proposalIndex"]).toBe(0);
+  });
+
+  // Short proposals (ADR-0014's memory path, refined): the parser leaves the
+  // tone placeholder and whatever the model wrote in `about`; the resolver
+  // resolves names to ids and takes tone/intensity from the action emotions.
+  it("resolves a short proposal's `about` names to agent ids and fills tone and intensity from the dominant action emotion", async () => {
+    const intent = makeIntent({
+      intentType: "send_message",
+      channelTarget: CHANNEL_ID,
+      memoryWrites: [{
+        type: "relationship",
+        subjectAgentIds: ["Íris", "agent_2", "ninguém"],
+        summary: "a Íris já falou com o comprador",
+        emotionalTone: MEMORY_TONE_UNSPECIFIED,
+        confidence: 0.7,
+        intensity: 0.5,
+        unresolved: true,
+      }],
+    });
+    const result = await resolver.resolve(intent, { ...ctx(), agentNames: { agent_2: "Bruno", agent_3: "Íris" } });
+    const memoryEvent = result.committedEvents.find((e) => e.type === "memory_written");
+    expect(memoryEvent?.payload["subjectAgentIds"]).toEqual(["agent_3", "agent_2"]);
+    // ACTION_EMOTIONS: warmth 0.3 and curiousApproach 0.3 tie; the first wins.
+    expect(memoryEvent?.payload["emotionalTone"]).toBe("warmth");
+    expect(memoryEvent?.payload["intensity"]).toBe(0.3);
+    expect(memoryEvent?.payload["memoryType"]).toBe("relationship");
+  });
+
+  it("a short proposal whose subjects all resolve to nobody becomes a self memory with a neutral tone when nothing is felt", async () => {
+    const intent = makeIntent({
+      intentType: "send_message",
+      channelTarget: CHANNEL_ID,
+      memoryWrites: [{
+        type: "relationship",
+        subjectAgentIds: ["alguém"],
+        summary: "x",
+        emotionalTone: MEMORY_TONE_UNSPECIFIED,
+        confidence: 0.7,
+        intensity: 0.5,
+        unresolved: true,
+      }],
+    });
+    const flat = { ...ACTION_EMOTIONS, warmth: 0.1, curiousApproach: 0.1 };
+    const result = await resolver.resolve(intent, { ...ctx(), actionEmotions: flat, agentNames: { agent_2: "Bruno" } });
+    const memoryEvent = result.committedEvents.find((e) => e.type === "memory_written");
+    expect(memoryEvent?.payload["subjectAgentIds"]).toEqual([]);
+    expect(memoryEvent?.payload["memoryType"]).toBe("self");
+    expect(memoryEvent?.payload["emotionalTone"]).toBe("neutral");
+    expect(memoryEvent?.payload["intensity"]).toBe(0.2);
   });
 
   it("blocks intent with missing motive summary", async () => {

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -12,10 +12,11 @@ import type {
   ResolvedIntentOutcome,
   EmotionalSalience,
   ActionEmotions,
+  MemoryWriteProposal,
   IntentViolation,
   PrivateMotiveSummaryPayload,
 } from "@perfectman/shared";
-import { createId } from "@perfectman/shared";
+import { createId, MEMORY_TONE_UNSPECIFIED } from "@perfectman/shared";
 import { validateIntentPure } from "@perfectman/engine";
 import { memoryWrittenPayload } from "./memory-written-payload.js";
 import { REPETITION_GUARD_MARKER } from "../agent/repetition-guard.js";
@@ -97,7 +98,6 @@ function parseMentionedAgentIds(
 ): string[] {
   if (!visibleContent || !agentNames) return [];
   // Diacritic-insensitive on both sides: "@iris" must find "Íris".
-  const fold = (text: string): string => text.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase();
   const nameCounts = new Map<string, number>();
   for (const displayName of Object.values(agentNames)) {
     const key = fold(displayName.trim());
@@ -117,6 +117,39 @@ function parseMentionedAgentIds(
     if (pattern.test(foldedContent)) mentioned.push(agentId);
   }
   return mentioned;
+}
+
+/** Diacritic- and case-insensitive key for name matching ("@iris" finds "Íris"). */
+function fold(text: string): string {
+  return text.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase();
+}
+
+/**
+ * Resolve a short proposal's `about` entries (ids or display names as the
+ * model saw them) to agent ids; unknown names are dropped rather than
+ * stored as a subject nobody has.
+ */
+function resolveSubjectAgentIds(subjects: readonly string[], agentNames: Record<string, string> | undefined): string[] {
+  if (!agentNames) return [...subjects];
+  const byName = new Map<string, string>();
+  for (const [agentId, displayName] of Object.entries(agentNames)) byName.set(fold(displayName.trim()), agentId);
+  const out: string[] = [];
+  for (const raw of subjects) {
+    const key = raw.trim().replace(/^@/, "");
+    const id = agentNames[key] !== undefined ? key : byName.get(fold(key));
+    if (id && !out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
+/** The action emotion the agent feels most, with its magnitude — a short proposal's tone. */
+function dominantActionEmotion(actionEmotions: ActionEmotions): { tone: string; magnitude: number } {
+  let tone = "neutral";
+  let magnitude = 0;
+  for (const [key, value] of Object.entries(actionEmotions)) {
+    if (typeof value === "number" && value > magnitude) { tone = key; magnitude = value; }
+  }
+  return magnitude >= 0.2 ? { tone, magnitude } : { tone: "neutral", magnitude };
 }
 
 /** Stamps the participant identifiers relational accretion reads off payloads. */
@@ -685,7 +718,24 @@ export class IntentResolver {
   }
 
   private memoryProposalEvents(intent: ActionIntent, ctx: ResolveContext): SimulationEvent[] {
-    return (intent.memoryWrites ?? []).map((proposal, i) => ({
+    return (intent.memoryWrites ?? []).map((raw, i) => {
+      // A short proposal arrives with structural defaults from the parser:
+      // subjects are whatever the model wrote (ids or names), tone is the
+      // placeholder. Resolve subjects to ids and take tone/intensity from
+      // what the agent is feeling as it acts.
+      // Only a short proposal is refined; a full one is the model's (or the
+      // mock's) own and passes through untouched.
+      const isShort = raw.emotionalTone === MEMORY_TONE_UNSPECIFIED;
+      const subjectAgentIds = isShort ? resolveSubjectAgentIds(raw.subjectAgentIds, ctx.agentNames) : raw.subjectAgentIds;
+      const dominant = isShort ? dominantActionEmotion(ctx.actionEmotions) : undefined;
+      const proposal: MemoryWriteProposal = {
+        ...raw,
+        subjectAgentIds,
+        type: isShort && subjectAgentIds.length === 0 && raw.type === "relationship" ? "self" : raw.type,
+        emotionalTone: dominant ? dominant.tone : raw.emotionalTone,
+        intensity: dominant ? Math.max(0.2, Math.min(1, Math.round(dominant.magnitude * 100) / 100)) : raw.intensity,
+      };
+      return {
       simulationId: ctx.simulationId,
       channelId: ctx.channelId,
       actorId: intent.actorId,
@@ -701,7 +751,8 @@ export class IntentResolver {
         visibleToOperators: true,
         visibilityReason: "operator_only",
       },
-    }));
+      };
+    });
   }
 
   private intentToEvents(intent: ActionIntent, ctx: ResolveContext): SimulationEvent[] {

--- a/packages/shared/src/__tests__/intent-packet-schema.test.ts
+++ b/packages/shared/src/__tests__/intent-packet-schema.test.ts
@@ -6,7 +6,7 @@ import {
   composeIntentPacket,
   memoryWriteProposalFieldContract,
 } from "../intent/intent-packet.schema.js";
-import { MemoryWriteProposalSchema, IntentTypeSchema } from "../intent/intent.schema.js";
+import { MemoryWriteProposalSchema, IntentTypeSchema, MEMORY_TONE_UNSPECIFIED } from "../intent/intent.schema.js";
 
 describe("ModelIntentPacket", () => {
   it("excludes engine-stamped structural fields (id, actorId, preferredDelay, fallbackIfBlocked)", () => {
@@ -45,6 +45,24 @@ describe("ModelIntentPacket", () => {
     expect(intent.visibleContent).toBe("oi");
     expect(intent.preferredDelay).toBe(0);
     expect(intent.fallbackIfBlocked).toBe("no_op");
+  });
+
+  it("schema mode requires only `summary` of a memory proposal; the full form is the second branch", () => {
+    const items = (ModelIntentPacketJsonSchema.properties as Record<string, { items?: { anyOf?: Array<{ required?: string[] }> } }>)["memoryWrites"]?.items;
+    expect(items?.anyOf).toHaveLength(2);
+    expect(items?.anyOf?.[0]?.required).toEqual(["summary"]);
+    expect(items?.anyOf?.[1]?.required).toContain("emotionalTone");
+  });
+
+  it("composeIntentPacket turns a short memory proposal into a full one with the placeholder tone", () => {
+    const packet = ModelIntentPacketSchema.parse({
+      intentType: "send_message",
+      privateMotiveSummary: "m",
+      memoryWrites: [{ summary: "o Rafa desviou", about: ["rafa"] }, { summary: "não tenho pra onde ir" }],
+    });
+    const intent = composeIntentPacket({ kind: "model", packet, agentId: "nina" });
+    expect(intent.memoryWrites[0]).toMatchObject({ type: "relationship", subjectAgentIds: ["rafa"], emotionalTone: MEMORY_TONE_UNSPECIFIED, unresolved: true });
+    expect(intent.memoryWrites[1]).toMatchObject({ type: "self", subjectAgentIds: [] });
   });
 
   it("composeIntentPacket assigns no fallback for types the engine can't usefully soften", () => {

--- a/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
+++ b/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
@@ -1,24 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { modelIntentPacketFieldContract } from "../intent-packet.schema.js";
+import { modelIntentPacketFieldContract, memoryWriteProposalFieldContract } from "../intent-packet.schema.js";
 
-describe("modelIntentPacketFieldContract — memoryWrites nested field types", () => {
-  it("tells the model which memory `type` enum values are valid, not just the field name", () => {
+describe("modelIntentPacketFieldContract — memoryWrites", () => {
+  // The packet asks the model for the short proposal only: twelve real
+  // DeepSeek runs answered the seven-field list with nothing. The full form
+  // stays accepted and is still described where a surface emits it directly.
+  it("describes the short memory proposal (summary, about) and nothing the model no longer has to fill", () => {
     const contract = modelIntentPacketFieldContract();
     const memoryLine = contract.find((line) => line.startsWith('"memoryWrites"'));
-    expect(memoryLine).toBeDefined();
-
-    // The real bug this guards: without this, the model has no way to know
-    // "type" must be one of these six values, and invents its own
-    // ("observation", "reflection", "interaction", ...) — every one of
-    // which fails MemoryWriteProposalSchema validation and silently
-    // degrades a real turn into a no_op (see the memoryWrites fallback
-    // path in composeIntentPacket / IntentParser).
+    expect(memoryLine).toBe('"memoryWrites" (optional): array of objects (summary: string; about: array of strings)');
+    expect(memoryLine).not.toContain("emotionalTone");
+    expect(memoryLine).not.toContain("confidence");
+    const full = memoryWriteProposalFieldContract().join("\n");
     for (const validType of ["episodic", "relationship", "self", "social_theory", "pending_intention", "emotional_residue"]) {
-      expect(memoryLine).toContain(validType);
+      expect(full).toContain(validType);
     }
-    // confidence/intensity must be typed as numbers, not left unspecified —
-    // the same live run also saw them sent as strings.
-    expect(memoryLine).toMatch(/confidence.*number/);
-    expect(memoryLine).toMatch(/intensity.*number/);
+    expect(full).toMatch(/confidence.*number/);
   });
 });

--- a/packages/shared/src/intent/intent-packet.schema.ts
+++ b/packages/shared/src/intent/intent-packet.schema.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { createId } from "../utils/id.js";
 import type { ActionIntent, IntentType } from "./intent.types.js";
-import { IntentTypeSchema, IntentChannelTypeSchema, MemoryWriteProposalSchema } from "./intent.schema.js";
+import { IntentTypeSchema, IntentChannelTypeSchema, MemoryWriteProposalSchema, MemoryWriteShortSchema, MEMORY_TONE_UNSPECIFIED } from "./intent.schema.js";
+import type { MemoryWriteProposal } from "../memory/memory.types.js";
 
 /**
  * The model-decision packet: only the fields the model legitimately decides.
@@ -20,7 +21,9 @@ export const ModelIntentPacketSchema = z.object({
   privateMotiveSummary: z.string().min(1),
   emotionDrivers: z.array(z.string()).default([]),
   motivationDrivers: z.array(z.string()).default([]),
-  memoryWrites: z.array(MemoryWriteProposalSchema).default([]),
+  // Short form first: it is what the prompt asks for and what schema mode
+  // requires; the seven-field form stays accepted (mock provider, fixtures).
+  memoryWrites: z.array(z.union([MemoryWriteShortSchema, MemoryWriteProposalSchema])).default([]),
   replyToEventId: z.string().optional(),
   emoji: z.string().optional(),
   targetEventId: z.string().optional(),
@@ -32,10 +35,32 @@ export const ModelIntentPacketSchema = z.object({
 
 export type ModelIntentPacket = z.infer<typeof ModelIntentPacketSchema>;
 
+/**
+ * A packet's memory proposal as the full `MemoryWriteProposal`: the seven-
+ * field form passes through; the short form gets structural defaults —
+ * `relationship` when it is about someone, `self` otherwise, the tone
+ * placeholder the resolver replaces from the agent's action emotions.
+ */
+export function normalizeMemoryWriteProposal(element: ModelIntentPacket["memoryWrites"][number]): MemoryWriteProposal {
+  if ("type" in element) return element;
+  const about = (element.about ?? []).map((s) => s.trim()).filter((s) => s.length > 0);
+  return {
+    type: about.length > 0 ? "relationship" : "self",
+    subjectAgentIds: about,
+    summary: element.summary,
+    emotionalTone: MEMORY_TONE_UNSPECIFIED,
+    confidence: 0.7,
+    intensity: 0.5,
+    unresolved: true,
+  };
+}
+
 type JsonSchemaProp = {
   type?: string;
   enum?: readonly string[];
-  items?: { type?: string; properties?: Record<string, JsonSchemaProp> };
+  items?: { type?: string; properties?: Record<string, JsonSchemaProp>; anyOf?: JsonSchemaProp[] };
+  properties?: Record<string, JsonSchemaProp>;
+  anyOf?: JsonSchemaProp[];
   minimum?: number;
   maximum?: number;
 };
@@ -73,7 +98,9 @@ export const ModelIntentPacketJsonSchema = zodToJsonSchema(ModelIntentPacketSche
 function describePacketFieldType(def: JsonSchemaProp): string {
   if (def.enum) return `one of: ${def.enum.join(", ")}`;
   if (def.type === "array") {
-    const items = def.items;
+    // A union of element shapes renders as its first branch: the short form
+    // is the one the model is asked for; the full form is accepted quietly.
+    const items = def.items?.anyOf?.[0] ?? def.items;
     if (items?.type === "object" && items.properties) {
       // Recurse one level: a bare key list (e.g. "memoryWrites: array of
       // objects (type, confidence, ...)") never told the model that "type"
@@ -189,7 +216,7 @@ export function composeIntentPacket(spec: IntentComposeInput): ActionIntent {
     privateMotiveSummary: packet.privateMotiveSummary,
     emotionDrivers: packet.emotionDrivers,
     motivationDrivers: packet.motivationDrivers,
-    memoryWrites: packet.memoryWrites,
+    memoryWrites: packet.memoryWrites.map(normalizeMemoryWriteProposal),
     replyToEventId: packet.replyToEventId,
     emoji: packet.emoji,
     targetEventId: packet.targetEventId,

--- a/packages/shared/src/intent/intent.schema.ts
+++ b/packages/shared/src/intent/intent.schema.ts
@@ -38,6 +38,23 @@ export const MemoryWriteProposalSchema = z.object({
   unresolved: z.boolean(),
 });
 
+/**
+ * The short memory proposal the model is asked for: what changed, about
+ * whom. Twelve real DeepSeek runs answered the seven-field contract with
+ * nothing at all; the parser fills structure from this shape and the
+ * resolver fills tone and intensity from the agent's action emotions.
+ */
+// `.strict()`: a seven-field proposal must not match the short branch by
+// having its extra keys stripped — the union tries this branch first.
+export const MemoryWriteShortSchema = z.object({
+  summary: z.string().min(1),
+  about: z.array(z.string()).optional(),
+}).strict();
+export type MemoryWriteShort = z.infer<typeof MemoryWriteShortSchema>;
+
+/** Tone placeholder on a short proposal until the resolver derives it. */
+export const MEMORY_TONE_UNSPECIFIED = "unspecified";
+
 export const ActionIntentSchema = z.object({
   id: z.string().min(1),
   actorId: z.string().min(1),


### PR DESCRIPTION
## What

Replaces the seven-field memory proposal the model never filled with a two-field one:

- `MemoryWriteShortSchema` `{ summary, about? }` (strict) in `intent.schema.ts`; `ModelIntentPacketSchema.memoryWrites` is `z.array(z.union([Short, Full])).default([])`, short branch first. The derived JSON schema renders `items.anyOf`, so schema mode requires only `summary`; `describePacketFieldType` renders the first branch — the contract line is now `"memoryWrites" (optional): array of objects (summary: string; about: array of strings)`. The full form stays accepted (mock provider, engine `write_memory`, fixtures).
- `normalizeMemoryWriteProposal` (shared): short → full with `relationship`/`self` from `about`, the `MEMORY_TONE_UNSPECIFIED` placeholder, confidence 0.7, intensity 0.5, unresolved; used by `composeIntentPacket` and the parser.
- `IntentParser`: per-element `safeParse` (full, then short); anything else is dropped and counted in `IntentParserResult.droppedMemoryWrites` — one bad proposal no longer sinks the intent into a `no_op` fallback. `ActionIntentStep` puts `memoryWritesDropped` on `pulse_metrics`.
- `IntentResolver.memoryProposalEvents`: for a short proposal, `about` names or ids resolve to agent ids (diacritic-insensitive, unknowns dropped), `emotionalTone`/`intensity` come from the dominant action emotion (`neutral`/0.2 floor when nothing is felt), and a subjectless `relationship` becomes `self`. Full proposals pass through untouched.
- Prompt Ensure bullet shows the shape in the profile language: `"memoryWrites": [{"summary": "o Rafa desviou de novo quando falei em cartório", "about": ["rafa"]}]`. Template `2imp7w` → `1bd8a0`, recorded in the protocol doc as the M4 marker.
- Evidence: `ScenarioRunArtifact.memoryProposals { accepted, dropped }` in every record.
- Tests: short proposal about someone → `relationship` with placeholder tone; about no one → `self`; seven-field form unchanged; malformed elements dropped with the count, intent kept; empty/null stays empty; JSON schema requires only `summary` in the first branch; `composeIntentPacket` normalizes short proposals; contract line pinned and enum values still on `memoryWriteProposalFieldContract`; resolver resolves names → ids and fills tone/intensity, and turns a subjectless proposal into `self`/`neutral`; prompt shows the short shape; evidence record carries `memoryProposals`. The old "out-of-range intensity → fallback" test now asserts the intent survives.

## Why

`memory_written` is 0 in 12 of 12 real DeepSeek reads (`docs/eval/evidence/hoc-m*`), so `memory_continuity` is judged on seeded memories alone and the `memory_written` signal never passes. The provider was asked in schema mode for seven required fields per proposal and answered with none.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1634, +10)
- Mock golden gate 132 scenarios, signals 100%, PASSED (the mock still emits the full form).
- Stacked on #184. The M4 milestone read carries the first live count.
