### PR TITLE
fix(eval): json_object instead of json_schema for deepseek-v4

### DIFF
--- a/packages/eval/src/run/scenario-runner.ts
+++ b/packages/eval/src/run/scenario-runner.ts
@@ -564,6 +564,14 @@ export function localLLMConfig(
     timeoutMs: isDeepseek ? 180000 : 120000,
     retryCount: 2,
     responseFormatJson: true,
+    // deepseek-v4 through the router under `response_format: json_schema`
+    // runs to the token cap (a direct probe: 3,732 chars, finish_reason
+    // "length", unparseable) and never fills memoryWrites; under
+    // `json_object` the same prompt returns a 538-char intent with the
+    // proposal filled. Nine M4 runs had 0 memory writes and 2–12 runaway
+    // turns each with schema mode on. Constrained decoding stays on for
+    // the local and other cloud paths.
+    ...(isDeepseekV4 ? { responseFormatJsonSchema: false } : {}),
     extraBody: isDeepseek
       ? {
           seed,

--- a/packages/eval/src/test/bench-seed.test.ts
+++ b/packages/eval/src/test/bench-seed.test.ts
@@ -52,6 +52,16 @@ describe("bench seed wiring (#45)", () => {
     expect(config.extraBody?.["thinking"]).toBeUndefined();
   });
 
+  it("uses json_object, not json_schema, for deepseek-v4 (schema mode runs it to the cap and drops memoryWrites); other paths keep constrained decoding", () => {
+    process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
+    process.env.PERFECTMAN_LLM_MODEL = "deepseek/deepseek-v4-flash";
+    expect(localLLMConfig(undefined).responseFormatJsonSchema).toBe(false);
+    process.env.PERFECTMAN_LLM_MODEL = "z-ai/glm-5.3-flash";
+    expect(localLLMConfig(undefined).responseFormatJsonSchema).toBeUndefined();
+    delete process.env.PERFECTMAN_LLM_PROVIDER;
+    expect(localLLMConfig(undefined).responseFormatJsonSchema).toBeUndefined();
+  });
+
   it("caps deepseek-v4 output at 2500 tokens with a 0.6 frequency-penalty floor; other cloud models keep 8000", () => {
     process.env.PERFECTMAN_LLM_PROVIDER = "deepseek";
     process.env.PERFECTMAN_LLM_MODEL = "deepseek/deepseek-v4-flash";


### PR DESCRIPTION
## What

Turns constrained decoding off for deepseek-v4 on the eval's local path:

- `localLLMConfig`: `responseFormatJsonSchema: false` when the model is deepseek-v4, so the transport sends `response_format: {type: "json_object"}` instead of the `intent_packet` JSON schema. Every other path (Ollama, other cloud models) keeps schema mode.
- Test: deepseek-v4 gets `false`; GLM and the local default keep it unset.

## Why

`memoryProposals` was `{accepted: 0, dropped: 0}` in all nine M4 runs even after the two-field contract (#187), and every run still repaired 2–12 runaway turns. A direct probe of `deepseek/deepseek-v4-flash` through OrcaRouter with the real field contract and `ModelIntentPacketJsonSchema`: `json_schema` → 3,732 characters, `finish_reason: length`, unparseable; `json_object` → 538 characters, clean intent, `memoryWrites: [{"summary": "O Rafa desviou de novo quando falei sobre a matrícula.", "about": ["rafa"]}]`; no response format → the same with the proposal. Schema mode was on for every DeepSeek intent call since the route was adopted.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1637, +1)
- Stacked on #190.
- One-scene confirmation read (`hoc-jo-86a56d4-heranca_do_sitio`, Sítio, seed 42): **27 `memory_written` events** (0 in the previous twelve runs), **0 runaway turns repaired** (2–12 per run before), 0 target-resolution retries, 0 fallbacks; jury `memory_continuity` 5, `motive_authenticity` 5. The run graded F on a p27 forbidden-phrase leak, unrelated to the mode.
