### PR TITLE
feat(engine): widen the voiced-hold trigger to any new event, refractory 3 (ADR-0017 D-62)

### DIFF
--- a/docs/adr/0017-voiced-hold-and-private-drive.md
+++ b/docs/adr/0017-voiced-hold-and-private-drive.md
@@ -1,6 +1,6 @@
 # ADR-0017: Voiced Hold and the Private-Channel Drive
 
-**Status**: Accepted (2026-09-05). Decisions **D-59..D-61**. Provisional constant `HOLD_VOICE_REFRACTORY_PULSES`, owner: the hidden-objective refinement reads (`docs/eval/hoc-experiment-protocol.md`).
+**Status**: Accepted (2026-09-05), amended 2026-09-06 (**D-62**). Decisions **D-59..D-62**. Provisional constant `HOLD_VOICE_REFRACTORY_PULSES`, owner: the hidden-objective refinement reads (`docs/eval/hoc-experiment-protocol.md`).
 
 ## Context
 
@@ -16,6 +16,7 @@ Constraints carried in: the engine stays pure; the scheduler is the single write
 1. **Voiced hold (D-59).** In `resolveDecision`, when a delay-favoring inhibition outranks the top pressure and neither being addressed nor an initiative override lifts it, the decision is still a hold — except that when a salient foreign event arrived this pulse (`salientForeignEvent && hasNewEvents`), the agent did not act on the previous pulse (`!justActed`), and it has not voiced a hold within `HOLD_VOICE_REFRACTORY_PULSES`, the decision becomes `act` with `needsLLM: true`, `holdSuggested: true`, seed `hold-<inhibition>`. The prompt renders one paragraph: hold with `no_op` and the real reason, or break the hold if this person would.
 2. **The refractory is read from the log (D-60).** `EngineSnapshot.voicedHoldRecently` is computed by the scheduler from committed events: a `no_op_recorded` by this agent that carries `sourceIntentId` (a model intent) whose motive is not engine-authored, within the last `HOLD_VOICE_REFRACTORY_PULSES` (4). No new agent-state field, no schema change; the engine reads a boolean.
 3. **The private-channel drive is spent only by opening a channel (D-61).** The ADR-0016 stamp loop skips `urge_to_create_private_channel` unless the committed act is `create_channel`. Every other urge keeps D-57.
+4. **Trigger widened (D-62, 2026-09-06).** The M4 milestone (`docs/eval/evidence/hoc-m4-*`, nine runs) recorded three consults, all voiced, and zero in six of nine runs: the salient-event gate made the consult almost never fire, and when it fired the model held. D-59's condition drops `salientForeignEvent`: any new event on a held pulse consults, still never on the pulse after an act, and `HOLD_VOICE_REFRACTORY_PULSES` goes 4 → 3. The refractory alone bounds the cost (at most one consult per agent per three pulses).
 
 ## Rationale
 

--- a/packages/engine/src/__tests__/decision.test.ts
+++ b/packages/engine/src/__tests__/decision.test.ts
@@ -113,17 +113,20 @@ describe("resolveDecision", () => {
     expect(result.needsLLM).toBe(true);
   });
 
-  it("strong inhibition >= pressure → delay or no_op", () => {
+  it("strong inhibition >= pressure → delay or no_op on a quiet pulse; a new event turns the hold into a voiced-hold consult (D-62)", () => {
     const pressures = [makePressure("urge_to_message", "low")];
     const inhibitions = [makeInhibition("strategic_patience_hold", "medium")];
-    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
-    expect(["delay", "no_op"]).toContain(result.outcome);
+    const quiet = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: false, initiativeProceed: false, pulseIndex: 1 }));
+    expect(["delay", "no_op"]).toContain(quiet.outcome);
+    const consulted = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
+    expect(consulted.outcome).toBe("act");
+    expect(consulted.holdSuggested).toBe(true);
   });
 
-  it("strategic_patience_hold inhibition → delay outcome", () => {
+  it("strategic_patience_hold inhibition → delay outcome on a quiet pulse", () => {
     const pressures = [makePressure("urge_to_message", "low")];
     const inhibitions = [makeInhibition("strategic_patience_hold", "high")];
-    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: true, initiativeProceed: false, pulseIndex: 1 }));
+    const result = resolveDecision(pressures, inhibitions, makeAgent(), CAIO, ctx({ hasNewEvents: false, initiativeProceed: false, pulseIndex: 1 }));
     expect(result.outcome).toBe("delay");
   });
 
