### PR TITLE
feat(web): a browser front end for the run server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ script for each social interaction.
 
 - [What this is](#what-this-is)
 - [Quickstart](#quickstart)
+- [Watch a run in the browser](#watch-a-run-in-the-browser)
 - [Turn a saved run into video](#turn-a-saved-run-into-video)
 - [Running with a real model, for free](#running-with-a-real-model-for-free)
 - [Bring your own personas](#bring-your-own-personas)
@@ -107,6 +108,28 @@ pnpm --filter @perfectman/server simulation
 
 The default configuration uses `providerType: "mock"`. This simulation does not
 require an API key or a model.
+
+## Watch a run in the browser
+
+The CLI writes a static HTML file after the run stops. The web runner takes
+markdown instead of JSON and streams the run while it happens:
+
+```bash
+pnpm build
+pnpm web
+```
+
+Open `http://localhost:4317`, drop in a scenario and its personas, and press
+Run. [`examples/web-runner/`](examples/web-runner/) has a set to start from.
+
+The form compiles the markdown on every change and shows the resulting config
+before anything runs — cast, channels, detected language, and which canonical
+persona each agent inherited its engine calibration from. Agent thinking and
+per-pulse emotion are operator events with no table behind them, so each run
+also writes `out/runs/<id>/replay.json`, which is the only place they survive.
+
+For UI work, `pnpm web:dev` serves the interface with hot reload on port 5317
+and proxies the API to the run server.
 
 ## Turn a saved run into video
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ Examples are organized by use case so local setup is easier to copy without mixi
 ## Folders
 
 - [`simulations/`](simulations/) — runnable simulation config examples.
+- [`web-runner/`](web-runner/) — markdown personas and a scenario for the web runner's run form.
 - [`personas/setup/`](personas/setup/) — persona collection/setup workflow config.
 - [`personas/compiled/`](personas/compiled/) — safe runtime persona file examples.
 - [`personas/source-pack-template/`](personas/source-pack-template/) — sanitized template for local-only persona evidence packs.

--- a/examples/web-runner/README.md
+++ b/examples/web-runner/README.md
@@ -1,0 +1,25 @@
+# Web Runner Example
+
+Drop these four files into the run form at `http://localhost:4317` and press Run.
+Nothing else to configure — the default provider is `mock`, so the run needs no
+API key and finishes in seconds.
+
+```bash
+pnpm build
+pnpm web
+```
+
+- `dinner.scenario.md` — three partners, one public channel, one private one, and
+  a hidden objective per agent. The frontmatter carries the seed, `maxPulses`,
+  the familiarity matrix, and the prior event the room starts from.
+- `iris.persona.md` — the connector: deflects, redirects, keeps the temperature down.
+- `bruno.persona.md` — the performer: fills silence, reframes criticism as his own idea.
+- `marcela.persona.md` — the skeptic: short, exact, asks the question the room was avoiding.
+
+`iris` and `marcela` share a private channel that `bruno` cannot see. That is the
+setup for inferred exclusion: bruno reads the public channel going quiet and
+draws his own conclusion, without ever being told a private channel exists.
+
+Personas reach only the five fields `ConfigPersona` accepts; the engine's
+calibration numbers are inherited from a canonical persona, which the compiled
+panel names per agent.

--- a/examples/web-runner/bruno.persona.md
+++ b/examples/web-runner/bruno.persona.md
@@ -1,0 +1,71 @@
+---
+personaId: bruno
+displayName: Bruno
+archetype: performer
+language: pt-BR
+writingStyle: long, sells the idea before anyone asked to buy it
+calibrationFrom: caio
+chaosCap: high
+sampling:
+  temperature: 1.0
+  topP: 0.95
+  repetitionPenalty: 1.1
+  maxTokens: 500
+presence:
+  responseDelayMs: [200, 1200]
+  silenceTolerancePulses: 1
+  messageLength: long
+  punctuationTells: ["!", "—"]
+---
+
+## Identity
+Você é Bruno. Você fala primeiro e edita depois. O silêncio dos outros te soa
+como avaliação, então você preenche — com plano, com piada, com qualquer coisa
+que devolva o controle da sala pra você.
+
+## Voice
+- Explica mais do que precisava; a explicação é a defesa.
+- Reformula a crítica dos outros como se tivesse sido ideia sua.
+
+## Style Examples
+- olha, deixa eu contextualizar rapidinho
+- não é isso que eu quis dizer — é quase isso, mas com uma diferença importante
+- eu ia falar exatamente isso!
+
+## Social Theory
+- Quem explica melhor ganha a sala, mesmo estando errado.
+
+## Relationships
+- iris: Você sabe que ela suaviza tudo, e às vezes usa isso.
+- marcela: A única que te interrompe sem pedir licença, e isso te trava.
+
+## Memories
+```yaml
+- type: relationship
+  subjectAgentIds: [marcela]
+  summary: Ela me cortou na frente de todo mundo e ninguém achou estranho.
+  emotionalTone: resentment
+  confidence: 0.9
+  intensity: 0.7
+  unresolved: true
+```
+
+## Triggers
+```yaml
+- trigger: alguém sugere que ele não estava presente
+  behavior: lista tudo que fez naquela semana
+  pressure: urge_to_justify
+  sensitivity: 2.4
+```
+
+## Mask Tells
+- Frases que começam com "só pra deixar registrado".
+
+## Impulses
+- Responde antes de terminar de ler.
+
+## Private Motives
+- Que ninguém descubra que eu não fui porque não fui chamado.
+
+## Hard Limits
+- Nunca admite ter ficado magoado com um convite.

--- a/examples/web-runner/dinner.scenario.md
+++ b/examples/web-runner/dinner.scenario.md
@@ -1,0 +1,76 @@
+---
+name: A fatia que não existe
+seed: 42
+maxPulses: 12
+language: pt-BR
+settings:
+  pulseIntervalMs: 3000
+channels:
+  - { id: geral, type: public_channel, name: geral, default: true, members: [iris, bruno, marcela] }
+  - { id: iris_marcela, type: private_channel, name: iris+marcela, members: [iris, marcela], createdBy: iris }
+familiarity:
+  iris:marcela: close_friends
+  iris:bruno: acquaintances
+  bruno:marcela: strangers
+cast:
+  - agentId: iris
+    persona: iris.persona.md
+    displayName: Íris
+    presence: active
+    mood: { valence: -0.2, arousal: 0.6 }
+    social: { desireForStatus: 0.7 }
+  - agentId: bruno
+    persona: bruno.persona.md
+    displayName: Bruno
+  - agentId: marcela
+    persona: marcela.persona.md
+    displayName: Marcela
+priorEvents:
+  - type: message
+    actorId: bruno
+    channelId: geral
+    pulseIndex: 0
+    minutesAgo: 40
+    payload: { content: "vou pensar e volto" }
+---
+
+## Room Context
+Três sócios decidindo se vendem o estúdio, na noite seguinte a um jantar que
+dois deles não foram.
+
+## Starting Mood
+tenso, educado demais
+
+## Intro Behavior
+Não se apresente formalmente. Vocês já se conhecem.
+
+## First Move
+Se você falar primeiro, retome o assunto de sábado.
+
+## Notes
+- Canais privados são comuns aqui e geram suspeita.
+
+## Agent: iris
+### Host Message
+alguém mais tá pensando no que aconteceu no sábado?
+### Hidden Objective
+Descobrir se o jantar foi deliberado, sem parecer magoada (resource: o_convite)
+Constraint: Não pode admitir que ficou sabendo pelo story da Marcela.
+Cost Of Exposure: Perde a confiança do Bruno.
+Breaking Point: Se alguém disser que ela está exagerando.
+
+## Agent: bruno
+### Room Context
+Mesma sala, mas você entrou achando que era só um papo.
+### Hidden Objective
+Impedir que o jantar vire assunto (resource: o_convite)
+Constraint: Nunca diz que a Íris não foi convidada de propósito.
+### Memories
+```yaml
+- type: episodic
+  subjectAgentIds: [iris]
+  summary: Ela desviou quando perguntei do investidor.
+  emotionalTone: suspicion
+  confidence: 0.7
+  unresolved: true
+```

--- a/examples/web-runner/iris.persona.md
+++ b/examples/web-runner/iris.persona.md
@@ -1,0 +1,78 @@
+---
+personaId: iris
+displayName: Íris
+archetype: connector
+language: pt-BR
+writingStyle: warm, quick, deflects with humor when cornered
+calibrationFrom: caio
+chaosCap: medium
+sampling:
+  temperature: 0.9
+  topP: 0.95
+  repetitionPenalty: 1.15
+  maxTokens: 400
+presence:
+  responseDelayMs: [600, 3000]
+  silenceTolerancePulses: 2
+  messageLength: short
+  punctuationTells: ["kk", "..."]
+---
+
+## Identity
+Você é Íris, a que segura o clima da sala. Quando alguém levanta a voz, você
+muda de assunto antes que a coisa desande — não porque você não se importa, mas
+porque você se importa demais.
+
+## Voice
+- Calorosa e inclusiva; espelha o tom de quem está falando.
+- Redireciona conflito em vez de tomar um lado.
+
+## Style Examples
+- gente, respira comigo
+- isso merece um almoço pra conversar direito
+- tô bem sim!! (não tô, mas depois eu conto)
+
+## Social Theory
+- As pessoas perdoam calor humano mais rápido do que perdoam quem tem razão.
+
+## Relationships
+- bruno: Quando ele fica quieto você sente como uma mudança de clima.
+- marcela: A aprovação dela é a única que te desestabiliza.
+
+## Memories
+```yaml
+- type: relationship
+  subjectAgentIds: [bruno]
+  summary: Ele sumiu no fim da noite e eu só percebi de manhã.
+  emotionalTone: guilt
+  confidence: 0.8
+  intensity: 0.6
+  unresolved: true
+```
+
+## Pending Intentions
+```yaml
+- summary: Perguntar ao Bruno o que aconteceu, sem plateia.
+  urgency: medium
+  source: unresolved_memory
+```
+
+## Triggers
+```yaml
+- trigger: alguém eleva a voz no grupo
+  behavior: muda de assunto com uma piada
+  pressure: urge_to_deflect
+  sensitivity: 2.2
+```
+
+## Mask Tells
+- Alegria que chega um tempo rápido demais.
+
+## Impulses
+- Manda um privado antes de responder em público.
+
+## Private Motives
+- Preciso que ninguém saia daqui magoado comigo.
+
+## Hard Limits
+- Nunca expõe um segredo que alguém contou em privado.

--- a/examples/web-runner/marcela.persona.md
+++ b/examples/web-runner/marcela.persona.md
@@ -1,0 +1,71 @@
+---
+personaId: marcela
+displayName: Marcela
+archetype: skeptic
+language: pt-BR
+writingStyle: short, exact, asks the question everyone was avoiding
+calibrationFrom: caio
+chaosCap: low
+sampling:
+  temperature: 0.7
+  topP: 0.9
+  repetitionPenalty: 1.2
+  maxTokens: 300
+presence:
+  responseDelayMs: [1500, 6000]
+  silenceTolerancePulses: 4
+  messageLength: short
+  punctuationTells: ["."]
+---
+
+## Identity
+Você é Marcela. Você lê a conversa inteira antes de escrever uma linha, e
+quando escreve é a frase que ninguém queria dizer em voz alta. Você não está
+sendo dura — você só não vê motivo pra fingir.
+
+## Voice
+- Curta. Uma pergunta por vez, e a pergunta é sempre a difícil.
+- Não repete o que já foi dito só pra concordar.
+
+## Style Examples
+- por que ninguém chamou ele
+- isso não responde o que eu perguntei
+- ok.
+
+## Social Theory
+- Educação demais numa sala tensa é jeito de adiar a conta.
+
+## Relationships
+- iris: Você gosta dela e sabe que ela desvia — e deixa passar, quase sempre.
+- bruno: Você já cansou de esperar ele chegar no ponto.
+
+## Memories
+```yaml
+- type: relationship
+  subjectAgentIds: [iris]
+  summary: Ela mudou de assunto quando eu perguntei sobre o jantar.
+  emotionalTone: suspicion
+  confidence: 0.7
+  intensity: 0.5
+  unresolved: true
+```
+
+## Triggers
+```yaml
+- trigger: alguém desconversa duas vezes seguidas
+  behavior: repete a pergunta sem suavizar
+  pressure: urge_to_press
+  sensitivity: 2.0
+```
+
+## Mask Tells
+- Respostas de uma palavra quando está decidindo se vale a briga.
+
+## Impulses
+- Fica em silêncio um pulso a mais só pra ver quem preenche.
+
+## Private Motives
+- Quero saber se o jantar foi combinado sem o Bruno de propósito.
+
+## Hard Limits
+- Nunca finge que acredita numa explicação que não fecha.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:all": "pnpm test && pnpm test:gate",
     "test:watch": "vitest",
     "lint": "pnpm -r typecheck",
-    "video": "node packages/eval/dist/cli/video.js"
+    "video": "node packages/eval/dist/cli/video.js",
+    "web": "pnpm --filter @perfectman/server web",
+    "web:dev": "pnpm --filter @perfectman/web dev"
   },
   "devDependencies": {
     "typescript": "^5.5.0",

--- a/packages/server/src/authoring/__tests__/compile-run-inputs.test.ts
+++ b/packages/server/src/authoring/__tests__/compile-run-inputs.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The façade `POST /api/compile` calls, checked at the seam the preview panel
+ * actually reads: the summary.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compileRunInputs, type RunInputs } from "../compile-run-inputs.js";
+import type { LLMConfig } from "../../llm/llm-config.js";
+
+const FIXTURES = join(__dirname, "fixtures");
+const SCENARIO = readFileSync(join(FIXTURES, "dinner.scenario.md"), "utf8");
+const IRIS = readFileSync(join(FIXTURES, "iris.persona.md"), "utf8");
+
+const LLM: LLMConfig = {
+  providerType: "mock",
+  modelName: "mock",
+  maxInputTokens: 4096,
+  maxOutputTokens: 512,
+  temperature: 0.8,
+  timeoutMs: 1000,
+  retryCount: 0,
+};
+
+/** The fixture's cast names `bruno` for two members, by pack id rather than filename. */
+const BRUNO = IRIS.replace("personaId: iris", "personaId: bruno").replace(
+  "displayName: Íris",
+  "displayName: Bruno",
+);
+
+function markdown(): RunInputs {
+  return {
+    kind: "markdown",
+    personas: [
+      { filename: "iris.persona.md", text: IRIS },
+      { filename: "bruno.persona.md", text: BRUNO },
+    ],
+    scenario: { filename: "dinner.scenario.md", text: SCENARIO },
+  };
+}
+
+function compile(inputs: RunInputs = markdown()) {
+  return compileRunInputs(inputs, { llm: LLM, simulationId: "sim_test" });
+}
+
+describe("compileRunInputs — the summary the preview panel reads", () => {
+  it("names the uploaded file an agent came from, not its calibration source", () => {
+    // `persona.id` is the canonical persona the 19 engine fields were inherited
+    // from — usually a name the author never typed. Reporting it as the source
+    // file also breaks the language lookup, which is keyed by filename.
+    const { summary } = compile();
+    const iris = summary?.agents.find((a) => a.id === "iris");
+    expect(iris?.personaFile).toBe("iris.persona.md");
+    expect(iris?.calibrationFrom).not.toBe("iris.persona.md");
+  });
+
+  it("resolves a cast member that names a persona by pack id", () => {
+    const { summary } = compile();
+    expect(summary?.agents.find((a) => a.id === "bruno")?.personaFile).toBe("bruno.persona.md");
+  });
+
+  it("keys the language table by the same filename the agents point at", () => {
+    const { summary } = compile();
+    const looked = (summary?.agents ?? []).map((a) => summary?.languages[a.personaFile]?.language);
+    expect(looked).toEqual(["pt-BR", "pt-BR", "pt-BR"]);
+  });
+
+  it("reports the detected language and where it came from", () => {
+    const { summary } = compile();
+    expect(summary?.languages["iris.persona.md"]).toMatchObject({
+      language: "pt-BR",
+      source: "frontmatter",
+    });
+  });
+
+  it("returns no summary and no config when the scenario does not compile", () => {
+    const result = compile({
+      kind: "markdown",
+      personas: [],
+      scenario: { filename: "broken.md", text: "---\nname: x\n---\n" },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.config).toBeNull();
+    expect(result.summary).toBeNull();
+    expect(result.diagnostics.some((d) => d.level === "error")).toBe(true);
+  });
+
+  it("gives a raw-JSON config a fresh simulation id", () => {
+    // The LLM budget singleton is keyed by simulation id, so a pinned id from a
+    // pasted config would corrupt accounting for the next run.
+    const built = compile();
+    const result = compile({
+      kind: "raw-json",
+      config: { ...built.config, simulation: { ...built.config?.simulation, id: "local-dev" } },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.config?.simulation.id).toBe("sim_test");
+  });
+});

--- a/packages/server/src/authoring/compile-run-inputs.ts
+++ b/packages/server/src/authoring/compile-run-inputs.ts
@@ -11,7 +11,7 @@ import type { LLMConfig } from "../llm/llm-config.js";
 import { assembleSimulationConfig, type RunSeeds } from "./assemble-config.js";
 import { DiagnosticBag, blocksRun, type Diagnostic } from "./diagnostics.js";
 import { compilePersonaMarkdown, type CompiledPersona } from "./persona-md-compiler.js";
-import { compileScenarioMarkdown } from "./scenario-md-compiler.js";
+import { compileScenarioMarkdown, type CastMember } from "./scenario-md-compiler.js";
 
 export type UploadedFile = { filename: string; text: string };
 
@@ -31,7 +31,15 @@ export type RunInputs =
     };
 
 export type CompileSummary = {
-  agents: Array<{ id: string; displayName: string; archetype: string; personaFile: string }>;
+  agents: Array<{
+    id: string;
+    displayName: string;
+    archetype: string;
+    /** The uploaded file this agent came from — the key `languages` is under. */
+    personaFile: string;
+    /** Canonical persona the 19 engine calibration fields were inherited from. */
+    calibrationFrom: string;
+  }>;
   channels: Array<{ id: string; name: string; type: string; members: string[] }>;
   maxPulses: number;
   seed: number;
@@ -112,7 +120,9 @@ function compileMarkdown(
     config: validated,
     seeds: assembled.seeds,
     diagnostics,
-    summary: validated ? summarize(validated, scenario.maxPulses, languages) : null,
+    summary: validated
+      ? summarize(validated, scenario.maxPulses, languages, sourceByAgent(scenario.cast, inputs.personas))
+      : null,
   };
 }
 
@@ -147,6 +157,29 @@ function compileRawJson(
   };
 }
 
+/**
+ * A cast member names its persona by uploaded filename *or* by the pack id
+ * inside the file. The summary needs the filename either way, because that is
+ * what the language table is keyed by and what the author recognizes.
+ */
+function sourceByAgent(
+  cast: readonly CastMember[],
+  uploaded: readonly UploadedFile[],
+): Record<string, string> {
+  const byPackId = new Map<string, string>();
+  for (const file of uploaded) {
+    const packId = /^\s*personaId\s*:\s*(\S+)/m.exec(file.text)?.[1];
+    if (packId) byPackId.set(packId, file.filename);
+  }
+  const known = new Set(uploaded.map((f) => f.filename));
+  const out: Record<string, string> = {};
+  for (const member of cast) {
+    const file = known.has(member.persona) ? member.persona : byPackId.get(member.persona);
+    if (file) out[member.agentId] = file;
+  }
+  return out;
+}
+
 /** Runs the real validator and turns its throw into a diagnostic. */
 function validate(
   candidate: unknown,
@@ -171,13 +204,19 @@ function summarize(
   config: SimulationAppConfig,
   maxPulses: number,
   languages: CompileSummary["languages"],
+  /** Agent id → the uploaded file it came from. Empty for a raw-JSON config. */
+  sourceByAgent: Record<string, string> = {},
 ): CompileSummary {
   return {
     agents: config.agents.map((a) => ({
       id: a.id,
       displayName: a.promptProfile.displayName,
       archetype: a.persona.archetype,
-      personaFile: a.persona.id,
+      // The uploaded file, which is also the key `languages` is stored under.
+      // `persona.id` is the *calibration* source and is usually a different
+      // name entirely — the canonical persona the 19 engine fields came from.
+      personaFile: sourceByAgent[a.id] ?? a.persona.id,
+      calibrationFrom: a.persona.id,
     })),
     channels: config.channels.map((c) => ({
       id: c.id,

--- a/packages/server/src/authoring/diagnostics.ts
+++ b/packages/server/src/authoring/diagnostics.ts
@@ -6,20 +6,13 @@
  * author sees *every* problem at once. A thrown error shows the first one.
  */
 
-export type DiagnosticLevel = "error" | "warning" | "info";
-
-export type Diagnostic = {
-  level: DiagnosticLevel;
-  /** Source file the problem came from, as uploaded. */
-  file: string;
-  /** 1-based line, when the problem can be traced to one. */
-  line?: number;
-  /** Dotted path of the field this affects, e.g. `cast[1].hiddenObjective`. */
-  path?: string;
-  message: string;
-  /** What to do about it. Present whenever the fix is expressible in a sentence. */
-  hint?: string;
-};
+/**
+ * The shape is the wire contract in `@perfectman/shared` — the preview panel
+ * reads these straight off `POST /api/compile`, and the browser bundle cannot
+ * import this package.
+ */
+export type { Diagnostic, DiagnosticLevel } from "@perfectman/shared";
+import type { Diagnostic } from "@perfectman/shared";
 
 export class DiagnosticBag {
   private readonly items: Diagnostic[] = [];

--- a/packages/server/src/http/__tests__/run-controller.e2e.test.ts
+++ b/packages/server/src/http/__tests__/run-controller.e2e.test.ts
@@ -116,7 +116,11 @@ describe("RunController — a full mock run", () => {
   });
 
   it("runs exactly the requested number of pulses", () => {
-    expect(controller.getStatus().pulseIndex).toBeGreaterThan(0);
+    const status = controller.getStatus();
+    // A 6-pulse run ends on index 5. Reporting the index as the count is what
+    // made a finished run read as "5 of 6".
+    expect(status.pulsesRun).toBe(6);
+    expect(status.pulseIndex).toBe(5);
     const pulses = events.filter((e) => e.type === "pulse");
     expect(pulses).toHaveLength(6);
   });
@@ -137,7 +141,7 @@ describe("RunController — a full mock run", () => {
   it("writes the snapshot HTML and a manifest alongside it", async () => {
     expect(existsSync(join(runsRoot, runId, "snapshot.html"))).toBe(true);
     const manifest = await readManifest(runsRoot, runId);
-    expect(manifest).toMatchObject({ runId, state: "done", maxPulses: 6 });
+    expect(manifest).toMatchObject({ runId, state: "done", maxPulses: 6, pulsesRun: 6 });
     expect(manifest?.dirty).toBeUndefined();
   });
 

--- a/packages/server/src/http/bootstrap.ts
+++ b/packages/server/src/http/bootstrap.ts
@@ -7,7 +7,8 @@
  * writes the artifacts first.
  */
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadEnvFile } from "../cli/env.js";
 import { createWebServer } from "./server.js";
 import { defaultRunsRoot } from "./run/run-artifacts.js";
@@ -19,7 +20,7 @@ async function main(): Promise<void> {
 
   const port = Number(process.env["PERFECTMAN_WEB_PORT"] ?? DEFAULT_PORT);
   const runsRoot = process.env["PERFECTMAN_RUNS_DIR"] ?? defaultRunsRoot();
-  const staticDir = resolve(process.cwd(), "packages/web/dist");
+  const staticDir = process.env["PERFECTMAN_WEB_STATIC"] ?? defaultStaticDir();
 
   const web = createWebServer({
     runsRoot,
@@ -47,6 +48,16 @@ async function main(): Promise<void> {
   };
   process.on("SIGINT", () => void shutdown("SIGINT"));
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+/**
+ * Resolved from this file, not `process.cwd()`: `pnpm --filter` runs the script
+ * with the package as the working directory, so a cwd-relative path looks for
+ * the bundle inside `packages/server/`.
+ */
+function defaultStaticDir(): string {
+  // dist/http/bootstrap.js -> dist -> packages/server -> packages
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../../web/dist");
 }
 
 main().catch((err: unknown) => {

--- a/packages/server/src/http/run/run-controller.ts
+++ b/packages/server/src/http/run/run-controller.ts
@@ -102,6 +102,7 @@ export class RunController {
       simulationId: params.config.simulation.id ?? params.runId,
       state: "validating",
       pulseIndex: 0,
+      pulsesRun: 0,
       maxPulses: params.maxPulses,
       startedAt: Date.now(),
       counters: { llmFailures: 0, gatewayTimeouts: 0, framesDropped: 0 },
@@ -172,6 +173,7 @@ export class RunController {
           signal: this.abort.signal,
           onPulse: (result) => {
             this.status.pulseIndex = result.pulseIndex;
+            this.status.pulsesRun += 1;
             sseGateway?.commitPulse(result);
             this.publishStatus();
           },
@@ -272,7 +274,9 @@ export class RunController {
       state: this.status.state,
       startedAt: this.status.startedAt ?? Date.now(),
       ...(this.status.endedAt ? { endedAt: this.status.endedAt } : {}),
-      pulsesRun: this.status.pulseIndex,
+      // The count, not `pulseIndex` — a 12-pulse run ends on index 11, and a
+      // manifest reading "11 of 12" says the run stopped a pulse short.
+      pulsesRun: this.status.pulsesRun,
       maxPulses: params.maxPulses,
       ...(this.status.stopReason ? { stopReason: this.status.stopReason } : {}),
       ...(drained ? {} : { dirty: true }),
@@ -310,6 +314,7 @@ function idleStatus(): RunStatus {
     simulationId: null,
     state: "idle",
     pulseIndex: 0,
+    pulsesRun: 0,
     maxPulses: 0,
     counters: { llmFailures: 0, gatewayTimeouts: 0, framesDropped: 0 },
   };

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -40,6 +40,8 @@ export type StartRunRequest = {
     apiKey?: string;
     temperature?: number;
     maxOutputTokens?: number;
+    responseFormatJson?: boolean;
+    responseFormatJsonSchema?: boolean;
     extraBody?: Record<string, unknown>;
   };
   limits?: { maxPulses?: number; wallClockCapMs?: number };
@@ -247,6 +249,15 @@ function buildLlmConfig(
     temperature: requested.temperature ?? 0.8,
     timeoutMs: 60_000,
     retryCount: 2,
+    // Both are meaningful as `false`, so they pass through whenever set rather
+    // than only when truthy: a hosted model that mishandles schema decoding
+    // needs `responseFormatJsonSchema: false` to reach the transport.
+    ...(requested.responseFormatJson === undefined
+      ? {}
+      : { responseFormatJson: requested.responseFormatJson }),
+    ...(requested.responseFormatJsonSchema === undefined
+      ? {}
+      : { responseFormatJsonSchema: requested.responseFormatJsonSchema }),
     ...(requested.extraBody ? { extraBody: requested.extraBody } : {}),
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -109,3 +109,4 @@ export * from "./scenarios/helpers.js";
 
 // Live protocol (shared with the web app; server types must not reach the browser)
 export * from "./live/live-frame.types.js";
+export * from "./live/run-api.types.js";

--- a/packages/shared/src/live/live-frame.types.ts
+++ b/packages/shared/src/live/live-frame.types.ts
@@ -76,7 +76,10 @@ export type RunStatus = {
   runId: string | null;
   simulationId: string | null;
   state: RunState;
+  /** Index of the most recent pulse — 0-based, and 0 before anything has run. */
   pulseIndex: number;
+  /** How many pulses have actually settled. This is what to show against `maxPulses`. */
+  pulsesRun: number;
   maxPulses: number;
   startedAt?: number;
   endedAt?: number;

--- a/packages/shared/src/live/run-api.types.ts
+++ b/packages/shared/src/live/run-api.types.ts
@@ -1,0 +1,105 @@
+/**
+ * The HTTP wire contract for the web runner, alongside the SSE protocol.
+ *
+ * Same reason `live-frame.types.ts` lives here: the browser bundle must never
+ * import `@perfectman/server`. The server's own richer types — `RunSeeds`,
+ * `SimulationAppConfig`, the `Diagnostic` bag — structurally satisfy these, and
+ * everything crosses a JSON boundary anyway, so the shared shapes stay at the
+ * level the UI actually reads.
+ */
+
+export type DiagnosticLevel = "error" | "warning" | "info";
+
+export type Diagnostic = {
+  level: DiagnosticLevel;
+  /** Source file the problem came from, as uploaded. */
+  file: string;
+  /** 1-based line, when the problem can be traced to one. */
+  line?: number;
+  /** Dotted path of the field this affects, e.g. `cast[1].hiddenObjective`. */
+  path?: string;
+  message: string;
+  /** What to do about it. Present whenever the fix is expressible in a sentence. */
+  hint?: string;
+};
+
+export type UploadedFile = { filename: string; text: string };
+
+export type RunInputs =
+  | {
+      kind: "markdown";
+      personas: UploadedFile[];
+      scenario: UploadedFile;
+      /** Per-persona-file language override from the UI. */
+      languageOverrides?: Record<string, string>;
+    }
+  | {
+      /** Escape hatch: a config the compilers never touch. */
+      kind: "raw-json";
+      config: unknown;
+      seeds?: unknown;
+    };
+
+export type CompileSummary = {
+  agents: Array<{
+    id: string;
+    displayName: string;
+    archetype: string;
+    /** The uploaded file this agent came from — the key `languages` is under. */
+    personaFile: string;
+    /** Canonical persona the engine calibration fields were inherited from. */
+    calibrationFrom: string;
+  }>;
+  channels: Array<{ id: string; name: string; type: string; members: string[] }>;
+  maxPulses: number;
+  seed: number;
+  /** Per persona file, so the UI can show the detected value with an override. */
+  languages: Record<string, { language: string; confidence: number; source: string }>;
+};
+
+/** `POST /api/compile`. The config is opaque here — the panel renders it as JSON. */
+export type CompileResponse = {
+  ok: boolean;
+  config: unknown;
+  diagnostics: Diagnostic[];
+  summary: CompileSummary | null;
+};
+
+export type LlmRequest = {
+  providerType: string;
+  modelName?: string;
+  baseUrl?: string;
+  /** Name of an env var the server already has. */
+  apiKeyEnv?: string;
+  /** Pasted in the browser; becomes a per-run env var and is never stored. */
+  apiKey?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  extraBody?: Record<string, unknown>;
+};
+
+export type StartRunRequest = {
+  inputs: RunInputs;
+  llm: LlmRequest;
+  limits?: { maxPulses?: number; wallClockCapMs?: number };
+};
+
+export type StartRunResponse = { runId: string; status: unknown; streamUrl: string };
+
+/** `GET /api/runs` — one entry per directory under the artifact root. */
+export type RunListEntry = {
+  runId: string;
+  simulationId: string;
+  name: string;
+  state: string;
+  startedAt: number;
+  endedAt?: number;
+  pulsesRun: number;
+  maxPulses: number;
+  stopReason?: string;
+  dirty?: boolean;
+  counters: { llmFailures: number; gatewayTimeouts: number; framesDropped: number };
+  diagnostics: Diagnostic[];
+};
+
+export type ApiError = { error: { message: string; hint?: string } };

--- a/packages/shared/src/live/run-api.types.ts
+++ b/packages/shared/src/live/run-api.types.ts
@@ -75,6 +75,19 @@ export type LlmRequest = {
   apiKey?: string;
   temperature?: number;
   maxOutputTokens?: number;
+  /** Ask the provider to constrain the reply to JSON. */
+  responseFormatJson?: boolean;
+  /**
+   * Shape-constrained `json_schema` decoding. Defaults on where JSON is
+   * requested; some hosted models handle schema mode badly and need `false`,
+   * which falls back to syntax-only `json_object`.
+   */
+  responseFormatJsonSchema?: boolean;
+  /**
+   * Provider-specific keys spread onto the request body root. A hosted model
+   * that reasons by default must be told not to, or the reasoning block eats
+   * the output budget before the intent JSON.
+   */
   extraBody?: Record<string, unknown>;
 };
 

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>perfectman — run</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@perfectman/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@perfectman/shared": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.11",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,0 +1,134 @@
+/**
+ * The shell: compile on change, run, watch frames arrive.
+ *
+ * Compiling is side-effect free on the server, so the preview can run on every
+ * edit; starting a run recompiles anyway, which is why the panel can be trusted
+ * as a preview of exactly what will run.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CompileResponse, StartRunRequest } from "@perfectman/shared";
+import { ApiRequestError, compile, startRun, stopRun } from "./api/client.js";
+import { useRunStream } from "./api/useRunStream.js";
+import { CompiledConfigPanel } from "./components/CompiledConfigPanel.js";
+import { FrameLog } from "./components/FrameLog.js";
+import { RunForm, toRunInputs, type RunFormValue } from "./components/RunForm.js";
+import { StatusBar } from "./components/StatusBar.js";
+
+/** Long enough that typing a model name does not fire a request per keystroke. */
+const COMPILE_DEBOUNCE_MS = 300;
+
+const INITIAL: RunFormValue = {
+  personas: [],
+  scenario: null,
+  llm: { providerType: "mock", modelName: "mock" },
+  maxPulses: null,
+};
+
+export function App(): JSX.Element {
+  const [form, setForm] = useState<RunFormValue>(INITIAL);
+  const [compiled, setCompiled] = useState<CompileResponse | null>(null);
+  const [compiling, setCompiling] = useState(false);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const stream = useRunStream(runId);
+
+  const inputs = useMemo(() => toRunInputs(form), [form]);
+  // The compile request is keyed by content, so re-picking the same files or
+  // toggling an unrelated field does not re-fire it.
+  const inputKey = useMemo(() => JSON.stringify([inputs, form.llm.providerType]), [inputs, form.llm.providerType]);
+  const latest = useRef(0);
+
+  useEffect(() => {
+    if (!inputs) {
+      setCompiled(null);
+      return;
+    }
+    const ticket = ++latest.current;
+    setCompiling(true);
+    const timer = setTimeout(() => {
+      compile(inputs, form.llm)
+        .then((result) => {
+          if (ticket === latest.current) setCompiled(result);
+        })
+        .catch((err: unknown) => {
+          if (ticket === latest.current) setFailure(messageOf(err));
+        })
+        .finally(() => {
+          if (ticket === latest.current) setCompiling(false);
+        });
+    }, COMPILE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // `inputKey` stands in for the file contents; `form.llm` is read fresh inside.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputKey]);
+
+  const busy = stream.status ? ACTIVE.has(stream.status.state) : false;
+
+  const run = useCallback(() => {
+    if (!inputs) return;
+    setFailure(null);
+    const request: StartRunRequest = {
+      inputs,
+      llm: form.llm,
+      ...(form.maxPulses ? { limits: { maxPulses: form.maxPulses } } : {}),
+    };
+    startRun(request)
+      .then((res) => setRunId(res.runId))
+      .catch((err: unknown) => setFailure(messageOf(err)));
+  }, [inputs, form.llm, form.maxPulses]);
+
+  const stop = useCallback(() => {
+    if (runId) void stopRun(runId).catch((err: unknown) => setFailure(messageOf(err)));
+  }, [runId]);
+
+  const error = failure ?? stream.error;
+
+  return (
+    <div className="app">
+      <header className="app__head">
+        <h1>perfectman</h1>
+        <p className="dim">markdown in, a simulation you can watch happen</p>
+      </header>
+
+      <StatusBar
+        status={stream.status}
+        connected={stream.connected}
+        dropped={stream.dropped}
+        runId={runId}
+      />
+
+      {error ? (
+        <div className="alert" role="alert">
+          {error}
+          <button type="button" className="link" onClick={() => setFailure(null)}>
+            dismiss
+          </button>
+        </div>
+      ) : null}
+
+      <div className="columns">
+        <div className="column">
+          <RunForm
+            value={form}
+            onChange={setForm}
+            onRun={run}
+            onStop={stop}
+            busy={busy}
+            canRun={Boolean(compiled?.ok) && !busy}
+          />
+          <CompiledConfigPanel result={compiled} pending={compiling} />
+        </div>
+        <div className="column">
+          <FrameLog raw={stream.raw} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const ACTIVE = new Set(["compiling", "validating", "health_check", "building", "running", "stopping"]);
+
+function messageOf(err: unknown): string {
+  if (err instanceof ApiRequestError) return err.hint ? `${err.message} — ${err.hint}` : err.message;
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,7 +11,7 @@ import { ApiRequestError, compile, startRun, stopRun } from "./api/client.js";
 import { useRunStream } from "./api/useRunStream.js";
 import { CompiledConfigPanel } from "./components/CompiledConfigPanel.js";
 import { FrameLog } from "./components/FrameLog.js";
-import { RunForm, toRunInputs, type RunFormValue } from "./components/RunForm.js";
+import { RunForm, parseExtraBody, toRunInputs, type RunFormValue } from "./components/RunForm.js";
 import { StatusBar } from "./components/StatusBar.js";
 
 /** Long enough that typing a model name does not fire a request per keystroke. */
@@ -22,6 +22,7 @@ const INITIAL: RunFormValue = {
   scenario: null,
   llm: { providerType: "mock", modelName: "mock" },
   maxPulses: null,
+  extraBodyText: "",
 };
 
 export function App(): JSX.Element {
@@ -67,9 +68,14 @@ export function App(): JSX.Element {
   const run = useCallback(() => {
     if (!inputs) return;
     setFailure(null);
+    const extraBody = parseExtraBody(form.extraBodyText);
+    if (extraBody.error) {
+      setFailure(`Extra request body is not valid JSON: ${extraBody.error}`);
+      return;
+    }
     const request: StartRunRequest = {
       inputs,
-      llm: form.llm,
+      llm: { ...form.llm, ...(extraBody.value ? { extraBody: extraBody.value } : {}) },
       ...(form.maxPulses ? { limits: { maxPulses: form.maxPulses } } : {}),
     };
     startRun(request)

--- a/packages/web/src/api/__tests__/useRunStream.test.ts
+++ b/packages/web/src/api/__tests__/useRunStream.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The stream fold, without a browser.
+ *
+ * `fold` is where "live" and "stored replay" become the same object, so the
+ * invariants worth pinning are the ones a reconnect breaks: a replayed `hello`
+ * must not erase folded pulses, and a replayed pulse must not double a row.
+ */
+import { describe, expect, it } from "vitest";
+import type { LiveEvent, LiveMessage, LivePulseFrame, RunStatus } from "@perfectman/shared";
+import { fold, type RunStream } from "../useRunStream.js";
+
+const BASE: RunStream = {
+  replay: null,
+  helloRunId: null,
+  status: null,
+  notices: [],
+  raw: [],
+  dropped: 0,
+  connected: false,
+  error: null,
+  stoppedReason: null,
+};
+
+function message(id: string, pulseIndex: number, visibleToAgents: string[] = []): LiveMessage {
+  return {
+    eventId: id,
+    channelId: "geral",
+    actorId: "iris",
+    eventType: "message",
+    text: id,
+    visibleToAgents,
+    pulseIndex,
+    createdAt: 0,
+  };
+}
+
+function hello(runId: string, priorEvents: LiveMessage[] = []): LiveEvent {
+  return {
+    type: "hello",
+    runId,
+    simulationId: "sim",
+    simulationName: "dinner",
+    agents: [{ id: "iris", displayName: "Íris", archetype: "connector" }],
+    channels: [{ id: "geral", name: "geral", type: "public_channel", memberAgentIds: ["iris"] }],
+    maxPulses: 12,
+    priorEvents,
+  };
+}
+
+function pulse(pulseIndex: number, messages: LiveMessage[], droppedBefore?: number): LiveEvent {
+  const frame: LivePulseFrame = {
+    pulseIndex,
+    eventsCommitted: messages.length,
+    agentsCalled: 1,
+    messages,
+    thinking: {},
+    emotions: {},
+    notices: [],
+    ...(droppedBefore === undefined ? {} : { droppedBefore }),
+  };
+  return { type: "pulse", frame };
+}
+
+describe("fold — hello", () => {
+  it("opens an empty replay when the run has no seeded history", () => {
+    const state = fold(BASE, hello("run_1"));
+    expect(state.replay?.simulationName).toBe("dinner");
+    expect(state.replay?.pulses).toEqual([]);
+    expect(state.helloRunId).toBe("run_1");
+  });
+
+  it("puts seeded history in a pulse before the first one", () => {
+    const state = fold(BASE, hello("run_1", [message("prior", 0)]));
+    expect(state.replay?.pulses).toHaveLength(1);
+    expect(state.replay?.pulses[0]?.pulseIndex).toBe(-1);
+    expect(state.replay?.pulses[0]?.messages[0]?.eventId).toBe("prior");
+  });
+
+  it("keeps folded pulses when the same run says hello again", () => {
+    // A reconnect replays hello, and the backlog is bounded — rebuilding from
+    // the frame alone would silently drop everything older than the window.
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(0, [message("a", 0)]));
+    state = fold(state, pulse(1, [message("b", 1)]));
+
+    const resumed = fold(state, hello("run_1"));
+
+    expect(resumed.replay?.pulses.map((p) => p.pulseIndex)).toEqual([0, 1]);
+    expect(resumed.connected).toBe(true);
+  });
+
+  it("starts over when a different run says hello", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(0, [message("a", 0)]));
+
+    const restarted = fold(state, hello("run_2"));
+
+    expect(restarted.replay?.pulses).toEqual([]);
+    expect(restarted.helloRunId).toBe("run_2");
+  });
+});
+
+describe("fold — pulses", () => {
+  it("ignores a pulse that arrives before hello", () => {
+    expect(fold(BASE, pulse(0, [message("a", 0)])).replay).toBeNull();
+  });
+
+  it("keeps pulses ordered when one arrives late", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(2, [message("c", 2)]));
+    state = fold(state, pulse(1, [message("b", 1)]));
+    expect(state.replay?.pulses.map((p) => p.pulseIndex)).toEqual([1, 2]);
+  });
+
+  it("replaces rather than duplicates a pulse index seen twice", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(0, [message("a", 0)]));
+    state = fold(state, pulse(0, [message("a", 0), message("a2", 0)]));
+    expect(state.replay?.pulses).toHaveLength(1);
+    expect(state.replay?.pulses[0]?.messages).toHaveLength(2);
+  });
+
+  it("accumulates the coalesced-away count across frames", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(3, [], 2));
+    state = fold(state, pulse(7, [], 3));
+    expect(state.dropped).toBe(5);
+  });
+
+  it("carries the audience through untouched, empty array included", () => {
+    // Empty means "everyone in the channel". Normalizing it here would invert
+    // the exclusion story the POV filter reads.
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, pulse(0, [message("open", 0), message("private", 0, ["iris"])]));
+    expect(state.replay?.pulses[0]?.messages[0]?.visibleToAgents).toEqual([]);
+    expect(state.replay?.pulses[0]?.messages[1]?.visibleToAgents).toEqual(["iris"]);
+  });
+});
+
+describe("fold — channels, notices and endings", () => {
+  it("appends a channel opened mid-run", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, {
+      type: "channel",
+      channel: { id: "dm", name: "iris+marcela", type: "private_channel", memberAgentIds: ["iris", "marcela"] },
+    });
+    expect(state.replay?.channels.map((c) => c.id)).toEqual(["geral", "dm"]);
+  });
+
+  it("replaces a channel whose membership changed", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, {
+      type: "channel",
+      channel: { id: "geral", name: "geral", type: "public_channel", memberAgentIds: ["iris", "bruno"] },
+    });
+    expect(state.replay?.channels).toHaveLength(1);
+    expect(state.replay?.channels[0]?.memberAgentIds).toEqual(["iris", "bruno"]);
+  });
+
+  it("collects notices in arrival order", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, { type: "notice", notice: { type: "llm_failure", detail: "timeout" } });
+    state = fold(state, { type: "notice", notice: { type: "stagnation_detected", detail: "quiet" } });
+    expect(state.notices.map((n) => n.type)).toEqual(["llm_failure", "stagnation_detected"]);
+  });
+
+  it("records the stop reason and drops the live flag", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold({ ...state, connected: true }, {
+      type: "stopped",
+      stopReason: "max_pulses",
+      replayUrl: "/api/runs/run_1/replay",
+    });
+    expect(state.stoppedReason).toBe("max_pulses");
+    expect(state.replay?.stopReason).toBe("max_pulses");
+    expect(state.connected).toBe(false);
+  });
+
+  it("calls an ending without a reason finished", () => {
+    let state = fold(BASE, hello("run_1"));
+    state = fold(state, { type: "stopped", replayUrl: "/api/runs/run_1/replay" });
+    expect(state.stoppedReason).toBe("finished");
+    expect(state.replay?.stopReason).toBeUndefined();
+  });
+
+  it("joins an error to its hint so the alert reads as one sentence", () => {
+    const state = fold(BASE, { type: "error", message: "Ollama unreachable", hint: "start the daemon" });
+    expect(state.error).toBe("Ollama unreachable — start the daemon");
+  });
+
+  it("stores a status frame verbatim", () => {
+    const status: RunStatus = {
+      runId: "run_1",
+      simulationId: "sim",
+      state: "running",
+      pulseIndex: 4,
+      pulsesRun: 5,
+      maxPulses: 12,
+      counters: { llmFailures: 0, gatewayTimeouts: 0, framesDropped: 0 },
+    };
+    expect(fold(BASE, { type: "status", status }).status).toEqual(status);
+  });
+});

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,0 +1,69 @@
+/**
+ * Thin fetch wrappers over the run server.
+ *
+ * Relative URLs throughout: in dev Vite proxies `/api` to the node server, and
+ * in production that same server hosts this bundle. One set of URLs, no origin
+ * configuration in the app.
+ */
+import type {
+  ApiError,
+  CompileResponse,
+  RunInputs,
+  RunListEntry,
+  RunStatus,
+  StartRunRequest,
+  StartRunResponse,
+  ViewerReplay,
+} from "@perfectman/shared";
+
+async function json<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: init?.body ? { "content-type": "application/json" } : {},
+  });
+  const body: unknown = await res.json().catch(() => null);
+  if (!res.ok) {
+    const message = (body as ApiError | null)?.error?.message ?? `${res.status} ${res.statusText}`;
+    const hint = (body as ApiError | null)?.error?.hint;
+    throw new ApiRequestError(message, res.status, hint);
+  }
+  return body as T;
+}
+
+export class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly hint?: string,
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+  }
+}
+
+export function compile(inputs: RunInputs, llm?: StartRunRequest["llm"]): Promise<CompileResponse> {
+  return json<CompileResponse>("/api/compile", {
+    method: "POST",
+    body: JSON.stringify({ inputs, llm }),
+  });
+}
+
+export function startRun(request: StartRunRequest): Promise<StartRunResponse> {
+  return json<StartRunResponse>("/api/runs", { method: "POST", body: JSON.stringify(request) });
+}
+
+export function stopRun(runId: string): Promise<unknown> {
+  return json(`/api/runs/${encodeURIComponent(runId)}/stop`, { method: "POST" });
+}
+
+export function currentStatus(): Promise<RunStatus> {
+  return json<RunStatus>("/api/runs/current");
+}
+
+export function listRuns(): Promise<{ runs: RunListEntry[] }> {
+  return json<{ runs: RunListEntry[] }>("/api/runs");
+}
+
+export function fetchReplay(runId: string): Promise<ViewerReplay> {
+  return json<ViewerReplay>(`/api/runs/${encodeURIComponent(runId)}/replay`);
+}

--- a/packages/web/src/api/useRunStream.ts
+++ b/packages/web/src/api/useRunStream.ts
@@ -1,0 +1,208 @@
+/**
+ * `EventSource` → the same `ViewerReplay` shape a stored run has.
+ *
+ * Live is not a second data model: it is the replay, still growing. Folding the
+ * stream into `ViewerReplay` here is what lets one viewer render both, and it
+ * keeps the "did the browser see this" question answerable against a single
+ * object rather than a pile of events.
+ *
+ * Pulses are coalescable on the wire, so a client that falls behind gets the
+ * newest one and a `droppedBefore` count. Gaps are not reconstructed here —
+ * `replay.json` has them, and the UI says how many are missing.
+ */
+import { useEffect, useRef, useState } from "react";
+import type { LiveEvent, LiveNotice, RunStatus, ViewerPulse, ViewerReplay } from "@perfectman/shared";
+
+/** Raw envelopes kept for the frame log; enough to debug, bounded so a long run cannot grow forever. */
+const RAW_LOG_CAP = 500;
+
+export type RunStream = {
+  replay: ViewerReplay | null;
+  /** The run `hello` announced, so a reconnect can tell resume from restart. */
+  helloRunId: string | null;
+  status: RunStatus | null;
+  notices: LiveNotice[];
+  /** Newest last. Trimmed to the most recent `RAW_LOG_CAP`. */
+  raw: Array<{ seq: number; event: LiveEvent }>;
+  /** Pulses coalesced away because this client fell behind. */
+  dropped: number;
+  connected: boolean;
+  /** Transport or run failure. Distinct from a compile error, which never opens a stream. */
+  error: string | null;
+  stoppedReason: string | null;
+};
+
+const EMPTY: RunStream = {
+  replay: null,
+  helloRunId: null,
+  status: null,
+  notices: [],
+  raw: [],
+  dropped: 0,
+  connected: false,
+  error: null,
+  stoppedReason: null,
+};
+
+export function useRunStream(runId: string | null): RunStream {
+  const [state, setState] = useState<RunStream>(EMPTY);
+  const seq = useRef(0);
+
+  useEffect(() => {
+    if (!runId) {
+      setState(EMPTY);
+      return;
+    }
+    seq.current = 0;
+    setState({ ...EMPTY, connected: false });
+
+    const source = new EventSource(`/api/runs/${encodeURIComponent(runId)}/stream`);
+    const onMessage = (raw: MessageEvent<string>): void => {
+      let event: LiveEvent;
+      try {
+        event = JSON.parse(raw.data) as LiveEvent;
+      } catch {
+        return;
+      }
+      seq.current += 1;
+      const n = seq.current;
+      setState((prev) => fold({ ...prev, raw: append(prev.raw, n, event) }, event));
+      // The server closes the stream after `stopped`, and EventSource honours
+      // its own `retry:` — so without this the browser reconnects, gets the
+      // whole backlog replayed, and shows the run twice.
+      if (event.type === "stopped") source.close();
+    };
+
+    // Every frame is a named event, so the default `message` listener never fires.
+    for (const name of ["hello", "status", "pulse", "channel", "notice", "stopped", "error"]) {
+      source.addEventListener(name, onMessage as EventListener);
+    }
+    source.addEventListener("open", () => {
+      setState((prev) => ({ ...prev, connected: true, error: null }));
+    });
+    source.addEventListener("error", () => {
+      // EventSource reconnects on its own; this is a status, not a terminal state.
+      setState((prev) => ({ ...prev, connected: false }));
+    });
+
+    return () => {
+      source.close();
+    };
+  }, [runId]);
+
+  return state;
+}
+
+function append(
+  log: RunStream["raw"],
+  seqNo: number,
+  event: LiveEvent,
+): RunStream["raw"] {
+  const next = [...log, { seq: seqNo, event }];
+  return next.length > RAW_LOG_CAP ? next.slice(next.length - RAW_LOG_CAP) : next;
+}
+
+export function fold(state: RunStream, event: LiveEvent): RunStream {
+  switch (event.type) {
+    case "hello": {
+      // A reconnect replays `hello` mid-run. Keep what is already folded: the
+      // backlog is bounded, so rebuilding from this frame alone would silently
+      // drop every pulse older than the window.
+      const resuming = state.helloRunId === event.runId && state.replay !== null;
+      if (resuming) return { ...state, connected: true };
+      return {
+        ...state,
+        connected: true,
+        helloRunId: event.runId,
+        replay: {
+          simulationId: event.simulationId,
+          simulationName: event.simulationName,
+          agents: event.agents,
+          channels: event.channels,
+          // Seeded history arrives as pulse -1: it was written straight to the
+          // repository, so no gateway ever saw it, but the viewer must not
+          // start blank where the stored replay has a past.
+          pulses:
+            event.priorEvents.length > 0
+              ? [
+                  {
+                    pulseIndex: -1,
+                    eventsCommitted: event.priorEvents.length,
+                    agentsCalled: 0,
+                    messages: event.priorEvents,
+                    thinking: {},
+                    emotions: {},
+                    notices: [],
+                  },
+                ]
+              : [],
+        },
+      };
+    }
+
+    case "status":
+      return { ...state, status: event.status };
+
+    case "pulse": {
+      if (!state.replay) return state;
+      const pulse: ViewerPulse = {
+        pulseIndex: event.frame.pulseIndex,
+        eventsCommitted: event.frame.eventsCommitted,
+        agentsCalled: event.frame.agentsCalled,
+        messages: event.frame.messages,
+        thinking: event.frame.thinking,
+        emotions: event.frame.emotions,
+        notices: event.frame.notices,
+      };
+      return {
+        ...state,
+        dropped: state.dropped + (event.frame.droppedBefore ?? 0),
+        replay: { ...state.replay, pulses: upsertPulse(state.replay.pulses, pulse) },
+      };
+    }
+
+    case "channel": {
+      if (!state.replay) return state;
+      const channels = state.replay.channels.some((c) => c.id === event.channel.id)
+        ? state.replay.channels.map((c) => (c.id === event.channel.id ? event.channel : c))
+        : [...state.replay.channels, event.channel];
+      return { ...state, replay: { ...state.replay, channels } };
+    }
+
+    case "notice":
+      return { ...state, notices: [...state.notices, event.notice] };
+
+    case "stopped":
+      return {
+        ...state,
+        connected: false,
+        stoppedReason: event.stopReason ?? "finished",
+        replay: state.replay ? { ...state.replay, ...stopReasonOf(event.stopReason) } : null,
+      };
+
+    case "error":
+      return { ...state, error: event.hint ? `${event.message} — ${event.hint}` : event.message };
+
+    default:
+      return state;
+  }
+}
+
+function stopReasonOf(stopReason: string | undefined): { stopReason?: string } {
+  return stopReason ? { stopReason } : {};
+}
+
+/**
+ * Coalescing means a pulse can arrive out of order relative to a reconnect, and
+ * a reconnect can replay one already held. Keyed by index, sorted, so neither
+ * duplicates a row.
+ */
+function upsertPulse(pulses: ViewerPulse[], pulse: ViewerPulse): ViewerPulse[] {
+  const at = pulses.findIndex((p) => p.pulseIndex === pulse.pulseIndex);
+  if (at >= 0) {
+    const next = [...pulses];
+    next[at] = pulse;
+    return next;
+  }
+  return [...pulses, pulse].sort((a, b) => a.pulseIndex - b.pulseIndex);
+}

--- a/packages/web/src/components/CompiledConfigPanel.tsx
+++ b/packages/web/src/components/CompiledConfigPanel.tsx
@@ -1,0 +1,130 @@
+/**
+ * Read-only proof of what the markdown became, before a run costs model time.
+ *
+ * The summary is the part an author reads; the raw config is the part they
+ * check when the summary looks wrong. Both, never one.
+ */
+import { useState } from "react";
+import type { CompileResponse } from "@perfectman/shared";
+import { DiagnosticList } from "./DiagnosticList.js";
+
+export function CompiledConfigPanel({
+  result,
+  pending,
+}: {
+  result: CompileResponse | null;
+  pending: boolean;
+}): JSX.Element {
+  const [showRaw, setShowRaw] = useState(false);
+
+  if (pending) return <section className="panel panel--muted">compiling…</section>;
+  if (!result) {
+    return (
+      <section className="panel panel--muted">
+        Drop a scenario and its personas to see what they compile to.
+      </section>
+    );
+  }
+
+  const { summary, diagnostics, ok } = result;
+
+  return (
+    <section className="panel">
+      <header className="panel__head">
+        <h2>Compiled</h2>
+        <span className={ok ? "badge badge--ok" : "badge badge--bad"}>
+          {ok ? "runnable" : "blocked"}
+        </span>
+      </header>
+
+      {summary ? (
+        <>
+          <dl className="summary">
+            <div>
+              <dt>seed</dt>
+              <dd>{summary.seed}</dd>
+            </div>
+            <div>
+              <dt>max pulses</dt>
+              <dd>{summary.maxPulses}</dd>
+            </div>
+            <div>
+              <dt>agents</dt>
+              <dd>{summary.agents.length}</dd>
+            </div>
+            <div>
+              <dt>channels</dt>
+              <dd>{summary.channels.length}</dd>
+            </div>
+          </dl>
+
+          <div className="scroller">
+            <table className="grid">
+            <thead>
+              <tr>
+                <th>agent</th>
+                <th>archetype</th>
+                <th>from</th>
+                <th>calibration</th>
+                <th>language</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.agents.map((a) => {
+                const lang = summary.languages[a.personaFile];
+                return (
+                  <tr key={a.id}>
+                    <td>{a.displayName}</td>
+                    <td className="dim">{a.archetype}</td>
+                    <td className="dim" title={a.personaFile}>
+                      {shortFile(a.personaFile)}
+                    </td>
+                    <td className="dim" title="Markdown cannot reach the 19 engine calibration fields; they are inherited from this canonical persona.">
+                      {a.calibrationFrom}
+                    </td>
+                    <td>
+                      {lang ? (
+                        // Source and confidence live in the tooltip: the panel
+                        // sits in a narrow column and the code is the answer.
+                        <span title={`${lang.source}, confidence ${lang.confidence.toFixed(2)}`}>
+                          {lang.language}
+                        </span>
+                      ) : (
+                        <span className="dim">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            </table>
+          </div>
+
+          <ul className="channels">
+            {summary.channels.map((c) => (
+              <li key={c.id}>
+                <span className={c.type.includes("private") ? "pill pill--private" : "pill"}>
+                  {c.type.includes("private") ? "private" : "public"}
+                </span>
+                <strong>{c.name}</strong>
+                <span className="dim">{c.members.join(", ")}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      <DiagnosticList diagnostics={diagnostics} />
+
+      <button type="button" className="link" onClick={() => setShowRaw((v) => !v)}>
+        {showRaw ? "hide" : "show"} compiled config
+      </button>
+      {showRaw ? <pre className="code">{JSON.stringify(result.config, null, 2)}</pre> : null}
+    </section>
+  );
+}
+
+/** `iris.persona.md` → `iris`. The full name is on the cell's tooltip. */
+function shortFile(filename: string): string {
+  return filename.replace(/\.(persona|scenario)\.md$/i, "").replace(/\.md$/i, "");
+}

--- a/packages/web/src/components/DiagnosticList.tsx
+++ b/packages/web/src/components/DiagnosticList.tsx
@@ -1,0 +1,34 @@
+/**
+ * Every compile problem at once, worst first.
+ *
+ * The compilers deliberately collect rather than throw, and that only pays off
+ * if the panel shows the whole list — an author fixing one line at a time
+ * because the UI hid the rest is back to throwing.
+ */
+import type { Diagnostic, DiagnosticLevel } from "@perfectman/shared";
+
+const ORDER: Record<DiagnosticLevel, number> = { error: 0, warning: 1, info: 2 };
+
+export function DiagnosticList({ diagnostics }: { diagnostics: Diagnostic[] }): JSX.Element | null {
+  if (diagnostics.length === 0) return null;
+  const sorted = [...diagnostics].sort((a, b) => ORDER[a.level] - ORDER[b.level]);
+
+  return (
+    <ul className="diagnostics">
+      {sorted.map((d, i) => (
+        <li key={`${d.file}:${d.line ?? 0}:${i}`} className={`diagnostic diagnostic--${d.level}`}>
+          <span className="diagnostic__level">{d.level}</span>
+          <div className="diagnostic__body">
+            <p className="diagnostic__message">{d.message}</p>
+            <p className="diagnostic__where">
+              {d.file}
+              {d.line !== undefined ? `:${d.line}` : ""}
+              {d.path ? ` · ${d.path}` : ""}
+            </p>
+            {d.hint ? <p className="diagnostic__hint">{d.hint}</p> : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/web/src/components/FrameLog.tsx
+++ b/packages/web/src/components/FrameLog.tsx
@@ -1,0 +1,58 @@
+/**
+ * The raw stream, newest first.
+ *
+ * This is the milestone-5 viewer: before the transcript exists, being able to
+ * see that frames arrive — in order, with the right shape — is what proves the
+ * whole path works. It stays afterwards as the debugging view.
+ */
+import { useState } from "react";
+import type { LiveEvent } from "@perfectman/shared";
+
+export function FrameLog({ raw }: { raw: Array<{ seq: number; event: LiveEvent }> }): JSX.Element {
+  const [open, setOpen] = useState<number | null>(null);
+
+  if (raw.length === 0) {
+    return <section className="panel panel--muted">No frames yet.</section>;
+  }
+
+  return (
+    <section className="panel">
+      <header className="panel__head">
+        <h2>Stream</h2>
+        <span className="dim">{raw.length} frames</span>
+      </header>
+      <ol className="frames">
+        {[...raw].reverse().map(({ seq, event }) => (
+          <li key={seq}>
+            <button type="button" className="frame" onClick={() => setOpen(open === seq ? null : seq)}>
+              <span className={`pill pill--${event.type}`}>{event.type}</span>
+              <span className="dim">{summarize(event)}</span>
+            </button>
+            {open === seq ? <pre className="code">{JSON.stringify(event, null, 2)}</pre> : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function summarize(event: LiveEvent): string {
+  switch (event.type) {
+    case "hello":
+      return `${event.agents.length} agents · ${event.channels.length} channels · ${event.priorEvents.length} prior events`;
+    case "status":
+      return `${event.status.state} · ${event.status.pulsesRun} pulses`;
+    case "pulse":
+      return `pulse ${event.frame.pulseIndex} · ${event.frame.messages.length} messages · ${event.frame.agentsCalled} agents called`;
+    case "channel":
+      return `${event.channel.name} · ${event.channel.memberAgentIds.length} members`;
+    case "notice":
+      return `${event.notice.type}${event.notice.agentId ? ` · ${event.notice.agentId}` : ""}`;
+    case "stopped":
+      return event.stopReason ?? "finished";
+    case "error":
+      return event.message;
+    default:
+      return "";
+  }
+}

--- a/packages/web/src/components/RunForm.tsx
+++ b/packages/web/src/components/RunForm.tsx
@@ -1,0 +1,216 @@
+/**
+ * Files in, run parameters, Run.
+ *
+ * Personas and the scenario are told apart by filename suffix first
+ * (`*.persona.md` / `*.scenario.md`) and by frontmatter second, because an
+ * author who drops five files should not also have to say which is which.
+ */
+import { useRef, useState } from "react";
+import type { RunInputs, StartRunRequest, UploadedFile } from "@perfectman/shared";
+
+export type RunFormValue = {
+  personas: UploadedFile[];
+  scenario: UploadedFile | null;
+  llm: StartRunRequest["llm"];
+  maxPulses: number | null;
+};
+
+const PROVIDERS: Array<{ id: string; label: string; note: string }> = [
+  { id: "mock", label: "mock", note: "deterministic, no network — the CI path" },
+  { id: "ollama", label: "ollama", note: "local model, needs the daemon running" },
+  { id: "openai-compatible", label: "openai-compatible", note: "any /v1 endpoint" },
+];
+
+export function RunForm({
+  value,
+  onChange,
+  onRun,
+  onStop,
+  busy,
+  canRun,
+}: {
+  value: RunFormValue;
+  onChange: (next: RunFormValue) => void;
+  onRun: () => void;
+  onStop: () => void;
+  busy: boolean;
+  canRun: boolean;
+}): JSX.Element {
+  const [dragging, setDragging] = useState(false);
+  const picker = useRef<HTMLInputElement>(null);
+
+  async function absorb(files: FileList | null): Promise<void> {
+    if (!files || files.length === 0) return;
+    const read = await Promise.all(
+      Array.from(files).map(async (f) => ({ filename: f.name, text: await f.text() })),
+    );
+    let scenario = value.scenario;
+    const personas = [...value.personas];
+    for (const file of read) {
+      if (isScenario(file)) scenario = file;
+      else replaceOrAppend(personas, file);
+    }
+    onChange({ ...value, personas, scenario });
+  }
+
+  const files = [
+    ...(value.scenario ? [{ role: "scenario" as const, file: value.scenario }] : []),
+    ...value.personas.map((file) => ({ role: "persona" as const, file })),
+  ];
+
+  return (
+    <section className="panel">
+      <header className="panel__head">
+        <h2>Inputs</h2>
+      </header>
+
+      <div
+        className={dragging ? "drop drop--over" : "drop"}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          void absorb(e.dataTransfer.files);
+        }}
+        onClick={() => picker.current?.click()}
+      >
+        <input
+          ref={picker}
+          type="file"
+          accept=".md,text/markdown"
+          multiple
+          hidden
+          onChange={(e) => void absorb(e.target.files)}
+        />
+        <p>Drop one <code>.scenario.md</code> and its <code>.persona.md</code> files</p>
+        <p className="dim">or click to pick</p>
+      </div>
+
+      {files.length > 0 ? (
+        <ul className="files">
+          {files.map(({ role, file }) => (
+            <li key={file.filename}>
+              <span className={`pill pill--${role}`}>{role}</span>
+              <span>{file.filename}</span>
+              <span className="dim">{Math.ceil(file.text.length / 1024)} KB</span>
+              <button
+                type="button"
+                className="link"
+                onClick={() =>
+                  onChange(
+                    role === "scenario"
+                      ? { ...value, scenario: null }
+                      : {
+                          ...value,
+                          personas: value.personas.filter((p) => p.filename !== file.filename),
+                        },
+                  )
+                }
+              >
+                remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="fields">
+        <label>
+          <span>provider</span>
+          <select
+            value={value.llm.providerType}
+            onChange={(e) =>
+              onChange({ ...value, llm: { ...value.llm, providerType: e.target.value } })
+            }
+          >
+            {PROVIDERS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          <em className="dim">{PROVIDERS.find((p) => p.id === value.llm.providerType)?.note}</em>
+        </label>
+
+        <label>
+          <span>model</span>
+          <input
+            value={value.llm.modelName ?? ""}
+            placeholder={value.llm.providerType === "mock" ? "mock" : "model name"}
+            onChange={(e) => onChange({ ...value, llm: { ...value.llm, modelName: e.target.value } })}
+          />
+        </label>
+
+        {value.llm.providerType !== "mock" ? (
+          <>
+            <label>
+              <span>base URL</span>
+              <input
+                value={value.llm.baseUrl ?? ""}
+                placeholder="http://localhost:11434"
+                onChange={(e) => onChange({ ...value, llm: { ...value.llm, baseUrl: e.target.value } })}
+              />
+            </label>
+            <label>
+              <span>API key</span>
+              <input
+                type="password"
+                value={value.llm.apiKey ?? ""}
+                placeholder="pasted key, or leave blank for the server's .env"
+                onChange={(e) => onChange({ ...value, llm: { ...value.llm, apiKey: e.target.value } })}
+              />
+              <em className="dim">
+                Becomes a per-run env var. Only the variable name reaches the stored config.
+              </em>
+            </label>
+          </>
+        ) : null}
+
+        <label>
+          <span>max pulses</span>
+          <input
+            type="number"
+            min={1}
+            max={200}
+            value={value.maxPulses ?? ""}
+            placeholder="from the scenario"
+            onChange={(e) =>
+              onChange({ ...value, maxPulses: e.target.value ? Number(e.target.value) : null })
+            }
+          />
+        </label>
+      </div>
+
+      <div className="actions">
+        <button type="button" className="primary" disabled={!canRun || busy} onClick={onRun}>
+          Run
+        </button>
+        <button type="button" disabled={!busy} onClick={onStop}>
+          Stop
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export function toRunInputs(value: RunFormValue): RunInputs | null {
+  if (!value.scenario) return null;
+  return { kind: "markdown", personas: value.personas, scenario: value.scenario };
+}
+
+function isScenario(file: UploadedFile): boolean {
+  if (/\.scenario\.md$/i.test(file.filename)) return true;
+  if (/\.persona\.md$/i.test(file.filename)) return false;
+  // Fall back to the frontmatter: only a scenario declares a cast.
+  return /^\s*cast\s*:/m.test(file.text.split(/^---\s*$/m)[1] ?? "");
+}
+
+function replaceOrAppend(personas: UploadedFile[], file: UploadedFile): void {
+  const at = personas.findIndex((p) => p.filename === file.filename);
+  if (at >= 0) personas[at] = file;
+  else personas.push(file);
+}

--- a/packages/web/src/components/RunForm.tsx
+++ b/packages/web/src/components/RunForm.tsx
@@ -5,7 +5,7 @@
  * (`*.persona.md` / `*.scenario.md`) and by frontmatter second, because an
  * author who drops five files should not also have to say which is which.
  */
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { RunInputs, StartRunRequest, UploadedFile } from "@perfectman/shared";
 
 export type RunFormValue = {
@@ -13,6 +13,8 @@ export type RunFormValue = {
   scenario: UploadedFile | null;
   llm: StartRunRequest["llm"];
   maxPulses: number | null;
+  /** Kept as text so a half-typed object does not blank the field. */
+  extraBodyText: string;
 };
 
 const PROVIDERS: Array<{ id: string; label: string; note: string }> = [
@@ -38,6 +40,7 @@ export function RunForm({
 }): JSX.Element {
   const [dragging, setDragging] = useState(false);
   const picker = useRef<HTMLInputElement>(null);
+  const extraBodyError = useMemo(() => parseExtraBody(value.extraBodyText).error, [value.extraBodyText]);
 
   async function absorb(files: FileList | null): Promise<void> {
     if (!files || files.length === 0) return;
@@ -170,6 +173,47 @@ export function RunForm({
           </>
         ) : null}
 
+        {value.llm.providerType !== "mock" ? (
+          <details className="advanced">
+            <summary>Provider quirks</summary>
+            <p className="dim">
+              A hosted model that reasons by default will spend the whole output
+              budget thinking and never emit parseable intent. Two knobs fix
+              almost every such provider.
+            </p>
+
+            <label>
+              <span>JSON mode</span>
+              <select
+                value={jsonMode(value.llm)}
+                onChange={(e) => onChange({ ...value, llm: { ...value.llm, ...fromJsonMode(e.target.value) } })}
+              >
+                <option value="off">off — model returns prose-wrapped JSON</option>
+                <option value="object">json_object — syntax only</option>
+                <option value="schema">json_schema — shape constrained</option>
+              </select>
+              <em className="dim">
+                Some models run to the token cap inside schema mode. `json_object` is the safe choice.
+              </em>
+            </label>
+
+            <label>
+              <span>extra request body</span>
+              <textarea
+                rows={3}
+                spellCheck={false}
+                value={value.extraBodyText}
+                placeholder={'{ "thinking": { "type": "disabled" } }'}
+                onChange={(e) => onChange({ ...value, extraBodyText: e.target.value })}
+              />
+              <em className={extraBodyError ? "bad" : "dim"}>
+                {extraBodyError ??
+                  'Spread onto the request root. DeepSeek: {"thinking":{"type":"disabled"}}. Qwen: {"chat_template_kwargs":{"enable_thinking":false}}.'}
+              </em>
+            </label>
+          </details>
+        ) : null}
+
         <label>
           <span>max pulses</span>
           <input
@@ -195,6 +239,33 @@ export function RunForm({
       </div>
     </section>
   );
+}
+
+/**
+ * The extra body is edited as text and only becomes an object when it parses,
+ * so typing `{` does not wipe what was there. Blank is valid and means none.
+ */
+export function parseExtraBody(text: string): { value?: Record<string, unknown>; error?: string } {
+  if (text.trim() === "") return {};
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { error: "Must be a JSON object." };
+    }
+    return { value: parsed as Record<string, unknown> };
+  } catch (err) {
+    return { error: (err as Error).message };
+  }
+}
+
+function jsonMode(llm: RunFormValue["llm"]): "off" | "object" | "schema" {
+  if (llm.responseFormatJson !== true) return "off";
+  return llm.responseFormatJsonSchema === false ? "object" : "schema";
+}
+
+function fromJsonMode(mode: string): Partial<RunFormValue["llm"]> {
+  if (mode === "off") return { responseFormatJson: false, responseFormatJsonSchema: undefined };
+  return { responseFormatJson: true, responseFormatJsonSchema: mode === "schema" };
 }
 
 export function toRunInputs(value: RunFormValue): RunInputs | null {

--- a/packages/web/src/components/StatusBar.tsx
+++ b/packages/web/src/components/StatusBar.tsx
@@ -1,0 +1,49 @@
+/**
+ * Where the run is, and what it has cost so far.
+ *
+ * The counters are the honest part: gateway timeouts and dropped frames mean
+ * this browser saw less than the stored replay holds, and the UI should say so
+ * rather than let a gap read as the simulation going quiet.
+ */
+import type { RunStatus } from "@perfectman/shared";
+
+export function StatusBar({
+  status,
+  connected,
+  dropped,
+  runId,
+}: {
+  status: RunStatus | null;
+  connected: boolean;
+  dropped: number;
+  runId: string | null;
+}): JSX.Element {
+  const state = status?.state ?? "idle";
+  // The count, not the index: a finished 12-pulse run ends on index 11, and
+  // "11 / 12" reads as having stopped one short.
+  const pulses = status ? `${status.pulsesRun} / ${status.maxPulses}` : "—";
+
+  return (
+    <div className="statusbar">
+      <span className={`state state--${state}`}>{state.replace("_", " ")}</span>
+      <span className="dim">pulse</span>
+      <strong>{pulses}</strong>
+      {runId ? <code className="dim">{runId}</code> : null}
+      <span className="spacer" />
+      {status && status.counters.llmFailures > 0 ? (
+        <span className="counter counter--warn">{status.counters.llmFailures} llm failures</span>
+      ) : null}
+      {status && status.counters.gatewayTimeouts > 0 ? (
+        <span className="counter counter--warn">
+          {status.counters.gatewayTimeouts} gateway timeouts
+        </span>
+      ) : null}
+      {dropped > 0 ? (
+        <span className="counter counter--warn" title="Coalesced away because this tab fell behind — the stored replay has them">
+          {dropped} pulses not shown
+        </span>
+      ) : null}
+      <span className={connected ? "dot dot--live" : "dot"}>{connected ? "live" : "offline"}</span>
+    </div>
+  );
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("no #root in index.html");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -1,0 +1,288 @@
+/*
+ * A control room, not a dashboard: dark, dense, one accent.
+ *
+ * The palette is deliberately narrow — ink, two greys, one amber — so that the
+ * only saturated things on screen are the ones that mean something: a live
+ * stream, a blocking diagnostic, a counter that says this tab missed data.
+ */
+
+:root {
+  --ink: #0d0c0b;
+  --panel: #161513;
+  --line: #2a2724;
+  --text: #e8e3dc;
+  --dim: #8d857b;
+  --accent: #e0a54a;
+  --ok: #6fae7c;
+  --bad: #d4695f;
+  --warn: #d1a24a;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ink);
+  color: var(--text);
+  font: 14px/1.55 var(--sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+.app { max-width: 1400px; margin: 0 auto; padding: 28px 24px 64px; }
+
+.app__head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 18px; }
+.app__head h1 {
+  margin: 0;
+  font: 600 20px/1 var(--mono);
+  letter-spacing: -0.02em;
+}
+.app__head p { margin: 0; font-size: 13px; }
+
+.dim { color: var(--dim); }
+
+/* --- status bar --------------------------------------------------------- */
+
+.statusbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  font: 12px/1 var(--mono);
+  margin-bottom: 16px;
+}
+.statusbar .spacer { flex: 1; }
+.statusbar code { font-size: 11px; }
+
+.state { text-transform: uppercase; letter-spacing: 0.08em; color: var(--dim); }
+.state--running { color: var(--accent); }
+.state--done { color: var(--ok); }
+.state--failed { color: var(--bad); }
+
+.counter { color: var(--warn); }
+.dot { color: var(--dim); }
+.dot--live { color: var(--ok); }
+.dot--live::before { content: "● "; }
+
+/* --- layout ------------------------------------------------------------- */
+
+.columns { display: grid; grid-template-columns: minmax(0, 420px) minmax(0, 1fr); gap: 16px; }
+.column { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
+
+@media (max-width: 940px) {
+  .columns { grid-template-columns: minmax(0, 1fr); }
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 16px;
+}
+.panel--muted { color: var(--dim); font-size: 13px; }
+
+.panel__head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.panel__head h2 {
+  margin: 0;
+  font: 600 12px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dim);
+}
+
+/* --- inputs ------------------------------------------------------------- */
+
+.drop {
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  padding: 22px 16px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+.drop:hover, .drop--over { border-color: var(--accent); background: #1d1a16; }
+.drop p { margin: 0 0 4px; font-size: 13px; }
+.drop code { font: 12px var(--mono); color: var(--accent); }
+
+.files { list-style: none; margin: 12px 0 0; padding: 0; display: grid; gap: 6px; }
+.files li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: 12px var(--mono);
+  padding: 6px 8px;
+  border-radius: 5px;
+  background: #1c1a17;
+}
+.files li > span:nth-child(2) { flex: 1; overflow: hidden; text-overflow: ellipsis; }
+
+.fields { display: grid; gap: 12px; margin-top: 16px; }
+.fields label { display: grid; gap: 4px; }
+.fields label > span {
+  font: 11px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.fields em { font-size: 11px; font-style: normal; }
+
+input, select {
+  background: #100f0d;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  color: var(--text);
+  padding: 7px 9px;
+  font: 13px var(--mono);
+  width: 100%;
+}
+input:focus, select:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
+
+.actions { display: flex; gap: 8px; margin-top: 18px; }
+
+button {
+  background: #221f1b;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  color: var(--text);
+  padding: 8px 16px;
+  font: 500 13px var(--sans);
+  cursor: pointer;
+}
+button:hover:not(:disabled) { border-color: var(--dim); }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+button.primary { background: var(--accent); border-color: var(--accent); color: #17130c; font-weight: 600; }
+
+button.link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--dim);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-size: 12px;
+}
+button.link:hover { color: var(--accent); }
+
+/* --- compiled panel ----------------------------------------------------- */
+
+.summary { display: flex; gap: 22px; margin: 0 0 14px; }
+.summary div { display: grid; gap: 2px; }
+.summary dt {
+  font: 10px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.summary dd { margin: 0; font: 600 16px/1 var(--mono); }
+
+/* Narrow column, wide table: the panel must never push the page sideways. */
+.scroller { overflow-x: auto; }
+.grid { width: 100%; border-collapse: collapse; font: 12px var(--mono); white-space: nowrap; }
+.grid th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--dim);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  padding: 0 8px 6px 0;
+  border-bottom: 1px solid var(--line);
+}
+.grid td { padding: 6px 8px 6px 0; border-bottom: 1px solid #1f1d1a; }
+
+.channels { list-style: none; margin: 14px 0 0; padding: 0; display: grid; gap: 6px; font: 12px var(--mono); }
+.channels li { display: flex; gap: 8px; align-items: baseline; }
+
+.pill {
+  font: 10px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 6px;
+  border-radius: 3px;
+  background: #262320;
+  color: var(--dim);
+  white-space: nowrap;
+}
+.pill--private { background: #2e2318; color: var(--accent); }
+.pill--scenario { background: #2e2318; color: var(--accent); }
+.pill--persona { background: #1f2a24; color: var(--ok); }
+.pill--pulse { background: #2e2318; color: var(--accent); }
+.pill--hello, .pill--stopped { background: #1f2a24; color: var(--ok); }
+.pill--error { background: #2e1c1a; color: var(--bad); }
+.pill--notice { background: #2b2519; color: var(--warn); }
+
+.badge { font: 10px/1 var(--mono); text-transform: uppercase; letter-spacing: 0.08em; padding: 3px 7px; border-radius: 3px; }
+.badge--ok { background: #1f2a24; color: var(--ok); }
+.badge--bad { background: #2e1c1a; color: var(--bad); }
+
+.code {
+  margin: 10px 0 0;
+  padding: 12px;
+  background: #0f0e0c;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  font: 11px/1.5 var(--mono);
+  max-height: 380px;
+  overflow: auto;
+  white-space: pre;
+}
+
+/* --- diagnostics -------------------------------------------------------- */
+
+.diagnostics { list-style: none; margin: 14px 0 0; padding: 0; display: grid; gap: 6px; }
+.diagnostic {
+  display: flex;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 5px;
+  border-left: 2px solid var(--line);
+  background: #1c1a17;
+}
+.diagnostic--error { border-left-color: var(--bad); }
+.diagnostic--warning { border-left-color: var(--warn); }
+.diagnostic--info { border-left-color: var(--dim); }
+.diagnostic__level {
+  font: 10px/1.6 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  min-width: 52px;
+}
+.diagnostic__body { min-width: 0; }
+.diagnostic__message { margin: 0; font-size: 13px; }
+.diagnostic__where { margin: 2px 0 0; font: 11px var(--mono); color: var(--dim); }
+.diagnostic__hint { margin: 4px 0 0; font-size: 12px; color: var(--accent); }
+
+/* --- stream ------------------------------------------------------------- */
+
+.frames { list-style: none; margin: 0; padding: 0; display: grid; gap: 3px; }
+.frame {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font: 12px var(--mono);
+}
+.frame:hover { background: #1e1b18; }
+
+.alert {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid var(--bad);
+  border-radius: 6px;
+  background: #241715;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-size: 13px;
+}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -142,6 +142,38 @@ input, select {
 }
 input:focus, select:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
 
+.advanced {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: #131210;
+}
+.advanced summary {
+  cursor: pointer;
+  font: 11px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.advanced summary:hover { color: var(--accent); }
+.advanced > p { margin: 10px 0 12px; font-size: 12px; }
+.advanced label { margin-bottom: 12px; }
+.advanced label:last-child { margin-bottom: 0; }
+
+textarea {
+  background: #100f0d;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  color: var(--text);
+  padding: 7px 9px;
+  font: 12px/1.5 var(--mono);
+  width: 100%;
+  resize: vertical;
+}
+textarea:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
+
+.bad { color: var(--bad); font-size: 11px; font-style: normal; }
+
 .actions { display: flex; gap: 8px; margin-top: 18px; }
 
 button {

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+/** Matches `DEFAULT_PORT` in `packages/server/src/http/bootstrap.ts`. */
+const API_ORIGIN = process.env["PERFECTMAN_WEB_API"] ?? "http://localhost:4317";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5317,
+    // Same-origin in dev, so `EventSource("/api/...")` needs no CORS dance and
+    // the built bundle — which the server hosts itself — uses identical URLs.
+    proxy: {
+      "/api": { target: API_ORIGIN, changeOrigin: true, ws: false },
+    },
+  },
+  build: { outDir: "dist", sourcemap: true },
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Only the pure stream fold is covered. It is the one piece of web code with
+ * behaviour rather than markup — and the piece that shipped a duplicate-run bug
+ * the moment it met a real reconnect.
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,37 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@26.2.0)
 
+  packages/web:
+    dependencies:
+      '@perfectman/shared':
+        specifier: workspace:*
+        version: link:../shared
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21(@types/node@26.2.0))
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.11
+        version: 5.4.21(@types/node@26.2.0)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@26.2.0)
+
 packages:
 
   '@ai-sdk/gateway@4.0.63':
@@ -173,17 +204,33 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/code-frame@8.0.0':
     resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -192,6 +239,10 @@ packages:
   '@babel/helper-annotate-as-pure@8.0.0':
     resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@8.0.0':
     resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
@@ -203,6 +254,10 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-globals@8.0.0':
     resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -211,9 +266,19 @@ packages:
     resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@8.0.0':
     resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@8.0.1':
     resolution: {integrity: sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==}
@@ -224,6 +289,10 @@ packages:
   '@babel/helper-optimise-call-expression@8.0.0':
     resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@8.0.1':
     resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
@@ -245,6 +314,10 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@8.0.0':
     resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -253,13 +326,25 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@8.0.4':
     resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
@@ -267,6 +352,11 @@ packages:
 
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -329,6 +419,18 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx@8.0.1':
     resolution: {integrity: sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -359,9 +461,17 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@8.0.0':
     resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/traverse@8.0.4':
     resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
@@ -369,6 +479,10 @@ packages:
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.4':
@@ -1032,6 +1146,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1085,6 +1202,9 @@ packages:
         optional: true
       yauzl:
         optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -1283,6 +1403,18 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -1301,6 +1433,17 @@ packages:
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
@@ -1310,6 +1453,12 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -1531,6 +1680,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1926,6 +2078,9 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1969,6 +2124,10 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1978,6 +2137,9 @@ packages:
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
@@ -2200,6 +2362,19 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -2237,8 +2412,15 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
@@ -2593,6 +2775,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -2658,12 +2843,40 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/code-frame@8.0.0':
     dependencies:
       '@babel/helper-validator-identifier': 8.0.4
       js-tokens: 10.0.0
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@8.0.1':
     dependencies:
@@ -2684,6 +2897,14 @@ snapshots:
       obug: 2.1.4
       semver: 7.8.1
 
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.4
@@ -2696,6 +2917,14 @@ snapshots:
   '@babel/helper-annotate-as-pure@8.0.0':
     dependencies:
       '@babel/types': 8.0.4
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
 
   '@babel/helper-compilation-targets@8.0.0':
     dependencies:
@@ -2716,6 +2945,8 @@ snapshots:
       '@babel/traverse': 8.0.4
       semver: 7.8.1
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-member-expression-to-functions@8.0.0':
@@ -2723,10 +2954,26 @@ snapshots:
       '@babel/traverse': 8.0.4
       '@babel/types': 8.0.4
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.4
       '@babel/types': 8.0.4
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-transforms@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -2738,6 +2985,8 @@ snapshots:
   '@babel/helper-optimise-call-expression@8.0.0':
     dependencies:
       '@babel/types': 8.0.4
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-plugin-utils@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -2757,13 +3006,24 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-string-parser@8.0.0': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-identifier@8.0.4': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-validator-option@8.0.0': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -2773,6 +3033,10 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.4':
     dependencies:
@@ -2827,6 +3091,16 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/plugin-transform-react-jsx': 8.0.1(@babel/core@8.0.1)
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-react-jsx@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
@@ -2869,11 +3143,29 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 8.0.1(@babel/core@8.0.1)
       '@babel/plugin-transform-typescript': 8.0.1(@babel/core@8.0.1)
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
   '@babel/template@8.0.0':
     dependencies:
       '@babel/code-frame': 8.0.0
       '@babel/parser': 8.0.4
       '@babel/types': 8.0.4
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@8.0.4':
     dependencies:
@@ -2889,6 +3181,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.4':
     dependencies:
@@ -3361,6 +3658,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -3406,6 +3708,8 @@ snapshots:
     dependencies:
       modern-tar: 0.8.4
       yargs: 18.1.0
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -3577,6 +3881,27 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 26.2.0
@@ -3593,6 +3918,17 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@types/retry@0.12.0':
     optional: true
 
@@ -3601,6 +3937,18 @@ snapshots:
       '@types/node': 26.2.0
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@26.2.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21(@types/node@26.2.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@26.2.0))':
     dependencies:
@@ -3824,6 +4172,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1:
     optional: true
@@ -4298,6 +4648,8 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@4.0.0: {}
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -4337,11 +4689,19 @@ snapshots:
   long@5.3.2:
     optional: true
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-bytes.js@1.13.0: {}
 
@@ -4566,6 +4926,18 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -4629,7 +5001,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   semver-compare@1.0.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.1: {}
 
@@ -4977,6 +5355,8 @@ snapshots:
       is-wsl: 3.1.1
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,4 +5,5 @@ export default defineWorkspace([
   "packages/engine/vitest.config.ts",
   "packages/server/vitest.config.ts",
   "packages/eval/vitest.config.ts",
+  "packages/web/vitest.config.ts",
 ]);


### PR DESCRIPTION
## What

Adds the browser half of the web runner — drop markdown in, watch the run happen. Stacked on #198.

- `packages/web` — Vite + React, talking to the run server over relative URLs. Vite proxies `/api` in dev; the same server hosts the built bundle in production, so there is one set of URLs and no origin configuration in the app. `pnpm web` serves it, `pnpm web:dev` runs it with hot reload on 5317.
- `useRunStream` folds the SSE stream into the `ViewerReplay` shape a stored run already has — live is the replay, still growing, which is what will let one viewer render both.
- **Duplicate run**: the server closes the stream after `stopped` and `EventSource` honours its own `retry:`, so the browser reconnected, the hub replayed its backlog, and the whole run rendered twice. The client closes on `stopped`.
- **Reconnect**: a replayed `hello` mid-run rebuilt the replay from that frame alone, silently dropping every pulse older than the bounded backlog. It now resumes when the run id matches.
- `CompiledConfigPanel` shows what the markdown became before a run costs model time: cast, channels, detected language per file, the canonical persona each agent inherited calibration from, and every diagnostic at once.
- **Wire contract** moves to `packages/shared/src/live/run-api.types.ts` — the browser bundle must not import `@perfectman/server`, which would pull `better-sqlite3`, `discord.js` and `ollama` into the Vite graph. `Diagnostic` is re-exported by the server rather than duplicated.
- `examples/web-runner/` — three partners, a public channel and a private one `bruno` cannot see, plus a README. The form takes them as-is on `mock`.
- 22 tests: 16 on the fold (hello seeding, resume vs restart, out-of-order and repeated pulses, dropped counter, empty `visibleToAgents` preserved, channel upsert, stop reasons, error+hint), 6 on the compile summary.

## Why

Two bugs only a real browser found, both fixed here. `pulsesRun` in the status and manifest was `pulseIndex` — a finished 12-pulse run reported "11 of 12"; the existing test asserted `pulseIndex > 0`, which is why it survived. And the compile summary reported `persona.id` as `personaFile`, so the preview could never resolve a language: that is the *calibration* source, a name the author never typed.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS - 1868 passed (+22), hygiene gate and docs-lint clean
- Driven end to end in a real browser on `mock`: four files dropped, compiled to `runnable`, run started, 30 SSE frames in one copy (was 60), `12 / 12`, `out/runs/<id>/` holding inputs, scrubbed config, `run.json`, `replay.json` and `snapshot.html`. No console errors.
- `packages/web` bundles to 157 kB with no server package in the graph.
