### PR TITLE
fix(deploy): give Vercel a top-level dist after the web build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .worktrees/
 node_modules/
 packages/*/dist/
+/dist
 .vercel
 # Copied from packages/eval/assets at build; one copy in git is enough.
 packages/web/public/audio/

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -74,6 +74,10 @@ resolve `@perfectman/shared` from a pnpm workspace; building here and shipping
 the output sidesteps it. The Build Output API config lives in
 `.vercel/output/config.json` and only needs single-page rewrites.
 
+Git-connected deploys build from the repo root and look for a top-level `dist`.
+The root `vercel.json` builds `@perfectman/web` and copies `packages/web/dist`
+there so that lookup succeeds.
+
 Unset `VITE_API_BASE` and every request goes back to being relative, which is
 what the local `pnpm web` path wants — one process serving both.
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm --filter @perfectman/web build && rm -rf dist && cp -R packages/web/dist dist",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/((?!assets/|audio/|favicon).*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Points the Git-connected Vercel project at a real `dist`:

- Root `vercel.json` runs `pnpm --filter @perfectman/web build` and copies `packages/web/dist` to `./dist`
- Same SPA `rewrites` / asset `headers` as `packages/web/vercel.json`
- `/dist` added to `.gitignore`

## Why

The last production build compiled the web package, then failed with `No Output Directory named "dist"`. Vite writes `packages/web/dist`; Vercel was looking at the repo root.

## Validation

- `pnpm lint` and `pnpm test:all` not run this round
- Config-only: output path now matches the directory Vercel already checks


Made with [Cursor](https://cursor.com)