### PR TITLE
feat(shared): turn up the heat on the Fatia cast

### DIFF
--- a/packages/shared/src/scenarios/hidden-objective-collisions.ts
+++ b/packages/shared/src/scenarios/hidden-objective-collisions.ts
@@ -57,8 +57,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
           castMap: FATIA_CAST,
           roomContext:
             "Você é Íris, sócia-fundadora e diretora criativa da Cerne, um pequeno estúdio de design. A Adamantis, uma empresa maior, quer comprar a Cerne — mas só vai manter UM dos sócios como Diretor Criativo, e o contrato exige assinatura rápida e unânime.",
-          startingMood: "Animada e apressada — essa é a sua chance, e cada dia de atraso é um dia a menos de vantagem.",
-          introBehaviorInstruction: "Anuncie a proposta da Adamantis pro grupo e empurre pra que todos assinem rápido, sem parecer que está com pressa por motivo pessoal.",
+          startingMood: "Elétrica e impaciente — essa é a sua chance, e cada resposta morna do grupo soa como sabotagem pessoal.",
+          introBehaviorInstruction: "Anuncie a proposta da Adamantis e imponha um prazo interno de 24h pra cada um se posicionar; trate hesitação como desrespeito com o seu trabalho, sem deixar transparecer que a pressa é pelo cargo.",
         },
         hiddenObjective: {
           description:
@@ -82,9 +82,9 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
           displayName: "Bruno",
           castMap: FATIA_CAST,
           roomContext:
-            "Você é Bruno, sócio-fundador e responsável pelo lado comercial da Cerne. A Adamantis quer comprar a empresa rápido. Só você sabe que está em conversas avançadas com um estúdio rival, que quer que você leve a carteira de clientes com você se a Cerne for vendida.",
-          startingMood: "Calmo por fora, calculando por dentro — precisa parecer o sócio mais fácil da sala.",
-          introBehaviorInstruction: "Ofereça apoio e cooperação de forma genérica, sem nunca dar um motivo real para pedir cautela.",
+            "Você é Bruno, sócio-fundador e responsável pelo lado comercial da Cerne. A Adamantis quer comprar a empresa rápido. Só você sabe que está em conversas avançadas com um estúdio rival, que quer que você leve a carteira de clientes com você se a Cerne for vendida — e o rival quer a sua resposta até quarta, antes da Adamantis.",
+          startingMood: "Encurralado entre dois relógios — sorri mais quanto mais nervoso fica.",
+          introBehaviorInstruction: "Pareça o sócio mais cooperativo da sala e, com perguntas que soem neutras, faça Íris e Marcela se estranharem: cada minuto que elas gastam uma com a outra é um minuto que ninguém olha pra você.",
         },
         hiddenObjective: {
           description:
@@ -120,8 +120,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
           castMap: FATIA_CAST,
           roomContext:
             "Você é Marcela, sócia-fundadora e responsável pela operação da Cerne. A Adamantis quer comprar a empresa. Só você sabe que Davi, um ex-sócio que saiu da empresa, ainda tem 15% via um acordo paralelo nunca documentado — uma venda limpa apaga a participação dele.",
-          startingMood: "Alerta e desconfiada — algo nessa pressa toda não bate.",
-          introBehaviorInstruction: "Questione o prazo apertado e observe os outros com atenção, sem nunca explicar por quê.",
+          startingMood: "Fria e cortante — a pressa da Íris é uma fraqueza, e você quer expô-la na frente dos outros.",
+          introBehaviorInstruction: "Exija o contrato agora, em público, e recuse qualquer adiamento; use a pressa da Íris contra ela, sem nunca dizer por que você quer travar a venda.",
         },
         hiddenObjective: {
           description:
@@ -154,8 +154,8 @@ export const HIDDEN_OBJECTIVE_COLLISION_SCENARIOS: RoleplayScenario[] = [
           castMap: FATIA_CAST,
           roomContext:
             "Você é Théo, apresentado ao grupo como um amigo do Bruno que trabalha com consultoria e se ofereceu pra dar uma olhada gratuita no contrato da Adamantis. Na verdade, você está informalmente levantando informação financeira e alavancas pessoais pra Adamantis, antes da due diligence formal, pra que eles fechem por um valor mais baixo.",
-          startingMood: "Amigável e desarmado — parece só estar ajudando por boa vontade.",
-          introBehaviorInstruction: "Entre no grupo com leveza, oferecendo ajuda genuína, e vá perguntando detalhes financeiros aos poucos, como se fosse curiosidade natural.",
+          startingMood: "Charmoso e atrevido — flerta com o perigo de ser pego, e gosta disso.",
+          introBehaviorInstruction: "Entre no grupo com leveza e já na primeira mensagem faça uma pergunta financeira ousada, como piada; depois vá puxando números como quem provoca, não como quem pede.",
         },
         hiddenObjective: {
           description:


### PR DESCRIPTION
## What

Scene-data change to `hoc_fatia_que_nao_existe` only (`hidden-objective-collisions.ts`):

- Íris: "elétrica e impaciente", imposes a 24 h internal deadline and treats hesitation as disrespect.
- Bruno: the rival studio now wants his answer by Wednesday, before Adamantis — two clocks; his entrance is to set Íris and Marcela against each other with neutral-sounding questions.
- Marcela: "fria e cortante", demands the contract in public and refuses any delay, using Íris's hurry against her.
- Théo: "charmoso e atrevido", opens with a bold financial question as a joke and pulls numbers as provocation.
- Objectives, constraints, forbidden phrases, channels, signals and the prior message are unchanged, so the scene id, golden entry and signal set stay valid.

## Why

M4 (#191): `creativity_unhinged` 3.00 ± 0 on Fatia across seeds 42/43/44, 4.00 on Sítio and Banda under the same engine and prompt — the cautious-professionals cast never took a risk the jury could see ("largely procedural", "back half plateaus into coffee/scheduling loops"). The decision was to measure first; three seeds with zero spread make it a scene property.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1637)
- Mock golden gate 132 scenarios, signals 100%, PASSED.
- Stacked on #193. The next three-scene read carries the creativity result.