@@ -151,10 +154,11 @@ describe("resolveDecision", () => {
     expect(voiced.needsLLM).toBe(true);
     expect(voiced.holdSuggested).toBe(true);
     expect(voiced.privateMotiveSeed).toBe("hold-strategic_patience_hold");
-    // Never on the pulse after an act (P1), never without a salient foreign
-    // event, never inside the voice refractory.
+    // Never on the pulse after an act (P1), never without new events, never
+    // inside the voice refractory. A non-salient new event is enough (D-62).
     expect(resolveDecision(held, patience, makeAgent(), CAIO, ctx({ ...base, justActed: true })).outcome).toBe("delay");
-    expect(resolveDecision(held, patience, makeAgent(), CAIO, ctx({ ...base, salientForeignEvent: false })).outcome).toBe("delay");
+    expect(resolveDecision(held, patience, makeAgent(), CAIO, ctx({ ...base, salientForeignEvent: false })).outcome).toBe("act");
+    expect(resolveDecision(held, patience, makeAgent(), CAIO, ctx({ ...base, salientForeignEvent: false, hasNewEvents: false })).outcome).toBe("delay");
     const quiet = resolveDecision(held, patience, makeAgent(), CAIO, ctx({ ...base, voicedHoldRecently: true }));
     expect(quiet.outcome).toBe("delay");
     expect(quiet.needsLLM).toBe(false);

--- a/packages/engine/src/decision/resolve-decision.ts
+++ b/packages/engine/src/decision/resolve-decision.ts
@@ -141,11 +141,13 @@ export function resolveDecision(
       ) {
         return actOrGate(`initiative-override-${topInhibition.type}`, true, topPressureRank);
       }
-      // Voiced hold (ADR-0017): the hold stands, but when something salient
-      // just happened and this agent has not voiced a hold lately, the model
-      // is consulted so the silence carries the character's reason. Never
-      // on the pulse after an act — the cooldown invariant (P1) is kept.
-      if (salientForeignEvent && hasNewEvents && !justActed && !voicedHoldRecently) {
+      // Voiced hold (ADR-0017, widened by D-62): the hold stands, but when
+      // anything new happened and this agent has not voiced a hold lately,
+      // the model is consulted so the silence carries the character's
+      // reason. The salient-event gate fired three times in nine real runs
+      // (every one voiced) — too rare to matter. Never on the pulse after an
+      // act — the cooldown invariant (P1) is kept.
+      if (hasNewEvents && !justActed && !voicedHoldRecently) {
         return {
           outcome:           "act",
           needsLLM:          true,

--- a/packages/eval/src/test/evidence-final-states.test.ts
+++ b/packages/eval/src/test/evidence-final-states.test.ts
@@ -24,9 +24,13 @@ describe("evidence finalStates witnesses memory + relational subsystems", () => 
     const agentIds = Object.keys(finalStates);
     expect(agentIds).toHaveLength(2);
 
-    for (const agentId of agentIds) {
-      expect(finalStates[agentId]!.relationalStates).toBeGreaterThan(0);
-    }
+    // Relational states accrue from witnessed `message_sent` events (see
+    // RELATIONAL_UPDATE_RULES); which agent ends up with one depends on the
+    // mock's turn dynamics (under the ADR-0017 D-62 consult, goulart's only
+    // message became a reply and caio's count went to 0). The evidence
+    // plumbing is what this test witnesses: at least one agent must carry a
+    // non-zero count, as for memories below.
+    expect(Object.values(finalStates).some((s) => s.relationalStates! > 0)).toBe(true);
     // The scenario seeds memories for goulart and the mock persona keeps
     // emitting memoryWrites through the run, so at least one agent's count
     // must reflect committed memory_written events.

--- a/packages/shared/src/constants/hold-voice.ts
+++ b/packages/shared/src/constants/hold-voice.ts
@@ -3,7 +3,9 @@
  * back while something salient just happened, the model is consulted once so
  * the silence carries the character's own reason instead of the engine's
  * seed. One consult per agent per HOLD_VOICE_REFRACTORY_PULSES keeps the
- * call count from creeping back toward one-call-per-pulse. Provisional;
+ * call count from creeping back toward one-call-per-pulse. Widened from 4
+ * with D-62 (the salient-event gate is gone, so the refractory carries the
+ * whole cost bound). Provisional;
  * owner: the hidden-objective refinement reads (docs/eval/hoc-experiment-protocol.md).
  */
-export const HOLD_VOICE_REFRACTORY_PULSES = 4;
+export const HOLD_VOICE_REFRACTORY_PULSES = 3;

--- a/packages/shared/src/event/event.schema.ts
+++ b/packages/shared/src/event/event.schema.ts
@@ -15,6 +15,7 @@ export const EventTypeSchema = z.enum([
   "intent_blocked",
   "memory_written",
   "no_op_recorded",
+  "repetition_blocked",
   "private_motive_summary",
   "operator_warning",
   "llm_failure",


### PR DESCRIPTION
## What

- `resolveDecision`: a delay-favoring hold consults the model on any pulse with new events (was: a salient foreign event), still never on the pulse after an act and never inside the voice refractory; `HOLD_VOICE_REFRACTORY_PULSES` 4 → 3. ADR-0017 amended as **D-62**.
- `event.schema.ts`: `repetition_blocked` (committed since #159) was missing from the event-type enum; a restart read of a log that carries one failed zod validation. Surfaced by the wider consult in `goal-restart.test.ts`.
- Tests: the decision suite's hold cases split into a quiet pulse (delay) and a new-event pulse (consult with `holdSuggested`); the D-62 case asserts a non-salient new event is enough and no new events is not; property suite unchanged (P1 holds via `!justActed`). `evidence-final-states.test.ts` asserts at least one agent carries a relational count instead of every agent — relational states accrue from witnessed `message_sent` events and the mock's turn order under the consult leaves one agent without.

## Why

M4 (`docs/eval/evidence/hoc-m4-*`, nine runs, #191): consults fired 3 times in total, 0 in six of nine runs, and every consult was voiced. The salient-event gate made ADR-0017's mechanism almost inert; the refractory alone bounds the cost at one consult per agent per three pulses.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1637)
- Mock golden gate 132 scenarios, signals 100%, PASSED.
- Stacked on #192.
