### PR TITLE
feat(simulation): stamp hold consults on the motive event and count them in evidence

### DIFF
--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -471,6 +471,7 @@ export async function runBench(opts: {
             recoveredFallbacks: artifact.recoveredFallbacks,
             llmFailures: artifact.llmFailures ?? [],
             memoryProposals: artifact.memoryProposals ?? { accepted: 0, dropped: 0 },
+            holdConsults: artifact.holdConsults ?? { total: 0, voiced: 0, broke: 0 },
           },
         });
       }

--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -67,6 +67,8 @@ export type ScenarioRunArtifact = {
   llmFailures?: LlmFailureRecord[];
   /** Memory proposals: committed `memory_written` events vs proposals the parser dropped as malformed. */
   memoryProposals?: { accepted: number; dropped: number };
+  /** ADR-0017 hold consults: how many the model answered, how many it voiced (`no_op` with its own motive), how many it broke. */
+  holdConsults?: HoldConsultCounts;
   /** `liveOnly` signals not evaluated because the run was in mock mode; never in `totalSignals`. */
   skippedSignals?: number;
   probeResults: ProbeResult[];
@@ -227,6 +229,7 @@ export class ScenarioRunner {
     const { fallbackCount, fallbackNoOps, operatorEventCounts } = countFallbacks(events, operatorEvents);
     const recoveredFallbacks = operatorEvents.filter(e => e.type === "llm_retry_recovered").length;
     const llmFailures = collectLlmFailures(operatorEvents);
+    const holdConsults = countHoldConsults(events);
     const memoryProposals = {
       accepted: events.filter(e => e.type === "memory_written").length,
       dropped: operatorEvents.reduce((n, e) => n + (e.type === "pulse_metrics" ? Number((e.data as { memoryWritesDropped?: unknown } | undefined)?.memoryWritesDropped ?? 0) : 0), 0),
@@ -260,6 +263,7 @@ export class ScenarioRunner {
       operatorEventCounts,
       llmFailures,
       memoryProposals,
+      holdConsults,
       operatorFailures: failures,
       recoveredFallbacks,
       probeResults,
@@ -274,6 +278,28 @@ export class ScenarioRunner {
       providerCalls: tracking?.providerCalls(),
     };
   }
+}
+
+export type HoldConsultCounts = { total: number; voiced: number; broke: number };
+
+/**
+ * ADR-0017: every motive event stamped `holdSuggested` answered a consult. A
+ * character-authored `no_op` there is a voiced hold; any other character-
+ * authored intent broke the hold; engine-authored answers (fallbacks) count
+ * as neither.
+ */
+export function countHoldConsults(events: readonly CommittedEvent[]): HoldConsultCounts {
+  const counts: HoldConsultCounts = { total: 0, voiced: 0, broke: 0 };
+  for (const e of events) {
+    if (e.type !== "private_motive_summary") continue;
+    const p = e.payload as { holdSuggested?: unknown; intentType?: unknown; engineAuthored?: unknown };
+    if (p.holdSuggested !== true) continue;
+    counts.total++;
+    if (p.engineAuthored === true) continue;
+    if (p.intentType === "no_op") counts.voiced++;
+    else counts.broke++;
+  }
+  return counts;
 }
 
 export type LlmFailureRecord = {

--- a/packages/eval/src/test/bench-hygiene.test.ts
+++ b/packages/eval/src/test/bench-hygiene.test.ts
@@ -45,6 +45,7 @@ function artifact(seed: unknown) {
       { type: "llm_failure", agentId: "a", pulseIndex: 3, detail: "LLM parsing failed for agent a: No JSON object found in response", data: { errorDetail: "No JSON object found in response", rawHead: "", rawLength: 0 } },
     ],
     memoryProposals: { accepted: 2, dropped: 1 },
+    holdConsults: { total: 3, voiced: 1, broke: 2 },
   };
 }
 
@@ -141,6 +142,7 @@ describe("bench hygiene", () => {
     expect(record.llmFailures).toHaveLength(1);
     expect(record.llmFailures?.[0]?.data?.rawLength).toBe(0);
     expect((record as { memoryProposals?: unknown }).memoryProposals).toEqual({ accepted: 2, dropped: 1 });
+    expect((record as { holdConsults?: unknown }).holdConsults).toEqual({ total: 3, voiced: 1, broke: 2 });
     const meta = JSON.parse(readFileSync(join(dir, "run-meta.json"), "utf8")) as Record<string, unknown>;
     expect(meta["runId"]).toBe("hoc-test");
     expect(meta["seeds"]).toEqual([7]);

--- a/packages/eval/src/test/fallback-count.test.ts
+++ b/packages/eval/src/test/fallback-count.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { CommittedEvent, OperatorEvent } from "@perfectman/shared";
-import { countFallbacks, collectLlmFailures } from "../run/scenario-runner.js";
+import { countFallbacks, collectLlmFailures, countHoldConsults } from "../run/scenario-runner.js";
 
 function committed(type: CommittedEvent["type"], motive?: string): CommittedEvent {
   return {
@@ -52,5 +52,22 @@ describe("collectLlmFailures", () => {
     expect(out[0]).toMatchObject({ type: "llm_failure", agentId: "lia", pulseIndex: 8, data: { rawHead: "", rawLength: 0 } });
     expect(out[1]).toMatchObject({ type: "llm_retry_recovered", agentId: "nina", pulseIndex: 9 });
     expect(out[1]?.data).toBeUndefined();
+  });
+});
+
+describe("countHoldConsults", () => {
+  const motive = (holdSuggested: boolean | undefined, intentType: string, engineAuthored = false): CommittedEvent =>
+    ({
+      id: "m", simulationId: "s", channelId: "c", actorId: "a", type: "private_motive_summary",
+      payload: { summary: "x", intentType, emotionDrivers: [], motivationDrivers: [], engineAuthored, ...(holdSuggested !== undefined ? { holdSuggested } : {}) },
+      sourceEventIds: [], emotionalSalience: "low", pulseIndex: 1,
+      visibility: { visibleToAgents: [], visibleToSpectators: false, visibleToOperators: true, visibilityReason: "operator_only" },
+      createdAt: 0,
+    }) as CommittedEvent;
+
+  it("counts consults, voiced holds, and broken holds; engine answers count as neither; unflagged motives are ignored", () => {
+    const events = [motive(true, "no_op"), motive(true, "send_message"), motive(true, "no_op", true), motive(undefined, "no_op"), motive(false, "send_message")];
+    expect(countHoldConsults(events)).toEqual({ total: 3, voiced: 1, broke: 1 });
+    expect(countHoldConsults([])).toEqual({ total: 0, voiced: 0, broke: 0 });
   });
 });

--- a/packages/server/src/simulation/__tests__/intent-resolver-motive.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-motive.test.ts
@@ -170,6 +170,16 @@ describe("private_motive_summary per resolved intent", () => {
     expect(result.committedEvents.some(e => e.type === "no_op_recorded")).toBe(true);
   });
 
+  it("stamps holdSuggested on the motive only when the context says the engine consulted on a hold (ADR-0017)", async () => {
+    const plain = await resolver.resolve(makeIntent({ intentType: "no_op", channelTarget: undefined }), ctx());
+    const plainMotive = plain.committedEvents.find((e) => e.type === "private_motive_summary");
+    expect(plainMotive?.payload).not.toHaveProperty("holdSuggested");
+    const held = await resolver.resolve(makeIntent({ intentType: "no_op", channelTarget: undefined }), { ...ctx(), holdSuggested: true });
+    const heldMotive = held.committedEvents.find((e) => e.type === "private_motive_summary");
+    expect(heldMotive?.payload["holdSuggested"]).toBe(true);
+    expect(heldMotive?.payload["intentType"]).toBe("no_op");
+  });
+
   it("still records the thought when the act was blocked", async () => {
     // send_message to a channel the agent is not a member of → not_member block.
     const intent = makeIntent({ channelTarget: "ch_elsewhere" });

--- a/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
+++ b/packages/server/src/simulation/__tests__/pulse-scheduler.test.ts
@@ -394,7 +394,8 @@ describe("PulseScheduler", () => {
             { intentType: "send_message", channelTargets: ["ch_public"], personTargets: ["agent_1", "agent_2"], blocked: false },
             { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
           ],
-          decision: { outcome: "act", needsLLM: true, initiativeProceed: false },
+          // ADR-0017: the consult flag rides from the decision to the motive event.
+          decision: { outcome: "act", needsLLM: true, initiativeProceed: false, holdSuggested: true },
           noOpRecord: null,
         };
       }, [AGENT, AGENT_2]);
@@ -414,9 +415,15 @@ describe("PulseScheduler", () => {
       return message!.payload;
     }
 
-    it("the scheduler's agentNames map reaches the resolver: a display-name mention stamps mentionedAgentIds", async () => {
+    it("the scheduler's agentNames map reaches the resolver: a display-name mention stamps mentionedAgentIds; a hold consult reaches the motive event", async () => {
       const payload = await committedMessagePayload("hey Other Agent, what do you think?");
       expect(payload["mentionedAgentIds"]).toEqual(["agent_2"]);
+      const events = await eventRepo.getAfter("sim_test");
+      const motive = events.find((e) => e.type === "private_motive_summary" && e.actorId === "agent_1");
+      expect(motive?.payload["holdSuggested"]).toBe(true);
+      // agent_2's step never consults: whatever it committed carries no flag.
+      const other = events.find((e) => e.type === "private_motive_summary" && e.actorId === "agent_2");
+      expect(other?.payload?.["holdSuggested"]).toBeUndefined();
     });
 
     it("a substring of a display name is not a mention", async () => {

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -77,6 +77,8 @@ type ResolveContext = {
   actionEmotions: ActionEmotions;
   /** agentId → display name; powers mention parsing over visibleContent. */
   agentNames?: Record<string, string>;
+  /** ADR-0017: the engine consulted the model on a hold this pulse; stamped on the motive event so evidence can count consults. */
+  holdSuggested?: boolean;
 };
 
 const MENTION_BOUNDARY = "[^\\p{L}\\p{N}]";
@@ -697,6 +699,7 @@ export class IntentResolver {
       emotionDrivers: intent.emotionDrivers ?? [],
       motivationDrivers: intent.motivationDrivers ?? [],
       engineAuthored: isEngineAuthoredMotive(intent.privateMotiveSummary),
+      ...(ctx.holdSuggested ? { holdSuggested: true } : {}),
     };
     return {
       simulationId: ctx.simulationId,

--- a/packages/server/src/simulation/pulse-scheduler.ts
+++ b/packages/server/src/simulation/pulse-scheduler.ts
@@ -370,6 +370,7 @@ export class PulseScheduler {
           settings: sim.settings,
           actionEmotions: stepResult.actionEmotions,
           agentNames: this.agentNamesByAgentId,
+          ...(stepResult.decision.holdSuggested === true ? { holdSuggested: true } : {}),
         }).catch(async (err) => {
           await this.emitOperatorEvent(this.schedulerError("Intent resolver failed", err, agent.id));
           return null;

--- a/packages/shared/src/event/event.types.ts
+++ b/packages/shared/src/event/event.types.ts
@@ -61,6 +61,8 @@ export type PrivateMotiveSummaryPayload = {
   emotionDrivers: string[];
   motivationDrivers: string[];
   engineAuthored: boolean;
+  /** ADR-0017: this intent answered a hold consult — a `no_op` here is a voiced hold, anything else broke it. */
+  holdSuggested?: boolean;
 };
 
 export type EventVisibility = {


### PR DESCRIPTION
## What

Makes the ADR-0017 consult countable:

- `ResolveContext.holdSuggested?` — the scheduler passes `stepResult.decision.holdSuggested` to the resolver; `privateMotiveEvent` stamps `holdSuggested: true` on the committed `private_motive_summary` payload (`PrivateMotiveSummaryPayload.holdSuggested?`, additive on a `z.record` payload).
- `countHoldConsults(events)` in `scenario-runner.ts`: `total` motives that answered a consult, `voiced` (character-authored `no_op`), `broke` (any other character-authored intent); engine-authored answers count as neither. `ScenarioRunArtifact.holdConsults` rides into every evidence record.
- Tests: the resolver stamps the flag only when the context sets it; the scheduler wiring test now also checks the flag travels from the decision to the motive event and that an unconsulted agent carries none; `countHoldConsults` counts total/voiced/broke and ignores unflagged and engine-authored motives; the evidence record carries `holdConsults`.

## Why

M2 and M3 produced one model-voiced silence in six runs after the voiced hold landed (#183). Whether the consult fires and the model breaks the hold, or the trigger (salient foreign event, no act last pulse, refractory) rarely fires, decides the next engine change and was unrecorded.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1636, +2)
- Mock golden gate 132 scenarios, signals 100%, PASSED.
- Stacked on #187. The M4 milestone read (3 scenes × seeds 42/43/44) runs on this head.
