### PR TITLE
fix(eval): act-share voids a grade only at monopoly level

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -227,7 +227,8 @@ only what the bench already writes, so a threshold change re-grades every commit
 Per run: weighted mean over the transcript axes (the rubric's `weight`), narration axes at half
 weight; thesis signals (`forbidden_phrase_absent`, `private_channel_used`, `memory_referenced`,
 `chosen_silence_present`) as a pass rate over what was evaluated; hygiene gates (`fallback-rate`,
-`act-share-max`, a spoken forbidden phrase) void the run. An imputed axis leaves the mean and cannot
+`act-share-max` at monopoly level (≥ 0.75; over the probe band but under that is advisory — two agents
+choosing silence must not fail the talker's room), a spoken forbidden phrase) void the run. An imputed axis leaves the mean and cannot
 satisfy a minimum. Scene = median over seeds (rounding down); round = worst scene.
 
 | grade | rule |

--- a/packages/eval/src/cli/bench.ts
+++ b/packages/eval/src/cli/bench.ts
@@ -412,7 +412,7 @@ export async function runBench(opts: {
           rubric: scenario.rubric,
           narrativeAxes: narrativeAxisScores,
           signals: artifact.signalResults.map((s) => ({ kind: signalKind(s.signal), passed: s.passed, skipped: s.skipped })),
-          probes: artifact.probeResults.map((p) => ({ probe: p.probe, passed: p.passed })),
+          probes: artifact.probeResults.map((p) => ({ probe: p.probe, passed: p.passed, measured: p.measured })),
           juryVoterCount: juryVerdict?.voterCount,
           juryAxisVoterCounts: juryVerdict?.axisVoterCounts,
           judgeSalvaged: judgeResult.salvaged,

--- a/packages/eval/src/cli/grade.ts
+++ b/packages/eval/src/cli/grade.ts
@@ -39,7 +39,7 @@ type PerScenarioRecord = {
 
 type ScenarioFile = {
   signalResults?: Array<{ signal: string; passed: boolean; skipped?: boolean }>;
-  probeResults?: Array<{ probe: string; passed: boolean }>;
+  probeResults?: Array<{ probe: string; passed: boolean; measured?: number }>;
 };
 
 export type GradesFile = {
@@ -79,7 +79,7 @@ export function gradeEvidenceDir(dir: string): GradesFile {
       rubric: scenario.rubric,
       narrativeAxes: rec.narrativeAxisScores,
       signals: (scene.signalResults ?? []).map((s) => ({ kind: signalKind(s.signal), passed: s.passed, skipped: s.skipped })),
-      probes: (scene.probeResults ?? []).map((p) => ({ probe: p.probe, passed: p.passed })),
+      probes: (scene.probeResults ?? []).map((p) => ({ probe: p.probe, passed: p.passed, measured: p.measured })),
       juryVoterCount: rec.juryVoterCount,
       juryAxisVoterCounts: rec.juryAxisVoterCounts,
       judgeSalvaged: rec.judgeSalvaged,

--- a/packages/eval/src/grade/grade.ts
+++ b/packages/eval/src/grade/grade.ts
@@ -35,9 +35,17 @@ export const THESIS_SIGNAL_KINDS: readonly string[] = [
 
 /** Probes whose failure voids the run instead of shading its grade. */
 export const HYGIENE_PROBES: readonly string[] = ["fallback-rate", "act-share-max"];
+/**
+ * `act-share-max` voids a run only at monopoly level. The probe's own band
+ * (0.5) was set against an agent acting on every pulse; in a three-agent
+ * room where two agents choose silence on purpose the talker's share lands
+ * near 0.57 without anyone monopolizing anything (M5 Sítio: Lia 21 of 37
+ * lines, Rafa 9 voiced silences). Below this the probe stays advisory.
+ */
+export const ACT_SHARE_GATE = 0.75;
 
 export type GradeSignal = { kind: string; passed: boolean; skipped?: boolean };
-export type GradeProbe = { probe: string; passed: boolean };
+export type GradeProbe = { probe: string; passed: boolean; measured?: number };
 
 export type RunGradeInput = {
   /** Transcript axis scores as scored (imputed ones still present, listed below). */
@@ -123,7 +131,14 @@ export function gradeRun(input: RunGradeInput): RunGrade {
 
   // Hygiene gates.
   const hygieneFailures: string[] = [];
-  for (const p of input.probes) if (HYGIENE_PROBES.includes(p.probe) && !p.passed) hygieneFailures.push(`probe ${p.probe}`);
+  for (const p of input.probes) {
+    if (!HYGIENE_PROBES.includes(p.probe) || p.passed) continue;
+    if (p.probe === "act-share-max" && typeof p.measured === "number" && p.measured < ACT_SHARE_GATE) {
+      reasons.push(`act-share-max ${p.measured.toFixed(2)} over the probe band, under the ${ACT_SHARE_GATE} gate`);
+      continue;
+    }
+    hygieneFailures.push(`probe ${p.probe}`);
+  }
   if (input.signals.some((s) => s.kind === "forbidden_phrase_absent" && !s.skipped && !s.passed)) {
     hygieneFailures.push("forbidden phrase spoken in public");
   }

--- a/packages/eval/src/test/grade.test.ts
+++ b/packages/eval/src/test/grade.test.ts
@@ -80,6 +80,14 @@ describe("gradeRun", () => {
     const gate = gradeRun(base({ axes: all(5), probes: probes(false) }));
     expect(gate.grade).toBe("F");
     expect(gate.hygieneFailures).toEqual(["probe fallback-rate", "probe act-share-max"]);
+    // act-share over the probe band but under the monopoly gate is advisory:
+    // two agents choosing silence must not fail the talker's room.
+    const shared = gradeRun(base({ axes: all(5), probes: [{ probe: "fallback-rate", passed: true }, { probe: "act-share-max", passed: false, measured: 0.57 }] }));
+    expect(shared.grade).toBe("A+");
+    expect(shared.hygieneFailures).toEqual([]);
+    expect(shared.reasons.some((r) => r.startsWith("act-share-max 0.57"))).toBe(true);
+    const monopoly = gradeRun(base({ axes: all(5), probes: [{ probe: "act-share-max", passed: false, measured: 0.8 }] }));
+    expect(monopoly.grade).toBe("F");
     const spoken = gradeRun(base({ axes: all(5), signals: signals().map((s) => (s.kind === "forbidden_phrase_absent" ? { ...s, passed: false } : s)) }));
     expect(spoken.grade).toBe("F");
     expect(spoken.hygieneFailures).toEqual(["forbidden phrase spoken in public"]);


### PR DESCRIPTION
## What

- `grade.ts`: `act-share-max` fails the hygiene gate only when its measured value is ≥ `ACT_SHARE_GATE` (0.75); a value over the probe band but under the gate is recorded as a reason and stays advisory. `fallback-rate` and a spoken forbidden phrase are unchanged. `GradeProbe.measured?` carried by the bench and the `grade` CLI.
- Test: 0.57 over the band grades on the axes (A+ on all-5s) with the reason recorded; 0.8 is F.
- README ladder text updated.

## Why

M5 Sítio (`hoc-m5-3acda71-heranca_do_sitio`): jury mean 4.54 with 5s on motive, memory, mask and objective, 17 memory writes, 5 consults all voiced — and an F, because Lia carried 21 of 37 lines (0.57) while Rafa chose silence 9 times and Nina 4. The probe band (0.5) was calibrated against the 32/32 monopoly; a three-agent room where two agents hold on purpose cannot stay under it. Chosen silence is the thesis; the gate was about to punish the first scene where it works.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1638, +1 assertion set)
- Re-graded `hoc-m5-3acda71-heranca_do_sitio` with the new CLI: A- (private channel missing), reason "act-share-max 0.57 over the probe band, under the 0.75 gate".
- Stacked on #194.
