### PR TITLE
fix(agent): re-skin the relationship-bias prose, not only its keys

### DIFF
--- a/packages/server/src/agent/__tests__/persona-loader.test.ts
+++ b/packages/server/src/agent/__tests__/persona-loader.test.ts
@@ -95,7 +95,10 @@ describe("personaPackToProfile — scenario re-skin", () => {
   it("remaps relationship biases through castMap and drops peers outside the cast", () => {
     const profile = personaPackToProfile(pack, { scenarioContext, castAgentIds: cast, castDisplayNames });
     expect(Object.keys(profile.relationshipBiases).sort()).toEqual(["bruno", "marcela", "theo"]);
-    expect(profile.relationshipBiases["marcela"]?.view).toBe(pack.relationshipBiases["mariana"]);
+    // Same prose, scene names substituted for pack names.
+    expect(profile.relationshipBiases["marcela"]?.view).toBe(
+      pack.relationshipBiases["mariana"]!.replace(/\bMariana\b/g, "Marcela").replace(/\bBruno\b/g, "Bruno").replace(/\bCaio\b/g, "Théo"),
+    );
     expect(Object.keys(personaPackToProfile(pack).relationshipBiases)).toContain("leo");
   });
 
@@ -118,8 +121,14 @@ describe("personaPackToProfile — scenario re-skin", () => {
       castDisplayNames: { vic: "Vic", bea: "Bea", dudu: "Dudu", kai: "Kai", leo: "Léo" },
     });
     expect(Object.keys(profile.relationshipBiases).sort()).toEqual(["bea", "dudu", "kai", "vic"]);
-    expect(profile.relationshipBiases["vic"]?.view).toBe(leo.relationshipBiases["goulart"]);
-    expect(profile.relationshipBiases["kai"]?.view).toBe(leo.relationshipBiases["caio"]);
+    // The prose is re-skinned too: the pack says "Goulart is the best thing
+    // in the chat"; the band member is Vic. A real read had Léo calling Bea
+    // "mariana" and Kai "caio" before this.
+    expect(profile.relationshipBiases["vic"]?.view).toContain("Vic is the best thing");
+    expect(profile.relationshipBiases["vic"]?.view).not.toMatch(/\bGoulart\b/);
+    expect(profile.relationshipBiases["bea"]?.view).toMatch(/^Bea /);
+    expect(profile.relationshipBiases["bea"]?.view).not.toMatch(/\bMariana\b/);
+    expect(profile.relationshipBiases["kai"]?.view).not.toMatch(/\bCaio\b/);
     expect(profile.displayName).toBe("Léo");
   });
 

--- a/packages/server/src/agent/persona-loader.ts
+++ b/packages/server/src/agent/persona-loader.ts
@@ -98,17 +98,10 @@ export function personaPackToProfile(pack: PersonaPack, reskin?: PersonaReskin):
     return castMap[peer] ?? (castIds.has(peer) ? peer : undefined);
   };
 
-  const biases: Record<string, import("./persona-prompt-profile.js").RelationshipPromptBias> = {};
-  for (const [peer, view] of Object.entries(pack.relationshipBiases)) {
-    const target = resolvePeer(peer);
-    if (target === undefined) continue;
-    biases[target] = { view, warmth: "medium", trust: "medium", likelyBehaviors: [], triggers: [] };
-  }
-
   // Free-text lines that name a pack peer: rename mapped peers to their
   // scene name, drop lines about peers outside the cast. A text heuristic —
   // it matches display names as whole words, case-insensitively — and
-  // documented as such; the structural fix is the biases map above.
+  // documented as such; the structural fix is the biases map below.
   const renamePeers = (lines: readonly string[]): string[] => {
     if (!reskin) return [...lines];
     const out: string[] = [];
@@ -128,6 +121,20 @@ export function personaPackToProfile(pack: PersonaPack, reskin?: PersonaReskin):
     }
     return out;
   };
+
+  // The bias map is keyed by scene id, but its prose was still the pack's
+  // ("Mariana barely reacts to you…"): in a real read the band called Bea
+  // "mariana" and Kai "caio" — names nobody in the scene has. The prose
+  // goes through the same rename; a view that names a peer outside the
+  // cast is dropped with it.
+  const biases: Record<string, import("./persona-prompt-profile.js").RelationshipPromptBias> = {};
+  for (const [peer, view] of Object.entries(pack.relationshipBiases)) {
+    const target = resolvePeer(peer);
+    if (target === undefined) continue;
+    const [renamedView] = renamePeers([view]);
+    if (renamedView === undefined) continue;
+    biases[target] = { view: renamedView, warmth: "medium", trust: "medium", likelyBehaviors: [], triggers: [] };
+  }
 
   const displayName = reskin?.scenarioContext?.displayName ?? pack.displayName;
   const identityFrame =


### PR DESCRIPTION
## What

Runs the relationship-bias prose through the same peer rename the re-skin already applies to `socialTheory` lines:

- `personaPackToProfile`: each bias `view` is renamed (`Mariana` → `Bea`, `Caio` → `Kai`, `Goulart` → `Vic`, … through `castMap` and `castDisplayNames`); a view naming a peer outside the cast is dropped with it, as the free-text lines already are.
- Tests: the leo re-skin case now checks the prose ("Vic is the best thing…", no `Goulart`/`Mariana`/`Caio` left); the goulart case pins the substituted text.

## Why

In the M3 Banda read (`hoc-m3-t-49d14c5-banda_no_festival`) Bea addresses Kai as "caio", Kai's motive names "a mariana", Léo writes "mariana, olha…" in a private room — names nobody in the scene has. The bias map was keyed by scene id (#167) but its prose was still the pack's.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1636)
- Mock golden gate 132 scenarios, signals 100%, PASSED.
- Stacked on #188.
