### PR TITLE
feat(web): prefill known endpoints, and size Cloud Run from measurement

### DIFF
--- a/.playwright-mcp/console-2026-09-06T22-52-01-925Z.log
+++ b/.playwright-mcp/console-2026-09-06T22-52-01-925Z.log
@@ -1,0 +1,2 @@
+[   29114ms] [VERBOSE] [DOM] Password field is not contained in a form: (More info: https://goo.gl/9p2vKq) %o @ https://web-rli81upwa-caiotheodoros-projects.vercel.app/:0
+[   45198ms] [ERROR] Failed to load resource: the server responded with a status of 409 () @ https://perfectman-server-46159542194.us-central1.run.app/api/runs:0

--- a/.playwright-mcp/page-2026-09-06T22-52-02-562Z.yml
+++ b/.playwright-mcp/page-2026-09-06T22-52-02-562Z.yml
@@ -1,0 +1,15 @@
+- main [ref=f28e3]:
+  - generic [ref=f28e4]:
+    - heading "Three people in a room. One is not saying what they want." [level=1] [ref=f28e5]: Three people in a room.One is not saying what they want.
+    - paragraph [ref=f28e6]: "Nobody here takes turns. Each character reads the room, weighs what it would cost to speak, and often decides against it. What you see below is the whole product: a line, and the reason behind it."
+    - generic [ref=f28e7]:
+      - button "Build a room" [ref=f28e8] [cursor=pointer]
+      - button "Skip" [ref=f28e9] [cursor=pointer]
+  - generic [aria-hidden] [ref=f28e10]:
+    - generic [ref=f28e11]:
+      - generic [ref=f28e12]: íris
+      - generic [ref=f28e32]: bruno
+      - generic [ref=f28e52]: marcela
+    - paragraph [ref=f28e73]:
+      - generic [ref=f28e74]: íris
+      - text: so are we talking about last night or not

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -19,7 +19,7 @@ and CPU always allocated is the smallest thing that qualifies.
 gcloud run deploy perfectman-server \
   --source . --region=us-central1 \
   --allow-unauthenticated \
-  --port=8080 --cpu=1 --memory=1Gi \
+  --port=8080 --cpu=4 --memory=2Gi \
   --min-instances=0 --max-instances=1 \
   --no-cpu-throttling --timeout=3600 \
   --set-env-vars=PERFECTMAN_RUNS_DIR=/tmp/runs
@@ -33,7 +33,30 @@ Each flag is load-bearing:
 | `--no-cpu-throttling` | The pulse loop runs between requests. Throttled CPU stalls it the moment the POST response is sent. |
 | `--timeout=3600` | The SSE stream stays open for the length of the run. |
 | `--min-instances=0` | Scales to zero when idle. A cold start adds a few seconds; set it to 1 to avoid that and pay for the idle instance. |
+| `--cpu=4` | Measured, not guessed — see below. |
 | `PERFECTMAN_RUNS_DIR=/tmp/runs` | Cloud Run's filesystem is read-only apart from `/tmp`, which does not outlive the instance. Artifacts are readable while it is up and gone afterwards. |
+
+### On the CPU count
+
+One vCPU looks like plenty for a service that spends its time waiting on a
+model, and it is not. Measured on the same scene, model and key within minutes
+of each other:
+
+| Where | One pulse |
+|---|---|
+| Cloud Run, 1 vCPU | 483s |
+| Laptop | 80s |
+| Cloud Run, 4 vCPU | 61s |
+
+A pulse is not one request and a wait. It builds a prompt per agent, opens
+three TLS connections, and parses three large JSON replies, and all of that is
+CPU on a single-threaded runtime. A `mock` run hides it completely — ten pulses
+in under five seconds on the starved instance — because mock skips every part
+that costs anything.
+
+The failure mode is worth recognising because it does not look like slowness:
+`stop` cannot interrupt a pulse already in flight, so a starved instance sits
+in `stopping` for minutes and reads as a hang.
 
 ## The interface, on Vercel
 

--- a/packages/web/src/run/ProviderForm.tsx
+++ b/packages/web/src/run/ProviderForm.tsx
@@ -8,6 +8,7 @@
  */
 import { useMemo } from "react";
 import type { StartRunRequest } from "@perfectman/shared";
+import { KNOWN_ROUTES } from "./known-routes.js";
 
 export type ProviderValue = {
   llm: StartRunRequest["llm"];
@@ -61,6 +62,34 @@ export function ProviderForm({
         ))}
       </div>
 
+      {hosted ? (
+        <div className="routes">
+          <p className="u-dim">
+            Endpoints someone has already got working. Filling one in still
+            leaves you to paste the key.
+          </p>
+          <div className="routes__list">
+            {KNOWN_ROUTES.map((route) => (
+              <button
+                key={route.id}
+                type="button"
+                className="route"
+                onClick={() =>
+                  onChange({
+                    ...value,
+                    llm: { ...value.llm, ...route.llm },
+                    extraBodyText: route.extraBodyText,
+                  })
+                }
+              >
+                <span className="route__label">{route.label}</span>
+                <span className="route__note">{route.note}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <div className="provider__fields">
         {hosted ? (
           <>
@@ -76,7 +105,7 @@ export function ProviderForm({
               <span>Base URL</span>
               <input
                 value={value.llm.baseUrl ?? ""}
-                placeholder="https://api.example.com/v1"
+                placeholder="https://api.orcarouter.ai/v1"
                 onChange={(e) => set({ baseUrl: e.target.value })}
               />
             </label>

--- a/packages/web/src/run/known-routes.ts
+++ b/packages/web/src/run/known-routes.ts
@@ -1,0 +1,65 @@
+/**
+ * Endpoints somebody has already got working, and what each one needs.
+ *
+ * The two settings under "if the model answers with nothing" are the ones
+ * people get wrong, and they are not guessable: a reasoning model spends its
+ * whole output budget thinking unless told not to, some models run to the token
+ * cap inside schema-constrained decoding, and the key that disables reasoning
+ * differs per family. Every one of those cost a debugging session to find, so
+ * they are recorded here rather than left in the placeholder text.
+ *
+ * A route never carries a key. That is typed per run, becomes an environment
+ * variable for the run's lifetime, and is never written down — which is the
+ * whole reason the config stores a variable name instead.
+ */
+import type { StartRunRequest } from "@perfectman/shared";
+
+export type KnownRoute = {
+  id: string;
+  label: string;
+  note: string;
+  llm: Partial<StartRunRequest["llm"]>;
+  extraBodyText: string;
+};
+
+export const KNOWN_ROUTES: KnownRoute[] = [
+  {
+    id: "orca-qwen",
+    label: "OrcaRouter · Qwen3.5 27B",
+    note: "Verified. Needs json_object; no reasoning-disable field.",
+    llm: {
+      providerType: "openai-compatible",
+      modelName: "qwen/qwen3.5-27b",
+      baseUrl: "https://api.orcarouter.ai/v1",
+      responseFormatJson: true,
+      responseFormatJsonSchema: false,
+    },
+    extraBodyText: "",
+  },
+  {
+    id: "orca-deepseek",
+    label: "OrcaRouter · DeepSeek v4 Flash",
+    note: "Reasons by default — the extra field switches it off, or nothing parses.",
+    llm: {
+      providerType: "openai-compatible",
+      modelName: "deepseek/deepseek-v4-flash",
+      baseUrl: "https://api.orcarouter.ai/v1",
+      responseFormatJson: true,
+      responseFormatJsonSchema: false,
+    },
+    extraBodyText: '{ "thinking": { "type": "disabled" } }',
+  },
+  {
+    id: "ollama-local",
+    label: "Ollama on this machine",
+    note: "Needs the daemon running. No key.",
+    llm: {
+      providerType: "ollama",
+      modelName: "qwen3:8b",
+      baseUrl: "http://localhost:11434/v1",
+      responseFormatJson: true,
+      responseFormatJsonSchema: false,
+    },
+    extraBodyText: "",
+  },
+];

--- a/packages/web/src/run/run.css
+++ b/packages/web/src/run/run.css
@@ -15,6 +15,48 @@
   gap: 12px;
 }
 
+/* --- known routes -------------------------------------------------------- */
+
+.routes {
+  display: grid;
+  gap: 10px;
+}
+
+.routes > p {
+  font-size: 12.5px;
+}
+
+.routes__list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.route {
+  display: grid;
+  gap: 3px;
+  text-align: left;
+  border: none;
+  background: var(--paper);
+  box-shadow: var(--ring);
+  border-radius: var(--r-md);
+  padding: 9px 13px;
+  transition: box-shadow var(--quick) var(--ease);
+}
+.route:hover {
+  box-shadow: inset 0 0 0 1.5px var(--ink);
+}
+
+.route__label {
+  font-size: 13px;
+}
+
+.route__note {
+  font-size: 11.5px;
+  color: var(--ink-30);
+  max-width: 34ch;
+}
+
 .provider__fields {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));


### PR DESCRIPTION
## What

- Three one-click routes in the provider form — OrcaRouter/Qwen3.5-27B, OrcaRouter/DeepSeek-v4-Flash, local Ollama — filling base URL, model, JSON mode and extra request fields. None carries a key.
- `docs/deploying.md` gains the measured CPU numbers and raises the deploy to `--cpu=4 --memory=2Gi`.

## Why

The base-URL placeholder was `https://api.example.com/v1`, which conveys the shape and nothing else, while the two settings that actually decide whether a run produces anything sit behind a disclosure and are not guessable: a reasoning model burns its whole output budget thinking unless told not to, some models run to the token cap in schema-constrained decoding, and the disable field differs per family. That knowledge was living in a session transcript.

The CPU number was a guess and a bad one. Same scene, model and key: **483s per pulse on 1 vCPU, 80s on a laptop, 61s on 4**. A pulse builds three prompts, opens three TLS connections and parses three large replies — all CPU on a single-threaded runtime. `mock` hides it completely (ten pulses in under five seconds on the starved instance), and since `stop` cannot interrupt a pulse in flight, a starved instance sits in `stopping` for minutes and reads as a hang.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS - 1930 passed
- Prefill verified on the deployed site: one click fills model `qwen/qwen3.5-27b`, base URL, `json_object`, no extra fields, key left blank.
- 1-pulse run against Orca after the resize: 61s, 0 llmFailures.