### PR TITLE
feat(web): flipbook stage with a contact-sheet scrubber and page turns

### DIFF
--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -20,14 +20,14 @@ measured in a browser; the gaps are stated as found, not as planned.
 
 ## The one idea to preserve
 
-Three typefaces carry three kinds of knowledge. That mapping is the design, not
+Two typefaces carry three kinds of knowledge. That mapping is the design, not
 decoration on it.
 
 | Face | Carries |
 |---|---|
 | Fraunces | What was said out loud — dialogue, headings |
 | Instrument Sans | The interface talking about itself — labels, controls, counts |
-| Caveat | What only the viewer can see — private motive, character name tags |
+| Fraunces italic | What only the viewer can see — private motive, character name tags |
 
 The engine's whole claim is that there is a gap between what an agent says and
 what it wants. Setting both in one face throws that away.

--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -4,14 +4,14 @@ A React SPA that turns a live simulation into a scene: characters as drawn
 figures whose faces move with recorded emotion, speech on paper, private motive
 in handwriting.
 
-Written against `main` @ `477f62a`. Everything below was read off the repo or
+Written against `main` @ `477f62a`, revised for the flipbook stage. Everything below was read off the repo or
 measured in a browser; the gaps are stated as found, not as planned.
 
 | | |
 |---|---|
 | Path | `packages/web` |
 | Stack | Vite 5 · React 18 · TypeScript |
-| Tests | 28 passing (`pnpm --filter @perfectman/web test`) |
+| Tests | 64 passing (`pnpm --filter @perfectman/web test`) |
 | Bundle | ~340 kB, ~100 kB gzipped |
 | Interface | https://web-rli81upwa-caiotheodoros-projects.vercel.app |
 | Run server | https://perfectman-server-46159542194.us-central1.run.app |
@@ -59,9 +59,12 @@ specific hop.
 6. **Clock** holds each beat for its reading time, then yields. A queue, not a
    timeline.
    `stage/useStageClock.ts`
-7. **Stage** places figures in slots and hangs one balloon off the speaker's
-   head.
-   `stage/Stage.tsx`, `stage/Bubble.tsx`
+7. **Place** every beat's seating in one pass, sticky per room.
+   `packages/shared/src/stage/placement.ts`
+8. **Stage** draws the placement and hangs one balloon off the speaker's
+   measured head; `Panel` turns the page when the room changes; the
+   `ContactSheet` under it is the run as a strip of pictures.
+   `stage/Panel.tsx`, `stage/Stage.tsx`, `stage/Bubble.tsx`, `stage/ContactSheet.tsx`
 
 ---
 
@@ -89,10 +92,13 @@ Forty files. These are the ones that carry weight.
 
 | File | What it does |
 |---|---|
-| `stage/Stage.tsx` | Slot placement, room kind, who is excluded. The busiest file. |
+| `stage/Panel.tsx` | The page. Keeps the leaving room mounted for the turn, with direction; instant under reduced motion. |
+| `stage/Stage.tsx` | Draws a `Placement`: figures on their marks, the excluded named, one balloon. Room only. |
+| `stage/Attribution.tsx` | The caption under the room. Separate so the turn rotates the picture, not the text. |
+| `stage/ContactSheet.tsx`, `stage/Frame.tsx` | The scrubber: one SVG frame per beat, no words, `aria-label` per frame, arrow keys. |
 | `stage/Figure.tsx` | The drawn character. Face is a pose lookup; every change is a CSS transition. |
-| `stage/useBubbleAnchor.ts` | Measures the balloon and clamps it inside the room. The pure function is tested. |
-| `stage/useStageClock.ts` | Live queue and replay seeking, one machine. |
+| `stage/useBubbleAnchor.ts` | Measures the speaker's drawn head and the balloon, clamps inside the room, moves beside the head when it cannot fit above. The pure functions are tested. |
+| `stage/useStageClock.ts` | Live queue and replay seeking, one machine. `reached` is the high-water mark the sheet draws up to. |
 | `stage/room-label.ts` | Names a private room by its members, because the engine names it with an id. |
 
 ### Run controls and the debug drawer
@@ -101,7 +107,8 @@ Forty files. These are the ones that carry weight.
 |---|---|
 | `run/RunScreen.tsx` | Warm-up gate, stage, transport, drawer. |
 | `run/known-routes.ts` | One-click provider prefills. Never holds a key. |
-| `run/useSoundtrack.ts` | Mood beds with an 8 s hold, plus SFX. See gaps — unverified by ear. |
+| `run/useSoundtrack.ts` | Mood beds with an 8 s hold, plus cues. `unlock()` runs in the Run click; a refusal flips the control but is not saved. |
+| `run/sfx-cue.ts` | Which cue a beat makes: once per line, none for a thought, none while paused. |
 | `run/DetailsDrawer.tsx` | Compiled config, diagnostics, raw frame log. Kept, just demoted. |
 
 ### Shared contract — outside `packages/web`
@@ -110,7 +117,8 @@ Forty files. These are the ones that carry weight.
 |---|---|
 | `shared/src/stage/live-to-beats.ts` | Pulse → beats. The event allowlist lives here. |
 | `shared/src/stage/emotion-face.ts` | Recorded emotion → face. Shared with the MP4 renderer so both agree. |
-| `shared/src/stage/slots.ts` | Where figures stand, as fractions. Also the figure-height constant the CSS mirrors. |
+| `shared/src/stage/slots.ts` | Where figures stand, as fractions. The figure-height constant is only the first-paint guess. |
+| `shared/src/stage/placement.ts` | `placeBeats`: seating for the whole run in one pass, memory keyed by room, not channel. |
 
 ---
 
@@ -139,9 +147,31 @@ order. Sorting first is what makes a character the same colour in both.
 Public seats six, private five. Carrying a slot index across without checking
 crashed on the first private channel a real run opened.
 
-**`FIGURE_HEIGHT_FRACTION` mirrors the CSS.**
-Balloon anchoring derives from it. Change the figure's width or the room's
-aspect ratio and you must change both, or balloons detach from heads.
+**A room is `kind/channel`, not the channel.**
+A silence renders the same channel as a one-seat thought room. Keying seating
+memory by channel let that overwrite the public room's seats, and the next
+spoken line moved everyone. `placeBeats` keys by room and walks the whole
+list, so seeking back also shows the seating a beat had the first time.
+
+**Balloon anchoring is measured; the constant is a guess.**
+`FIGURE_HEIGHT_FRACTION` knows the drawn figure and not the name tag under it,
+so a balloon placed from it sat 6–14px onto the head on every beat, and on a
+phone — where the mark's old 78px minimum made figures taller than the room —
+the balloon was clipped out of the frame. The hook measures the speaker's
+`.figure__body` against the room and re-measures on resize. When it still
+cannot fit above the head it goes beside it, never over the face.
+
+**One scrubber, and it has no words in it.**
+The contact sheet is the run as pictures: ground per room kind, a dot per
+person where they stood, a ring on the speaker. It replaced the range input.
+Anything readable in it would make it a transcript, which is what the details
+drawer is for. `reached` is not `behind`: seeking back does not un-draw.
+
+**Mute flips, only the toggle persists.**
+A refused `play()` turns the control off so it never claims sound that is not
+there, but does not write to `localStorage` — a missing file today must not
+mute every run tomorrow. An `AbortError` is a `play()` interrupted by
+`pause()`, which `unlock()` does on purpose, and is not a refusal.
 
 ---
 
@@ -149,24 +179,33 @@ aspect ratio and you must change both, or balloons detach from heads.
 
 Ranked by how likely it is to matter. Nothing here is secretly done.
 
-**Eight files have no test coverage.**
-`App`, `Stage`, `Figure`, `RunScreen`, `useSoundtrack`, `useStageClock`,
-`PickStep`, `preview.ts`. The 28 passing tests cover pure logic only — the
-fold, the balloon clamp, room naming. There is no DOM testing setup at all;
-adding jsdom and Testing Library is step one. `useStageClock` is the
-highest-value target: it is pure-ish and its queue behaviour is load-bearing.
+**Five files have no test coverage.**
+`App`, `Figure`, `RunScreen`, `useSoundtrack`, `PickStep`, `preview.ts`.
+`.test.tsx` files run under jsdom with Testing Library; `.test.ts` stay in
+node. `Stage`, `Panel`, `ContactSheet` and the clock's high-water mark have DOM
+tests; the fold, the balloon clamp, the cue rule, room naming and seating are
+pure. `useSoundtrack` is the largest untested surface and needs a fake
+`HTMLMediaElement`.
 
-**The soundtrack has never been heard.**
-Mood selection, the 8-second hold and the LUFS levelling are ported and
-typechecked, and the mute toggle works. Nobody has confirmed a bed actually
-plays or that the crossfade sounds like anything. Assume it is broken until you
-listen.
+**iOS ignores element volume.**
+The LUFS levelling and the crossfade are `HTMLMediaElement.volume` ramps, which
+iPhone Safari treats as read-only. The hook detects that and keeps beds off
+there rather than play one at full level over the dialogue; cues still play.
+A `GainNode` is the fix, and needs its own gesture-scoped `resume()`.
 
-**One breakpoint in the whole app.**
-940 px, and only in `intro.css`. Everything else leans on `auto-fill` grids and
-`clamp()`. Measured at 390 px: no horizontal scroll and balloons stay inside the
-room, but the stage compresses to 153 px tall and the transport wraps to three
-rows. Functional, not designed.
+**The page turn has not been seen on a real run.**
+The mock never leaves the public channel, so the room never changes in a mock
+run and the turn is covered by seven unit tests and a keyframe check only.
+Watch the first real run with a private channel.
+
+**Two breakpoints in the whole app.**
+940 px in `intro.css`, 640 px in `stage.css` where the room goes 4:3 and the
+sheet's frames shrink. Measured at 390 px: no horizontal scroll, the balloon is
+inside the room, and the longest mid-row name tag touches the front figure by
+1 px. The transport still wraps to rows. Functional, not designed.
+
+**The sheet stops being scannable past a few hundred beats.**
+A 40-beat run is ~2800 px of strip. Nothing paginates or groups it.
 
 **No way to open a past run.**
 `GET /api/runs` and `/api/runs/:id/replay` both exist, and the viewer already

--- a/packages/shared/src/stage/__tests__/live-to-beats.test.ts
+++ b/packages/shared/src/stage/__tests__/live-to-beats.test.ts
@@ -143,3 +143,32 @@ describe("priorEventsToBeats", () => {
     expect(beat?.duration).toBeGreaterThan(0);
   });
 });
+
+describe("pulseToBeats — pages", () => {
+  it("numbers a single-page line page 0", () => {
+    const [beat] = pulseToBeats(frame({ messages: [message()] }), CONTEXT);
+    expect(beat?.page).toBe(0);
+  });
+
+  it("numbers the pages of a long line so only the first can cue a sound", () => {
+    const text = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+    const beats = pulseToBeats(frame({ messages: [message({ text })] }), CONTEXT);
+    const spoken = beats.filter((b) => b.kind === "message");
+    expect(spoken.length).toBeGreaterThan(1);
+    expect(spoken.map((b) => b.page)).toEqual(spoken.map((_, i) => i));
+  });
+
+  it("numbers thought pages too", () => {
+    const motive = Array.from({ length: 50 }, (_, i) => `reason${i}`).join(" ");
+    const beats = pulseToBeats(
+      frame({ thinking: { marcela: thinking({ privateMotiveSummary: motive }) } }),
+      CONTEXT,
+    );
+    expect(beats.map((b) => b.page)).toEqual(beats.map((_, i) => i));
+  });
+
+  it("gives seeded history page 0", () => {
+    const [beat] = priorEventsToBeats([message()], CONTEXT);
+    expect(beat?.page).toBe(0);
+  });
+});

--- a/packages/shared/src/stage/__tests__/placement.test.ts
+++ b/packages/shared/src/stage/__tests__/placement.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Where everyone stands, for every beat at once.
+ *
+ * The stage used to remember seating in a ref keyed by channel. That had two
+ * failures this file pins down: a silence beat renders the same channel as a
+ * one-seat "thought" room and overwrote the public room's memory, and seeking
+ * backwards replayed with whatever the memory held by then. A pure pass over
+ * the whole beat list has neither problem, and the contact sheet needs every
+ * beat's seating anyway.
+ */
+import { describe, expect, it } from "vitest";
+import type { LiveChannel } from "../../live/live-frame.types.js";
+import type { StageBeat } from "../beat.js";
+import { idlePlacement, kindOf, placeBeats, roomKeyOf } from "../placement.js";
+import { slotsFor } from "../slots.js";
+
+const AGENTS = [{ id: "iris" }, { id: "bruno" }, { id: "marcela" }];
+const CHANNELS: LiveChannel[] = [
+  { id: "geral", name: "geral", type: "public_channel", memberAgentIds: ["iris", "bruno", "marcela"] },
+  { id: "dm", name: "dm", type: "private_channel", memberAgentIds: ["iris", "marcela"] },
+];
+
+let n = 0;
+function beat(over: Partial<StageBeat> = {}): StageBeat {
+  n += 1;
+  return {
+    id: `b${n}`,
+    kind: "message",
+    pulseIndex: 0,
+    channelId: "geral",
+    actorId: "iris",
+    text: "…",
+    audienceIds: [],
+    participantIds: ["iris", "bruno", "marcela"],
+    duration: 3,
+    page: 0,
+    ...over,
+  };
+}
+
+function seats(placement: { marks: readonly { agentId: string; slot: number }[] }): Record<string, number> {
+  return Object.fromEntries(placement.marks.map((m) => [m.agentId, m.slot]));
+}
+
+describe("placeBeats", () => {
+  it("returns one placement per beat, in order", () => {
+    const beats = [beat(), beat({ actorId: "bruno" })];
+    const placed = placeBeats(beats, AGENTS, CHANNELS);
+    expect(placed).toHaveLength(2);
+    expect(placed[1]?.speaker?.agentId).toBe("bruno");
+  });
+
+  it("keeps everyone seated across beats in the same room", () => {
+    const beats = [beat(), beat({ actorId: "bruno" }), beat({ actorId: "marcela" })];
+    const [a, b, c] = placeBeats(beats, AGENTS, CHANNELS);
+    expect(seats(b!)).toEqual(seats(a!));
+    expect(seats(c!)).toEqual(seats(a!));
+  });
+
+  it("does not let a silence in the same channel reshuffle the public room", () => {
+    // The old ref keyed memory by channel id, so the one-seat thought room
+    // overwrote the public room's seating and the next line moved everyone.
+    const beats = [
+      beat(),
+      beat({ kind: "silence", actorId: "marcela", text: "", thought: { text: "…", drivers: [] } }),
+      beat({ actorId: "bruno" }),
+    ];
+    const [first, silence, after] = placeBeats(beats, AGENTS, CHANNELS);
+    expect(silence?.kind).toBe("thought");
+    expect(silence?.marks).toHaveLength(1);
+    expect(seats(after!)).toEqual(seats(first!));
+  });
+
+  it("re-checks a held seat against the size of the new room", () => {
+    const six = [...AGENTS, { id: "d" }, { id: "e" }, { id: "f" }];
+    const all = six.map((a) => a.id);
+    const channels: LiveChannel[] = [
+      { id: "geral", name: "geral", type: "public_channel", memberAgentIds: all },
+      { id: "dm", name: "dm", type: "private_channel", memberAgentIds: all },
+    ];
+    const beats = [beat({ participantIds: all }), beat({ channelId: "dm", participantIds: all, actorId: "f" })];
+    const [, inPrivate] = placeBeats(beats, six, channels);
+    for (const mark of inPrivate!.marks) expect(mark.slot).toBeLessThan(slotsFor("private").length);
+  });
+
+  it("is deterministic: walking the list twice gives the same seating", () => {
+    const beats = [beat(), beat({ channelId: "dm", participantIds: ["iris", "marcela"] }), beat({ actorId: "marcela" })];
+    const once = placeBeats(beats, AGENTS, CHANNELS).map(seats);
+    const twice = placeBeats(beats, AGENTS, CHANNELS).map(seats);
+    expect(twice).toEqual(once);
+  });
+
+  it("carries the warm-up seating into the first beat", () => {
+    const idle = idlePlacement(CHANNELS[0], AGENTS);
+    const [first] = placeBeats([beat({ actorId: "marcela" })], AGENTS, CHANNELS, { seed: idle });
+    expect(seats(first!)).toEqual(seats(idle));
+  });
+
+  it("orders marks front to back by slot", () => {
+    const [placed] = placeBeats([beat({ actorId: "marcela" })], AGENTS, CHANNELS);
+    const slots = placed!.marks.map((m) => m.slot);
+    expect(slots).toEqual([...slots].sort((a, b) => a - b));
+  });
+
+  it("names the room by kind and channel, so a thought is a different room than the channel it came from", () => {
+    expect(roomKeyOf("thought", "geral")).not.toBe(roomKeyOf("public", "geral"));
+    const beats = [beat(), beat({ kind: "silence", actorId: "bruno", text: "", thought: { text: "…", drivers: [] } })];
+    const [talk, quiet] = placeBeats(beats, AGENTS, CHANNELS);
+    expect(quiet?.roomKey).not.toBe(talk?.roomKey);
+  });
+});
+
+describe("kindOf", () => {
+  it("makes a silence a thought whatever the channel", () => {
+    expect(kindOf("public_channel", beat({ kind: "silence" }))).toBe("thought");
+  });
+  it("reads the channel type otherwise", () => {
+    expect(kindOf("private_channel", beat())).toBe("private");
+    expect(kindOf("operator_channel", beat())).toBe("operator");
+    expect(kindOf("public_channel", undefined)).toBe("public");
+  });
+});
+
+describe("idlePlacement", () => {
+  it("seats the channel's members in channel order with nobody speaking", () => {
+    const idle = idlePlacement(CHANNELS[1], AGENTS);
+    expect(idle.kind).toBe("private");
+    expect(idle.marks.map((m) => m.agentId)).toEqual(["iris", "marcela"]);
+    expect(idle.speaker).toBeUndefined();
+  });
+  it("is an empty public room when there is no channel yet", () => {
+    expect(idlePlacement(undefined, AGENTS).marks).toEqual([]);
+  });
+});

--- a/packages/shared/src/stage/__tests__/slot-geometry.test.ts
+++ b/packages/shared/src/stage/__tests__/slot-geometry.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A name tag must be readable. The mid row stands behind the front row by
+ * design, but its tag sits under its feet — and if that lands inside a front
+ * figure's box, the name is hidden by a torso.
+ *
+ * Geometry in fractions of the room's width (W) with H = 7/16 W. A mark is 15%
+ * of W wide, scaled; the figure is 168 tall in a 100-wide box plus a 19px tag,
+ * so at scale s a mark spans [x − .075s, x + .075s] × [y − .616s·(16/7)/… , y].
+ * The tag is budgeted at ten italic characters (~0.55em of 19px each).
+ */
+import { describe, expect, it } from "vitest";
+import { slotsFor, type StageSlot } from "../slots.js";
+
+const H_OVER_W = 7 / 16;
+/** Figure height as a fraction of H at scale 1 — SVG 168 over a 100-wide mark at 15% of W. */
+const FIGURE_H = 0.15 * 1.68 / H_OVER_W;
+/** Name tag: ten characters at ~0.55em × 19px, in a 1200px-wide room. */
+const TAG_HALF_W = (10 * 0.55 * 19) / 2 / 1200;
+const TAG_H = 22 / (1200 * H_OVER_W);
+
+type Box = { left: number; right: number; top: number; bottom: number };
+
+function markBox(slot: StageSlot): Box {
+  return {
+    left: slot.x - 0.075 * slot.scale,
+    right: slot.x + 0.075 * slot.scale,
+    top: slot.y - FIGURE_H * slot.scale - TAG_H * slot.scale,
+    bottom: slot.y,
+  };
+}
+
+function tagBox(slot: StageSlot): Box {
+  return {
+    left: slot.x - (TAG_HALF_W * slot.scale) / 0.76,
+    right: slot.x + (TAG_HALF_W * slot.scale) / 0.76,
+    top: slot.y - TAG_H * slot.scale,
+    bottom: slot.y,
+  };
+}
+
+function intersects(a: Box, b: Box): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+describe("slot geometry", () => {
+  for (const kind of ["public", "private"] as const) {
+    it(`keeps every ${kind} name tag out of every closer figure's box`, () => {
+      const slots = slotsFor(kind);
+      const offenders: string[] = [];
+      slots.forEach((slot, i) => {
+        slots.forEach((other, j) => {
+          if (i === j || other.scale <= slot.scale) return;
+          if (intersects(tagBox(slot), markBox(other))) offenders.push(`${kind}[${i}] tag inside ${kind}[${j}]`);
+        });
+      });
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it("spaces the public rows evenly enough to read as a group", () => {
+    const xs = slotsFor("public").slice(0, 4).map((s) => s.x).sort((a, b) => a - b);
+    const gaps = xs.slice(1).map((x, i) => x - xs[i]!);
+    for (const gap of gaps) expect(gap).toBeGreaterThanOrEqual(0.12);
+  });
+});

--- a/packages/shared/src/stage/beat.ts
+++ b/packages/shared/src/stage/beat.ts
@@ -48,6 +48,12 @@ export type StageBeat = {
   stageAction?: { kind: "arrive" | "leave" | "invite"; agentIds: string[] };
   /** Seconds this beat holds before the next one takes the stage. */
   duration: number;
+  /**
+   * Which page of a paginated line this is, from 0. A long line becomes several
+   * beats; anything that should happen once per line — a sound cue, a frame on
+   * the contact sheet — checks for page 0.
+   */
+  page: number;
 };
 
 /** Keep every code point and newline; split at a word boundary when possible. */

--- a/packages/shared/src/stage/index.ts
+++ b/packages/shared/src/stage/index.ts
@@ -4,3 +4,4 @@ export * from "./slots.js";
 export * from "./beat.js";
 export * from "./live-to-beats.js";
 export * from "./mood.js";
+export * from "./placement.js";

--- a/packages/shared/src/stage/live-to-beats.ts
+++ b/packages/shared/src/stage/live-to-beats.ts
@@ -131,6 +131,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
         ...(emotion ? { emotion } : {}),
         stageAction: { kind: STAGE_ACTIONS[message.eventType] ?? "invite", agentIds: [message.actorId] },
         duration: readingSeconds(message.text || " "),
+        page: 0,
       });
       continue;
     }
@@ -154,6 +155,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
         participantIds,
         ...(emotion ? { emotion } : {}),
         duration: readingSeconds(text),
+        page,
       });
     });
 
@@ -227,6 +229,7 @@ function thoughtBeats(
     // Drivers belong with the last page, where the caption sits.
     thought: { ...thought, text, ...(page < pages.length - 1 ? { drivers: [] } : {}) },
     duration: readingSeconds(text),
+    page,
   }));
 }
 
@@ -244,5 +247,6 @@ export function priorEventsToBeats(priorEvents: readonly LiveMessage[], context:
     audienceIds: message.visibleToAgents,
     participantIds: membersOf(context.channels, message.channelId),
     duration: readingSeconds(message.text),
+    page: 0,
   }));
 }

--- a/packages/shared/src/stage/placement.ts
+++ b/packages/shared/src/stage/placement.ts
@@ -1,0 +1,110 @@
+/**
+ * Where everyone stands, for every beat at once.
+ *
+ * Seating is sticky per room: a figure that jumps to a different spot between
+ * two lines reads as a different person. The stage used to remember that in a
+ * ref keyed by channel, which broke twice — a silence renders the same channel
+ * as a one-seat thought room and overwrote the public room's memory, and
+ * seeking backwards replayed with whatever the memory held by then.
+ *
+ * So the whole list is placed in one pure pass. The room, not the channel, is
+ * the unit of memory, and the same list always produces the same seating. The
+ * contact sheet reads the same result the stage does, so they cannot disagree.
+ */
+import type { LiveChannel } from "../live/live-frame.types.js";
+import type { StageBeat } from "./beat.js";
+import { assignSlots, slotsFor, type ChannelKind, type StageSlot } from "./slots.js";
+
+export type PlacementAgent = { id: string };
+
+export type PlacedMark = {
+  agentId: string;
+  /** Index into the agents list the placement was made from. */
+  agentIndex: number;
+  slot: number;
+  point: StageSlot;
+};
+
+export type Placement = {
+  kind: ChannelKind;
+  channelId: string;
+  /** The room as drawn. A change here is a change of page. */
+  roomKey: string;
+  /** Sorted by slot, so DOM order is front to back. */
+  marks: readonly PlacedMark[];
+  speaker?: PlacedMark;
+};
+
+export function roomKeyOf(kind: ChannelKind, channelId: string): string {
+  return `${kind}/${channelId}`;
+}
+
+export function kindOf(channelType: string | undefined, beat: StageBeat | undefined): ChannelKind {
+  if (beat?.kind === "silence") return "thought";
+  if (channelType === "private_channel") return "private";
+  if (channelType === "operator_channel" || channelType === "spectator_channel") return "operator";
+  return "public";
+}
+
+/** Who stands where before anything has been said: members in channel order, nobody lit. */
+export function idlePlacement(channel: LiveChannel | undefined, agents: readonly PlacementAgent[]): Placement {
+  const kind = kindOf(channel?.type, undefined);
+  const channelId = channel?.id ?? "";
+  const indexById = indexes(agents);
+  const order = (channel?.memberAgentIds ?? []).map((id) => indexById.get(id)).filter((i): i is number => i !== undefined);
+  const slots = assignSlots(order, kind, new Map());
+  return { kind, channelId, roomKey: roomKeyOf(kind, channelId), marks: marksOf(slots, kind, agents) };
+}
+
+export function placeBeats(
+  beats: readonly StageBeat[],
+  agents: readonly PlacementAgent[],
+  channels: readonly LiveChannel[],
+  options: { seed?: Placement } = {},
+): Placement[] {
+  const indexById = indexes(agents);
+  const held = new Map<string, Map<number, number>>();
+  if (options.seed) {
+    held.set(options.seed.roomKey, new Map(options.seed.marks.map((m) => [m.agentIndex, m.slot])));
+  }
+
+  return beats.map((beat) => {
+    const channel = channels.find((c) => c.id === beat.channelId);
+    const kind = kindOf(channel?.type, beat);
+    const roomKey = roomKeyOf(kind, beat.channelId);
+    const slots = assignSlots(presentOrder(beat, indexById), kind, held.get(roomKey) ?? new Map());
+    held.set(roomKey, slots);
+    const marks = marksOf(slots, kind, agents);
+    const speaker = marks.find((m) => m.agentId === beat.actorId);
+    return { kind, channelId: beat.channelId, roomKey, marks, ...(speaker ? { speaker } : {}) };
+  });
+}
+
+/**
+ * Who stands where, most important first: the speaker, then whoever the line
+ * is aimed at, then everyone else in the room. `assignSlots` caps it.
+ */
+function presentOrder(beat: StageBeat, indexById: ReadonlyMap<string, number>): number[] {
+  const ids = [...(beat.actorId ? [beat.actorId] : []), ...beat.audienceIds, ...beat.participantIds];
+  const seen = new Set<number>();
+  const order: number[] = [];
+  for (const id of ids) {
+    const at = indexById.get(id);
+    if (at === undefined || seen.has(at)) continue;
+    seen.add(at);
+    order.push(at);
+  }
+  return order;
+}
+
+function marksOf(slots: ReadonlyMap<number, number>, kind: ChannelKind, agents: readonly PlacementAgent[]): PlacedMark[] {
+  const points = slotsFor(kind);
+  return [...slots]
+    .map(([agentIndex, slot]) => ({ agentIndex, slot, agentId: agents[agentIndex]?.id ?? "", point: points[slot] }))
+    .filter((m): m is PlacedMark => m.point !== undefined && m.agentId !== "")
+    .sort((a, b) => a.slot - b.slot);
+}
+
+function indexes(agents: readonly PlacementAgent[]): Map<string, number> {
+  return new Map(agents.map((a, i) => [a.id, i]));
+}

--- a/packages/shared/src/stage/slots.ts
+++ b/packages/shared/src/stage/slots.ts
@@ -14,12 +14,11 @@
 export type StageSlot = { x: number; y: number; scale: number };
 
 /**
- * How tall a figure stands, as a fraction of the room's height.
- *
- * Derived, not measured: a mark is 15% of the room's width, the figure is drawn
- * 100 wide by 168 tall, and the room is 16:7. Balloons hang off the top of a
- * head, so they need this to know where a head ends — and it has to agree with
- * the CSS or a balloon will float or overlap. Change one, change both.
+ * How tall a figure's drawing stands, as a fraction of the room's height, in a
+ * 16:7 room: a mark is 15% of the room's width and the figure is drawn 100
+ * wide by 168 tall. This is the first-paint guess for where a head begins; the
+ * stage measures the real thing once it has laid out, because the name tag
+ * under the figure is set in pixels and the room is not 16:7 on a phone.
  */
 export const FIGURE_HEIGHT_FRACTION = 0.15 * 1.68 * (16 / 7);
 
@@ -38,8 +37,10 @@ export type ChannelKind = "public" | "private" | "thought" | "operator";
 const PUBLIC_SLOTS: readonly StageSlot[] = [
   { x: 0.29, y: 0.94, scale: 1.0 },
   { x: 0.71, y: 0.94, scale: 1.0 },
-  { x: 0.45, y: 0.7, scale: 0.78 },
-  { x: 0.63, y: 0.68, scale: 0.76 },
+  // The mid pair sits inside the front pair's gap so their name tags clear the
+  // front figures' torsos: a tag under .63 landed inside the figure at .71.
+  { x: 0.42, y: 0.7, scale: 0.78 },
+  { x: 0.58, y: 0.68, scale: 0.76 },
   { x: 0.13, y: 0.52, scale: 0.6 },
   { x: 0.87, y: 0.52, scale: 0.6 },
 ];

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@fontsource-variable/caveat": "^5.3.0",
     "@fontsource-variable/fraunces": "^5.3.0",
     "@fontsource-variable/instrument-sans": "^5.3.0",
     "@types/react": "^18.3.12",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,9 +19,11 @@
   "devDependencies": {
     "@fontsource-variable/fraunces": "^5.3.0",
     "@fontsource-variable/instrument-sans": "^5.3.0",
+    "@testing-library/react": "^16.3.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^30.0.1",
     "typescript": "^5.5.0",
     "vite": "^5.4.11",
     "vitest": "^2.0.0"

--- a/packages/web/src/components/legacy.css
+++ b/packages/web/src/components/legacy.css
@@ -64,6 +64,10 @@
   border-collapse: collapse;
   font: 12px var(--mono);
   white-space: nowrap;
+  /* Wide by nature; scrolls in place rather than widening the page. */
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 .grid th {
   text-align: left;

--- a/packages/web/src/design/fonts.css
+++ b/packages/web/src/design/fonts.css
@@ -1,16 +1,13 @@
 /*
- * Three faces, three kinds of knowledge.
+ * Two faces, two jobs.
  *
- * Fraunces carries what was said out loud and the display type. Instrument Sans
- * is the interface talking about itself. Caveat is reserved, strictly, for what
- * only the viewer can see — an agent's private motive and the name tags beside
- * the figures. That assignment is the point: the engine's claim is that there
- * is a gap between what someone says and what they want, so the two are not set
- * in the same voice.
+ * Fraunces carries what was said out loud, the display type, and — in italic —
+ * what only the viewer can see. Instrument Sans is the interface talking about
+ * itself. A script face used to mark the private line; it read as a costume.
+ * Italic is enough to keep speech and motive from being the same voice.
  *
  * Self-hosted rather than fetched. This is a localhost tool and it has to work
  * on a plane.
  */
 @import "@fontsource-variable/fraunces/full.css";
 @import "@fontsource-variable/instrument-sans/index.css";
-@import "@fontsource-variable/caveat/index.css";

--- a/packages/web/src/design/tokens.css
+++ b/packages/web/src/design/tokens.css
@@ -41,6 +41,8 @@
   --ease: cubic-bezier(0.2, 0.7, 0.3, 1);
   --quick: 160ms;
   --settle: 380ms;
+  /* A page turning. Mirrored by TURN_MS in stage/Panel.tsx. */
+  --turn: 520ms;
 
   color-scheme: light;
 }

--- a/packages/web/src/design/tokens.css
+++ b/packages/web/src/design/tokens.css
@@ -27,7 +27,8 @@
 
   --serif: "Fraunces Variable", Georgia, "Times New Roman", serif;
   --sans: "Instrument Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --hand: "Caveat Variable", "Bradley Hand", cursive;
+  /* Private motive and name tags: italic Fraunces, not a script face. */
+  --hand: "Fraunces Variable", Georgia, "Times New Roman", serif;
 
   /* Display Fraunces: soft, slightly wonky, optically sized for large text. */
   --serif-display: "opsz" 144, "SOFT" 60, "WONK" 1;
@@ -96,8 +97,10 @@ p {
 
 .u-hand {
   font-family: var(--hand);
-  font-weight: 500;
-  letter-spacing: 0;
+  font-variation-settings: var(--serif-text);
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: -0.01em;
 }
 
 .u-dim {

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -60,7 +60,7 @@ export function RunScreen({
   const beats = useStageBeats(stream.replay);
   const clock = useStageClock(beats);
   const running = stream.status ? !IDLE_STATES.has(stream.status.state) : false;
-  const sound = useSoundtrack(clock.beat, running || beats.length > 0);
+  const sound = useSoundtrack(clock.beat, running || beats.length > 0, clock.playing);
 
   const started = runId !== null;
   const agents = stream.replay?.agents ?? EMPTY_AGENTS;
@@ -106,7 +106,12 @@ export function RunScreen({
           <ProviderForm
             value={provider}
             onChange={setProvider}
-            onRun={() => onRun(provider.llm, provider.maxPulses ? { maxPulses: provider.maxPulses } : undefined)}
+            onRun={() => {
+              // Inside the click, before anything async: this is the gesture
+              // the browser will let the soundtrack play under later.
+              sound.unlock();
+              onRun(provider.llm, provider.maxPulses ? { maxPulses: provider.maxPulses } : undefined);
+            }}
             ready={Boolean(compiled?.ok)}
           />
         </>

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -9,8 +9,9 @@
 import { useMemo, useState } from "react";
 import { idlePlacement, placeBeats, type CompileResponse, type StartRunRequest } from "@perfectman/shared";
 import type { RunStream } from "../api/useRunStream.js";
-import type { LiveChannel, Placement } from "@perfectman/shared";
-import { Stage, type StageAgent } from "../stage/Stage.js";
+import type { LiveChannel } from "@perfectman/shared";
+import type { StageAgent } from "../stage/Stage.js";
+import { Panel } from "../stage/Panel.js";
 import { Attribution } from "../stage/Attribution.js";
 import { useStageClock } from "../stage/useStageClock.js";
 import { useStageBeats } from "./useStageBeats.js";
@@ -102,38 +103,52 @@ export function RunScreen({
             ready={Boolean(compiled?.ok)}
           />
         </>
-      ) : !ready ? (
-        <Warmup stream={stream} agents={agents} channels={channels} ids={ids} idle={idle} beats={beats.length} />
       ) : (
         <>
+          {/* One page for the whole run. The warm-up room is the same Panel as
+              the first line, so the first beat continues the picture rather
+              than replacing it. */}
           <div className="flipbook">
-            <Stage beat={clock.beat} placement={placement} agents={agents} channels={channels} ids={ids} />
-            <Attribution beat={clock.beat} agents={agents} channels={channels} ids={ids} />
+            <Panel
+              beat={ready ? clock.beat : undefined}
+              placement={ready ? placement : idle}
+              index={ready ? clock.index : 0}
+              agents={agents}
+              channels={channels}
+              ids={ids}
+            />
+            {ready ? <Attribution beat={clock.beat} agents={agents} channels={channels} ids={ids} /> : null}
           </div>
-          <Transport
-            beats={beats}
-            index={clock.index}
-            channels={channels}
-            agents={agents}
-            playing={clock.playing}
-            behind={clock.behind}
-            live={running}
-            muted={sound.muted}
-            onPlayPause={() => (clock.playing ? clock.pause() : clock.play())}
-            onStep={clock.step}
-            onSeek={clock.seek}
-            onMute={sound.toggle}
-          />
-          <div className="run__foot">
-            <RunState stream={stream} running={running} />
-            <span className="transport__spacer" />
-            {running ? (
-              <button type="button" className="btn--quiet" onClick={onStop}>
-                Stop the run
-              </button>
-            ) : null}
-          </div>
-          <DetailsDrawer compiled={compiled} stream={stream} runId={runId} />
+          {!ready ? (
+            <WarmupNote stream={stream} agents={agents} beats={beats.length} />
+          ) : (
+            <>
+              <Transport
+                beats={beats}
+                index={clock.index}
+                channels={channels}
+                agents={agents}
+                playing={clock.playing}
+                behind={clock.behind}
+                live={running}
+                muted={sound.muted}
+                onPlayPause={() => (clock.playing ? clock.pause() : clock.play())}
+                onStep={clock.step}
+                onSeek={clock.seek}
+                onMute={sound.toggle}
+              />
+              <div className="run__foot">
+                <RunState stream={stream} running={running} />
+                <span className="transport__spacer" />
+                {running ? (
+                  <button type="button" className="btn--quiet" onClick={onStop}>
+                    Stop the run
+                  </button>
+                ) : null}
+              </div>
+              <DetailsDrawer compiled={compiled} stream={stream} runId={runId} />
+            </>
+          )}
         </>
       )}
     </section>
@@ -143,31 +158,22 @@ export function RunScreen({
 /**
  * The wait, with something to look at.
  *
- * The cast is already known from `hello`, so the room can be set before anyone
- * has spoken — which also means the first real beat is a continuation rather
- * than the picture appearing from nothing.
+ * The cast is already known from `hello`, so the room above is set before
+ * anyone has spoken — which also means the first real beat is a continuation
+ * rather than the picture appearing from nothing. This is only the note.
  */
-function Warmup({
+function WarmupNote({
   stream,
   agents,
-  channels,
-  ids,
-  idle,
   beats,
 }: {
   stream: RunStream;
   agents: readonly StageAgent[];
-  channels: readonly LiveChannel[];
-  ids: readonly string[];
-  idle: Placement;
   beats: number;
 }): JSX.Element {
   const state = stream.status?.state;
   return (
     <div className="warmup">
-      <div className="flipbook">
-        <Stage beat={undefined} placement={idle} agents={agents} channels={channels} ids={ids} />
-      </div>
       <p className="warmup__note">
         <span className="warmup__pulse" aria-hidden="true" />
         {state === "health_check"

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -13,6 +13,8 @@ import type { LiveChannel } from "@perfectman/shared";
 import type { StageAgent } from "../stage/Stage.js";
 import { Panel } from "../stage/Panel.js";
 import { Attribution } from "../stage/Attribution.js";
+import { ContactSheet } from "../stage/ContactSheet.js";
+import { frameFor, frameLabel } from "../stage/Frame.js";
 import { useStageClock } from "../stage/useStageClock.js";
 import { useStageBeats } from "./useStageBeats.js";
 import { useSoundtrack } from "./useSoundtrack.js";
@@ -69,6 +71,11 @@ export function RunScreen({
   const idle = useMemo(() => idlePlacement(channels[0], agents), [channels, agents]);
   const placements = useMemo(() => placeBeats(beats, agents, channels, { seed: idle }), [beats, agents, channels, idle]);
   const placement = placements[clock.index] ?? idle;
+  const frames = useMemo(() => beats.map((b, i) => frameFor(b, placements[i] ?? idle, ids)), [beats, placements, idle, ids]);
+  const labels = useMemo(
+    () => beats.map((b) => frameLabel(b, agents, channels.find((c) => c.id === b.channelId))),
+    [beats, agents, channels],
+  );
   // Once it has played, it keeps playing: a mid-run dip below the threshold is
   // the queue working, not a reason to pull the curtain back down.
   const [warm, setWarm] = useState(false);
@@ -117,7 +124,19 @@ export function RunScreen({
               channels={channels}
               ids={ids}
             />
-            {ready ? <Attribution beat={clock.beat} agents={agents} channels={channels} ids={ids} /> : null}
+            {ready ? (
+              <>
+                <Attribution beat={clock.beat} agents={agents} channels={channels} ids={ids} />
+                <ContactSheet
+                  frames={frames}
+                  labels={labels}
+                  index={clock.index}
+                  reached={clock.reached}
+                  live={running}
+                  onSeek={clock.seek}
+                />
+              </>
+            ) : null}
           </div>
           {!ready ? (
             <WarmupNote stream={stream} agents={agents} beats={beats.length} />

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -6,11 +6,12 @@
  * moves into `details`, still complete, just no longer the thing you are
  * looking at.
  */
-import { useState } from "react";
-import type { CompileResponse, StartRunRequest } from "@perfectman/shared";
+import { useMemo, useState } from "react";
+import { idlePlacement, placeBeats, type CompileResponse, type StartRunRequest } from "@perfectman/shared";
 import type { RunStream } from "../api/useRunStream.js";
-import type { LiveChannel } from "@perfectman/shared";
+import type { LiveChannel, Placement } from "@perfectman/shared";
 import { Stage, type StageAgent } from "../stage/Stage.js";
+import { Attribution } from "../stage/Attribution.js";
 import { useStageClock } from "../stage/useStageClock.js";
 import { useStageBeats } from "./useStageBeats.js";
 import { useSoundtrack } from "./useSoundtrack.js";
@@ -19,6 +20,10 @@ import { DetailsDrawer } from "./DetailsDrawer.js";
 import { ProviderForm, type ProviderValue, DEFAULT_PROVIDER } from "./ProviderForm.js";
 
 const IDLE_STATES = new Set(["idle", "done", "failed"]);
+// Stable empties, so the memos below do not recompute on every render before
+// the run has said hello.
+const EMPTY_AGENTS: readonly StageAgent[] = [];
+const EMPTY_CHANNELS: readonly LiveChannel[] = [];
 
 /**
  * How much of the run to have in hand before the stage starts playing.
@@ -55,8 +60,14 @@ export function RunScreen({
   const sound = useSoundtrack(clock.beat, running || beats.length > 0);
 
   const started = runId !== null;
-  const agents = stream.replay?.agents ?? [];
-  const channels = stream.replay?.channels ?? [];
+  const agents = stream.replay?.agents ?? EMPTY_AGENTS;
+  const channels = stream.replay?.channels ?? EMPTY_CHANNELS;
+  const ids = useMemo(() => agents.map((a) => a.id), [agents]);
+  // Seating for the whole run, decided once. The idle room seeds it so the
+  // first line is a continuation of the warm-up picture, not a reshuffle.
+  const idle = useMemo(() => idlePlacement(channels[0], agents), [channels, agents]);
+  const placements = useMemo(() => placeBeats(beats, agents, channels, { seed: idle }), [beats, agents, channels, idle]);
+  const placement = placements[clock.index] ?? idle;
   // Once it has played, it keeps playing: a mid-run dip below the threshold is
   // the queue working, not a reason to pull the curtain back down.
   const [warm, setWarm] = useState(false);
@@ -92,10 +103,13 @@ export function RunScreen({
           />
         </>
       ) : !ready ? (
-        <Warmup stream={stream} agents={agents} channels={channels} beats={beats.length} />
+        <Warmup stream={stream} agents={agents} channels={channels} ids={ids} idle={idle} beats={beats.length} />
       ) : (
         <>
-          <Stage beat={clock.beat} agents={agents} channels={channels} />
+          <div className="flipbook">
+            <Stage beat={clock.beat} placement={placement} agents={agents} channels={channels} ids={ids} />
+            <Attribution beat={clock.beat} agents={agents} channels={channels} ids={ids} />
+          </div>
           <Transport
             beats={beats}
             index={clock.index}
@@ -137,17 +151,23 @@ function Warmup({
   stream,
   agents,
   channels,
+  ids,
+  idle,
   beats,
 }: {
   stream: RunStream;
   agents: readonly StageAgent[];
   channels: readonly LiveChannel[];
+  ids: readonly string[];
+  idle: Placement;
   beats: number;
 }): JSX.Element {
   const state = stream.status?.state;
   return (
     <div className="warmup">
-      <Stage beat={undefined} agents={agents} channels={channels} idleChannelId={channels[0]?.id} />
+      <div className="flipbook">
+        <Stage beat={undefined} placement={idle} agents={agents} channels={channels} ids={ids} />
+      </div>
       <p className="warmup__note">
         <span className="warmup__pulse" aria-hidden="true" />
         {state === "health_check"

--- a/packages/web/src/run/Transport.tsx
+++ b/packages/web/src/run/Transport.tsx
@@ -4,7 +4,8 @@
  * The channel row is a readout, not a filter: the stage follows the beat into
  * whichever room it happens in, and clicking a channel scrubs to the last thing
  * said there. Filtering the run down to one channel is what the details drawer
- * is for.
+ * is for. Scrubbing by position is the contact sheet's job, so there is no
+ * slider here; the count is a readout too.
  */
 import type { LiveChannel, StageBeat } from "@perfectman/shared";
 import { roomLabel, type NamedAgent } from "../stage/room-label.js";
@@ -93,22 +94,10 @@ export function Transport({
         >
           {muted ? "Sound off" : "Sound on"}
         </button>
-      </div>
-
-      <label className="transport__seek">
-        <span className="u-dim">position</span>
-        <input
-          type="range"
-          min={0}
-          max={Math.max(0, beats.length - 1)}
-          value={index}
-          onChange={(e) => onSeek(Number(e.target.value))}
-          aria-label="Position in the run"
-        />
-        <output>
+        <output className="transport__count" aria-label="Position in the run">
           {beats.length === 0 ? "0 / 0" : `${index + 1} / ${beats.length}`}
         </output>
-      </label>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/run/__tests__/playback-refusal.test.ts
+++ b/packages/web/src/run/__tests__/playback-refusal.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Not every rejected play() means the browser said no. Pausing an element
+ * while its play() is still settling rejects that promise with an AbortError,
+ * and the soundtrack does that on purpose when it unlocks. Only a real refusal
+ * should flip the sound control off.
+ */
+import { describe, expect, it } from "vitest";
+import { isPlaybackRefusal } from "../useSoundtrack.js";
+
+describe("isPlaybackRefusal", () => {
+  it("treats autoplay policy and unsupported media as refusals", () => {
+    expect(isPlaybackRefusal(new DOMException("blocked", "NotAllowedError"))).toBe(true);
+    expect(isPlaybackRefusal(new DOMException("bad file", "NotSupportedError"))).toBe(true);
+  });
+  it("lets an interrupted play() pass", () => {
+    expect(isPlaybackRefusal(new DOMException("interrupted", "AbortError"))).toBe(false);
+  });
+  it("does not flip the control over an unknown failure", () => {
+    expect(isPlaybackRefusal(new Error("weird"))).toBe(false);
+    expect(isPlaybackRefusal(undefined)).toBe(false);
+  });
+});

--- a/packages/web/src/run/__tests__/sfx-cue.test.ts
+++ b/packages/web/src/run/__tests__/sfx-cue.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Which sound a beat makes, if any. A long line is several beats and should
+ * click once; stepping through beats by hand should not click at all.
+ */
+import { describe, expect, it } from "vitest";
+import type { StageBeat } from "@perfectman/shared";
+import { sfxCueFor } from "../sfx-cue.js";
+
+function beat(over: Partial<StageBeat> = {}): StageBeat {
+  return {
+    id: "b", kind: "message", pulseIndex: 0, channelId: "c", actorId: "a", text: "hi",
+    audienceIds: [], participantIds: ["a"], duration: 3, page: 0, ...over,
+  };
+}
+
+describe("sfxCueFor", () => {
+  it("clicks for a spoken line", () => {
+    expect(sfxCueFor(beat())).toBe("message");
+  });
+  it("clicks once per line, not once per page", () => {
+    expect(sfxCueFor(beat({ page: 1 }))).toBeNull();
+  });
+  it("stays quiet for a thought", () => {
+    expect(sfxCueFor(beat({ kind: "aside" }))).toBeNull();
+    expect(sfxCueFor(beat({ kind: "silence" }))).toBeNull();
+  });
+  it("marks arrivals and departures", () => {
+    expect(sfxCueFor(beat({ kind: "event", stageAction: { kind: "arrive", agentIds: [] } }))).toBe("arrival");
+    expect(sfxCueFor(beat({ kind: "event", stageAction: { kind: "invite", agentIds: [] } }))).toBe("arrival");
+    expect(sfxCueFor(beat({ kind: "event", stageAction: { kind: "leave", agentIds: [] } }))).toBe("departure");
+  });
+});

--- a/packages/web/src/run/run.css
+++ b/packages/web/src/run/run.css
@@ -189,26 +189,11 @@
   gap: 14px;
 }
 
-.transport__seek {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex: 1 1 260px;
-  min-width: 200px;
-  font-size: 12px;
-}
-
-.transport__seek input {
-  flex: 1;
-  padding: 0;
-  box-shadow: none;
-  background: none;
-  accent-color: var(--ink);
-}
-
-.transport__seek output {
+.transport__count {
   font-variant-numeric: tabular-nums;
   color: var(--ink-50);
+  font-size: 12px;
+  padding-left: 4px;
 }
 
 .run__foot {

--- a/packages/web/src/run/run.css
+++ b/packages/web/src/run/run.css
@@ -144,6 +144,7 @@
 
 .transport__rooms {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
 }
 
@@ -151,6 +152,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  white-space: nowrap;
   border: none;
   background: none;
   border-radius: var(--r-pill);
@@ -199,6 +201,7 @@
 .run__foot {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 14px;
   font-size: 13px;
 }
@@ -226,6 +229,16 @@
   display: grid;
   gap: 16px;
   padding-top: 16px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+/* Compiled config and raw frames are wide by nature; they scroll inside their
+   own box rather than giving the page a horizontal scrollbar on a phone. */
+.drawer__body .panel {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .drawer__body code {

--- a/packages/web/src/run/sfx-cue.ts
+++ b/packages/web/src/run/sfx-cue.ts
@@ -1,0 +1,15 @@
+/**
+ * Which one-shot sound a beat makes, if any.
+ *
+ * Pure, so the rule is testable without an audio element: a spoken line clicks
+ * once — on its first page, because a long line is several beats — someone
+ * arriving or leaving gets their own cue, and a thought makes no sound because
+ * nobody in the room heard it.
+ */
+import type { SFX, StageBeat } from "@perfectman/shared";
+
+export function sfxCueFor(beat: StageBeat): keyof typeof SFX | null {
+  if (beat.stageAction) return beat.stageAction.kind === "leave" ? "departure" : "arrival";
+  if (beat.kind === "message" && beat.page === 0) return "message";
+  return null;
+}

--- a/packages/web/src/run/useSoundtrack.ts
+++ b/packages/web/src/run/useSoundtrack.ts
@@ -8,68 +8,94 @@
  *
  * Beds loop and crossfade; the volume per bed comes from its measured LUFS, so
  * all three sit at the same level under the dialogue rather than one jumping
- * out. Sound starts on because pressing Run is the gesture browsers want, and a
- * silent first run means nobody finds out it exists. If the browser refuses
- * anyway the toggle flips back rather than claiming to be playing.
+ * out. Sound starts on because pressing Run is the gesture browsers want — and
+ * `unlock` has to be called inside that click, because Safari only lets an
+ * element play later if it was played once during a gesture. If the browser
+ * refuses anyway the toggle flips back rather than claiming to be playing; the
+ * refusal is not saved, because a missing file today should not mute every
+ * run tomorrow. Only the reader's own toggle persists.
  */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   BEDS,
   CROSSFADE_SECONDS,
-  MINIMUM_MOOD_HOLD_SECONDS,
   SFX,
   SFX_VOLUME,
   bedVolume,
+  canChangeMood,
   moodFor,
   type Mood,
   type StageBeat,
 } from "@perfectman/shared";
+import { sfxCueFor } from "./sfx-cue.js";
 
 const MUTED_KEY = "perfectman.sound.muted";
 const AUDIO_BASE = "/audio";
 
-export function useSoundtrack(beat: StageBeat | undefined, active: boolean) {
+type Cue = keyof typeof SFX;
+
+export function useSoundtrack(beat: StageBeat | undefined, active: boolean, playing: boolean) {
   const [muted, setMuted] = useState(() => readMuted());
   const beds = useRef<Partial<Record<Mood, HTMLAudioElement>>>({});
+  const cues = useRef<Partial<Record<Cue, HTMLAudioElement>>>({});
   const mood = useRef<Mood>("calm");
   const changedAt = useRef(0);
   const lastBeatId = useRef<string | undefined>(undefined);
+  // iOS ignores writes to an element's volume, which makes the LUFS levelling
+  // and the crossfade no-ops and would play a bed at full level over the
+  // dialogue. Better no bed than that; the cues still play.
+  const volumeLocked = useRef(false);
+  const wantBeds = useRef(false);
 
-  // One element per bed, created once and reused. Looping in the element beats
-  // re-scheduling: the beds are minutes long and a run rarely outlasts one.
+  // One element per bed and per cue, created once and reused. Looping in the
+  // element beats re-scheduling: the beds are minutes long and a run rarely
+  // outlasts one. Cues are pre-created so `unlock` can reach them too.
   useEffect(() => {
+    const probe = new Audio();
+    probe.volume = 0.5;
+    volumeLocked.current = probe.volume !== 0.5;
+
     for (const [key, bed] of Object.entries(BEDS)) {
       const audio = new Audio(`${AUDIO_BASE}/${bed.file}`);
       audio.loop = true;
       audio.volume = 0;
+      audio.preload = "auto";
       beds.current[key as Mood] = audio;
     }
-    const created = beds.current;
+    for (const [key, file] of Object.entries(SFX)) {
+      const audio = new Audio(`${AUDIO_BASE}/${file}`);
+      audio.volume = SFX_VOLUME;
+      audio.preload = "auto";
+      cues.current[key as Cue] = audio;
+    }
+    const created = [...Object.values(beds.current), ...Object.values(cues.current)];
     return () => {
-      for (const audio of Object.values(created)) {
+      for (const audio of created) {
         audio.pause();
         audio.src = "";
       }
       beds.current = {};
+      cues.current = {};
     };
   }, []);
 
+  wantBeds.current = active && !muted && !volumeLocked.current;
+
+  // A refusal to play is shown, not stored: the control stops claiming sound
+  // that is not there, and the next run gets to try again.
+  const start = useCallback((audio: HTMLAudioElement) => {
+    void audio.play().catch(() => setMuted(true));
+  }, []);
+
   useEffect(() => {
-    const wanted = active && !muted;
+    const on = wantBeds.current;
     for (const [key, audio] of Object.entries(beds.current)) {
-      const target = key === mood.current && wanted ? bedVolume(key as Mood) : 0;
+      const target = key === mood.current && on ? bedVolume(key as Mood) : 0;
       fade(audio, target);
-      if (target > 0 && audio.paused) {
-        void audio.play().catch(() => {
-          // Autoplay refused, or the file is missing. Say so by flipping the
-          // control rather than leaving it claiming to play.
-          setMuted(true);
-          writeMuted(true);
-        });
-      }
-      if (target === 0 && !audio.paused && !wanted) audio.pause();
+      if (target > 0 && audio.paused) start(audio);
+      if (target === 0 && !audio.paused && !on) audio.pause();
     }
-  }, [muted, active]);
+  }, [muted, active, start]);
 
   useEffect(() => {
     if (!beat || beat.id === lastBeatId.current) return;
@@ -77,30 +103,65 @@ export function useSoundtrack(beat: StageBeat | undefined, active: boolean) {
 
     const now = Date.now() / 1000;
     const next = moodFor(beat.emotion);
-    if (next !== mood.current && now - changedAt.current >= MINIMUM_MOOD_HOLD_SECONDS) {
+    if (next !== mood.current && canChangeMood(changedAt.current, now)) {
       const leaving = beds.current[mood.current];
       if (leaving) fade(leaving, 0);
       mood.current = next;
       changedAt.current = now;
       const arriving = beds.current[next];
-      if (arriving && active && !muted) {
+      if (arriving && wantBeds.current) {
         fade(arriving, bedVolume(next));
-        void arriving.play().catch(() => undefined);
+        if (arriving.paused) start(arriving);
       }
     }
 
-    if (!muted && active) {
-      const cue = beat.stageAction?.kind === "leave" ? SFX.departure : beat.stageAction ? SFX.arrival : beat.kind === "message" ? SFX.message : null;
-      if (cue) {
-        const sfx = new Audio(`${AUDIO_BASE}/${cue}`);
-        sfx.volume = SFX_VOLUME;
-        void sfx.play().catch(() => undefined);
-      }
+    // Cues only while the run is playing itself: stepping through beats by
+    // hand should not click.
+    if (muted || !active || !playing) return;
+    const cue = sfxCueFor(beat);
+    const sfx = cue ? cues.current[cue] : undefined;
+    if (sfx) {
+      sfx.currentTime = 0;
+      void sfx.play().catch(() => undefined);
     }
-  }, [beat, muted, active]);
+  }, [beat, muted, active, playing, start]);
+
+  /**
+   * Call inside the click that starts the run. Plays and immediately pauses
+   * every element at zero volume, which is what Safari and iOS need before an
+   * element may play on its own later. Harmless elsewhere. Called even when
+   * muted, so a later "Sound on" works.
+   */
+  const unlock = useCallback(() => {
+    for (const [key, audio] of Object.entries(beds.current)) {
+      void audio
+        .play()
+        .then(() => {
+          // Unless, by the time this settles, this bed is the one that should
+          // be playing anyway.
+          if (!(wantBeds.current && key === mood.current)) audio.pause();
+        })
+        .catch(() => undefined);
+    }
+    for (const audio of Object.values(cues.current)) {
+      const level = audio.volume;
+      audio.volume = 0;
+      void audio
+        .play()
+        .then(() => {
+          audio.pause();
+          audio.currentTime = 0;
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          audio.volume = level;
+        });
+    }
+  }, []);
 
   return {
     muted,
+    unlock,
     toggle: () => {
       setMuted((was) => {
         writeMuted(!was);
@@ -110,18 +171,30 @@ export function useSoundtrack(beat: StageBeat | undefined, active: boolean) {
   };
 }
 
+/** Whatever fade is running on an element; a new target cancels it. */
+const fades = new WeakMap<HTMLAudioElement, number>();
+
 /** Linear ramp over the same crossfade the rendered soundtrack uses. */
 function fade(audio: HTMLAudioElement, to: number): void {
+  const running = fades.get(audio);
+  if (running !== undefined) {
+    cancelAnimationFrame(running);
+    fades.delete(audio);
+  }
   const from = audio.volume;
   if (Math.abs(from - to) < 0.001) return;
   const started = performance.now();
   const tick = (): void => {
     const t = Math.min(1, (performance.now() - started) / (CROSSFADE_SECONDS * 1000));
     audio.volume = Math.max(0, Math.min(1, from + (to - from) * t));
-    if (t < 1) requestAnimationFrame(tick);
-    else if (to === 0) audio.pause();
+    if (t < 1) {
+      fades.set(audio, requestAnimationFrame(tick));
+    } else {
+      fades.delete(audio);
+      if (to === 0) audio.pause();
+    }
   };
-  requestAnimationFrame(tick);
+  fades.set(audio, requestAnimationFrame(tick));
 }
 
 function readMuted(): boolean {

--- a/packages/web/src/run/useSoundtrack.ts
+++ b/packages/web/src/run/useSoundtrack.ts
@@ -82,9 +82,12 @@ export function useSoundtrack(beat: StageBeat | undefined, active: boolean, play
   wantBeds.current = active && !muted && !volumeLocked.current;
 
   // A refusal to play is shown, not stored: the control stops claiming sound
-  // that is not there, and the next run gets to try again.
+  // that is not there, and the next run gets to try again. An interrupted
+  // play() is not a refusal — unlock pauses elements on purpose.
   const start = useCallback((audio: HTMLAudioElement) => {
-    void audio.play().catch(() => setMuted(true));
+    void audio.play().catch((error: unknown) => {
+      if (isPlaybackRefusal(error)) setMuted(true);
+    });
   }, []);
 
   useEffect(() => {
@@ -169,6 +172,17 @@ export function useSoundtrack(beat: StageBeat | undefined, active: boolean, play
       });
     },
   };
+}
+
+/**
+ * Whether a rejected play() means the browser said no. Autoplay policy and an
+ * unplayable file are refusals. An AbortError is a play() interrupted by a
+ * pause() — which `unlock` does deliberately while a bed may already be
+ * starting — and means nothing about whether sound is allowed.
+ */
+export function isPlaybackRefusal(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : "";
+  return name === "NotAllowedError" || name === "NotSupportedError";
 }
 
 /** Whatever fade is running on an element; a new target cancels it. */

--- a/packages/web/src/stage/Attribution.tsx
+++ b/packages/web/src/stage/Attribution.tsx
@@ -1,0 +1,57 @@
+/**
+ * One line under the room saying whose moment this is and what kind.
+ *
+ * Separate from the room so a page turn rotates the picture and not the
+ * caption: the caption is the reader's, the picture is the scene's.
+ */
+import { chipFor, chipIndexFor, emotionLabel, type LiveChannel, type StageBeat } from "@perfectman/shared";
+import { roomLabel } from "./room-label.js";
+import type { StageAgent } from "./Stage.js";
+
+export function Attribution({
+  beat,
+  agents,
+  channels,
+  ids,
+}: {
+  beat: StageBeat | undefined;
+  agents: readonly StageAgent[];
+  channels: readonly LiveChannel[];
+  ids: readonly string[];
+}): JSX.Element {
+  if (!beat) {
+    return (
+      <div className="stage__utterance">
+        <p className="u-dim">Waiting for the first move.</p>
+      </div>
+    );
+  }
+  const channel = channels.find((c) => c.id === beat.channelId);
+  const caption = emotionLabel(beat.emotion);
+  return (
+    <div className="stage__utterance">
+      <p className="attribution">
+        <span className="attribution__chip" style={{ background: chipFor(chipIndexFor(beat.actorId ?? "", ids)) }} />
+        <strong>{nameOf(agents, beat.actorId)}</strong>
+        <span className="u-dim">{describe(beat, agents, roomLabel(channel, agents))}</span>
+        {caption ? <span className="attribution__reading">{caption}</span> : null}
+      </p>
+    </div>
+  );
+}
+
+/** One plain sentence about what kind of moment this is. */
+function describe(beat: StageBeat, agents: readonly StageAgent[], channelName: string | undefined): string {
+  if (beat.kind === "silence") return "says nothing this turn";
+  if (beat.kind === "aside") return "what they were actually after";
+  if (beat.kind === "event") return `in ${channelName ?? "the room"}`;
+  if (beat.audienceIds.length > 0) {
+    const who = beat.audienceIds.map((id) => nameOf(agents, id)).join(", ");
+    return `— only ${who} can see this`;
+  }
+  return channelName ? `in ${channelName}` : "";
+}
+
+function nameOf(agents: readonly StageAgent[], id: string | undefined): string {
+  return agents.find((a) => a.id === id)?.displayName ?? id ?? "someone";
+}

--- a/packages/web/src/stage/Bubble.tsx
+++ b/packages/web/src/stage/Bubble.tsx
@@ -1,25 +1,30 @@
 /**
  * One balloon. Speech is paper with a hard tail; a thought is a soft cloud with
- * a trail of dots, in the marker hand. Never both at once — that pairing does
- * not fit above a figure at the back of the room, and a thought reads better as
- * its own moment anyway.
+ * a trail of dots, in italic. Never both at once — that pairing does not fit
+ * above a figure at the back of the room, and a thought reads better as its
+ * own moment anyway.
  */
+import type { RefObject } from "react";
 import { useBubbleAnchor } from "./useBubbleAnchor.js";
 
 export function Bubble({
-  headTop,
+  speaker,
+  headTopGuess,
   x,
   contentKey,
   said,
   thought,
 }: {
-  headTop: number;
+  /** The speaker's mark, measured for where the head really is. */
+  speaker: RefObject<HTMLElement>;
+  /** Fraction from the room's top, used until the mark has been laid out. */
+  headTopGuess: number;
   x: number;
   contentKey: string;
   said: string;
   thought?: string;
 }): JSX.Element {
-  const { ref, bottom } = useBubbleAnchor(headTop, contentKey);
+  const { ref, bottom } = useBubbleAnchor(speaker, headTopGuess, contentKey);
   // Balloons open away from the nearest wall, so an edge figure's does not run
   // off the side of the room.
   const side = x > 0.5 ? "left" : "right";

--- a/packages/web/src/stage/Bubble.tsx
+++ b/packages/web/src/stage/Bubble.tsx
@@ -11,6 +11,7 @@ export function Bubble({
   speaker,
   headTopGuess,
   x,
+  scale,
   contentKey,
   said,
   thought,
@@ -20,17 +21,27 @@ export function Bubble({
   /** Fraction from the room's top, used until the mark has been laid out. */
   headTopGuess: number;
   x: number;
+  /** The speaker's slot scale; a mark is 15% of the room wide at scale 1. */
+  scale: number;
   contentKey: string;
   said: string;
   thought?: string;
 }): JSX.Element {
-  const { ref, bottom } = useBubbleAnchor(speaker, headTopGuess, contentKey);
+  const { ref, bottom, beside } = useBubbleAnchor(speaker, headTopGuess, contentKey);
   // Balloons open away from the nearest wall, so an edge figure's does not run
   // off the side of the room.
   const side = x > 0.5 ? "left" : "right";
+  // A balloon that could not fit above the head sits beside it instead, clear
+  // of the figure: half a mark's width plus a little, on the open side.
+  const clearance = beside ? 0.075 * scale + 0.015 : 0;
+  const left = side === "right" ? x + clearance : x - clearance;
 
   return (
-    <div ref={ref} className={`bubbles bubbles--${side}`} style={{ left: `${x * 100}%`, bottom }}>
+    <div
+      ref={ref}
+      className={`bubbles bubbles--${side}${beside ? " bubbles--beside" : ""}`}
+      style={{ left: `${left * 100}%`, bottom }}
+    >
       {thought !== undefined ? (
         <div className="bubble bubble--thought">
           <p className="bubble__thought u-hand">{thought}</p>

--- a/packages/web/src/stage/ContactSheet.tsx
+++ b/packages/web/src/stage/ContactSheet.tsx
@@ -1,0 +1,98 @@
+/**
+ * The run so far, as a strip of small pictures.
+ *
+ * This is the scrubber. Each frame is one beat, drawn from the same placement
+ * the room used, so the strip is a faithful index of what was on the page and
+ * never a transcript. In a live run the beats the run has produced but the
+ * reader has not reached yet are there, blank, so the queue is visible without
+ * being readable. The current frame is ringed and kept in view unless the
+ * reader is already looking at the strip.
+ */
+import { useEffect, useRef, type KeyboardEvent } from "react";
+import { Frame, type FrameModel } from "./Frame.js";
+import { reducedMotion } from "./motion.js";
+
+export function ContactSheet({
+  frames,
+  labels,
+  index,
+  reached,
+  live,
+  onSeek,
+}: {
+  frames: readonly FrameModel[];
+  labels: readonly string[];
+  index: number;
+  /** The furthest beat the reader has been shown. Everything past it is blank while live. */
+  reached: number;
+  live: boolean;
+  onSeek: (index: number) => void;
+}): JSX.Element {
+  const strip = useRef<HTMLDivElement>(null);
+  const current = useRef<HTMLButtonElement>(null);
+  const hovering = useRef(false);
+  const last = Math.max(0, frames.length - 1);
+
+  // Keep the current frame in view, unless the reader is on the strip already
+  // — moving it under a pointer or a focus ring is worse than letting it drift.
+  useEffect(() => {
+    const node = strip.current;
+    const target = current.current;
+    if (!node || !target || typeof node.scrollTo !== "function") return;
+    if (hovering.current || node.contains(document.activeElement)) {
+      if (node.contains(document.activeElement)) target.focus();
+      return;
+    }
+    node.scrollTo({
+      left: target.offsetLeft - node.clientWidth / 2 + target.offsetWidth / 2,
+      behavior: reducedMotion() ? "auto" : "smooth",
+    });
+  }, [index]);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    const to =
+      event.key === "ArrowRight"
+        ? Math.min(last, index + 1)
+        : event.key === "ArrowLeft"
+          ? Math.max(0, index - 1)
+          : event.key === "Home"
+            ? 0
+            : event.key === "End"
+              ? last
+              : null;
+    if (to === null) return;
+    event.preventDefault();
+    onSeek(to);
+  };
+
+  return (
+    <div
+      ref={strip}
+      className="sheet"
+      role="group"
+      aria-label="Frames of the run"
+      onKeyDown={onKeyDown}
+      onPointerEnter={() => (hovering.current = true)}
+      onPointerLeave={() => (hovering.current = false)}
+    >
+      {frames.map((frame, i) => {
+        const here = i === index;
+        const blank = live && i > reached;
+        return (
+          <button
+            key={frame.id}
+            ref={here ? current : undefined}
+            type="button"
+            className={`sheet__frame${here ? " sheet__frame--here" : ""}`}
+            aria-label={blank ? `Beat ${i + 1}, ahead of you` : labels[i]}
+            aria-current={here ? "true" : undefined}
+            tabIndex={here ? 0 : -1}
+            onClick={() => onSeek(i)}
+          >
+            <Frame model={frame} blank={blank} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/stage/Frame.tsx
+++ b/packages/web/src/stage/Frame.tsx
@@ -1,0 +1,120 @@
+/**
+ * One frame of the contact sheet: a beat as a picture with no words in it.
+ *
+ * The ground says which kind of room it was, a dot per person says who stood
+ * where — the same seating the stage drew, from the same placement — and one
+ * dot is ringed for whose moment it was, with a glyph above it for what kind
+ * of moment: a box for something said, a cloud for something only thought, an
+ * arrow for someone arriving or leaving. Nothing here is readable, on purpose:
+ * the strip is for finding your place in the run, not for reading it again.
+ */
+import { memo } from "react";
+import {
+  chipFor,
+  chipIndexFor,
+  FIGURE_HEIGHT_FRACTION,
+  type ChannelKind,
+  type LiveChannel,
+  type Placement,
+  type StageBeat,
+} from "@perfectman/shared";
+import { roomLabel, type NamedAgent } from "./room-label.js";
+
+/** 16:7, like the room, so the dots land where the figures stood. */
+export const FRAME_W = 64;
+export const FRAME_H = 28;
+
+export type FrameGlyph = "speech" | "thought" | "arrive" | "leave" | "invite" | null;
+
+export type FrameDot = { x: number; y: number; r: number; chip: number; speaker: boolean };
+
+export type FrameModel = {
+  id: string;
+  kind: ChannelKind;
+  glyph: FrameGlyph;
+  dots: readonly FrameDot[];
+  /** Two frames with the same signature draw the same picture. */
+  sig: string;
+};
+
+export function frameFor(beat: StageBeat, placement: Placement, ids: readonly string[]): FrameModel {
+  const dots = placement.marks.map(({ agentId, point }) => {
+    const r = 2.6 * point.scale;
+    return {
+      x: point.x * FRAME_W,
+      // The dot stands for the whole figure, so it sits at the figure's middle.
+      y: (point.y - (FIGURE_HEIGHT_FRACTION * point.scale) / 2) * FRAME_H,
+      r,
+      chip: chipIndexFor(agentId, ids),
+      speaker: agentId === beat.actorId,
+    };
+  });
+  const glyph = glyphFor(beat);
+  const sig = [
+    placement.kind,
+    glyph ?? "-",
+    ...dots.map((d) => `${d.chip}:${d.x.toFixed(1)}:${d.y.toFixed(1)}:${d.r.toFixed(1)}:${d.speaker ? 1 : 0}`),
+  ].join("|");
+  return { id: beat.id, kind: placement.kind, glyph, dots, sig };
+}
+
+function glyphFor(beat: StageBeat): FrameGlyph {
+  if (beat.kind === "message") return "speech";
+  if (beat.kind === "aside" || beat.kind === "silence") return "thought";
+  if (beat.kind === "event") return beat.stageAction?.kind ?? null;
+  return null;
+}
+
+/** What a screen reader gets instead of the picture. */
+export function frameLabel(beat: StageBeat, agents: readonly NamedAgent[], channel: LiveChannel | undefined): string {
+  const who = agents.find((a) => a.id === beat.actorId)?.displayName ?? beat.actorId ?? "someone";
+  const where = roomLabel(channel, agents);
+  if (beat.kind === "silence") return `${who} says nothing`;
+  if (beat.kind === "aside") return `what ${who} was after`;
+  if (beat.kind === "event") {
+    if (beat.stageAction?.kind === "leave") return `${who} leaves ${where}`;
+    if (beat.stageAction?.kind === "arrive") return `${who} arrives in ${where}`;
+    return `${who} opens ${where}`;
+  }
+  return `${who} speaks in ${where}`;
+}
+
+export const Frame = memo(
+  function Frame({ model, blank = false }: { model: FrameModel; blank?: boolean }): JSX.Element {
+    const speaker = model.dots.find((d) => d.speaker);
+    return (
+      <svg
+        className={`frame frame--${model.kind}${blank ? " frame--blank" : ""}`}
+        viewBox={`0 0 ${FRAME_W} ${FRAME_H}`}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <rect className="frame__ground" x="0.3" y="0.3" width={FRAME_W - 0.6} height={FRAME_H - 0.6} rx="2" />
+        {model.kind === "private" ? (
+          <rect className="frame__inset" x="2.5" y="2.5" width={FRAME_W - 5} height={FRAME_H - 5} rx="1.2" />
+        ) : null}
+        {blank
+          ? null
+          : model.dots.map((d, i) => (
+              <circle key={i} className="frame__dot" cx={d.x} cy={d.y} r={d.r} fill={chipFor(d.chip)} />
+            ))}
+        {!blank && speaker ? (
+          <>
+            <circle className="frame__ring" cx={speaker.x} cy={speaker.y} r={speaker.r + 1.1} />
+            <Glyph kind={model.glyph} x={speaker.x} y={speaker.y - speaker.r - 2.2} />
+          </>
+        ) : null}
+      </svg>
+    );
+  },
+  (a, b) => a.model.sig === b.model.sig && a.blank === b.blank,
+);
+
+function Glyph({ kind, x, y }: { kind: FrameGlyph; x: number; y: number }): JSX.Element | null {
+  if (kind === "speech") return <rect className="frame__glyph frame__glyph--speech" x={x - 4} y={y - 4} width="8" height="4" rx="1" />;
+  if (kind === "thought") return <ellipse className="frame__glyph frame__glyph--thought" cx={x} cy={y - 2} rx="4.2" ry="2.2" />;
+  if (kind === "arrive") return <path className="frame__glyph frame__glyph--move" d={`M${x - 3.5} ${y - 2}h5.5m-2.2-2.2l2.2 2.2-2.2 2.2`} />;
+  if (kind === "leave") return <path className="frame__glyph frame__glyph--move" d={`M${x + 3.5} ${y - 2}h-5.5m2.2-2.2l-2.2 2.2 2.2 2.2`} />;
+  if (kind === "invite") return <path className="frame__glyph frame__glyph--move" d={`M${x} ${y - 4.5}v5m-2.5-2.5h5`} />;
+  return null;
+}

--- a/packages/web/src/stage/Panel.tsx
+++ b/packages/web/src/stage/Panel.tsx
@@ -1,0 +1,83 @@
+/**
+ * The page the room is drawn on.
+ *
+ * A change of room is a page turning. The page that is leaving stays mounted
+ * for the length of the turn, still drawing the beat it was on, and the new
+ * room comes in behind it — forwards when the run moves on, backwards when
+ * the reader seeks back. Two lines in the same room are not a turn; the room
+ * just updates, and the balloon and faces do their own transitions.
+ *
+ * This is deliberately not the View Transitions API: that snapshots the whole
+ * document, so the breathing figures and the sheet's scroll would freeze for
+ * the turn, and it cannot be tested in jsdom. Two keyed pages and a timer can.
+ */
+import { useEffect, useRef, useState } from "react";
+import type { LiveChannel, Placement, StageBeat } from "@perfectman/shared";
+import { reducedMotion } from "./motion.js";
+import { Stage, type StageAgent } from "./Stage.js";
+
+/** Mirrors `--turn` in tokens.css. */
+export const TURN_MS = 520;
+
+type Direction = "forward" | "back";
+
+type Page = {
+  roomKey: string;
+  index: number;
+  beat: StageBeat | undefined;
+  placement: Placement;
+};
+
+export function Panel({
+  beat,
+  placement,
+  index,
+  agents,
+  channels,
+  ids,
+}: {
+  beat: StageBeat | undefined;
+  placement: Placement;
+  /** Position in the run, so a turn knows which way to go. */
+  index: number;
+  agents: readonly StageAgent[];
+  channels: readonly LiveChannel[];
+  ids: readonly string[];
+}): JSX.Element {
+  const current: Page = { roomKey: placement.roomKey, index, beat, placement };
+  // What was on the page last render. A ref, not state: it is a memo of the
+  // previous picture, and writing it must not cause a render of its own.
+  const last = useRef<Page>(current);
+  const direction = useRef<Direction>("forward");
+  const [leaving, setLeaving] = useState<(Page & { dir: Direction }) | null>(null);
+
+  if (last.current.roomKey !== current.roomKey) {
+    const dir: Direction = index >= last.current.index ? "forward" : "back";
+    direction.current = dir;
+    // Setting state during render is how React wants a derived reset done: it
+    // re-renders this component at once, before any child is committed.
+    if (!reducedMotion()) setLeaving({ ...last.current, dir });
+  }
+  last.current = current;
+
+  // A timer rather than `animationend`: the room's own children animate too and
+  // their end events bubble, and a page can be replaced before its turn ends.
+  useEffect(() => {
+    if (!leaving) return;
+    const timer = setTimeout(() => setLeaving(null), TURN_MS);
+    return () => clearTimeout(timer);
+  }, [leaving]);
+
+  return (
+    <div className="panel">
+      {leaving ? (
+        <div key={leaving.roomKey} className={`panel__page panel__page--leave-${leaving.dir}`} aria-hidden="true">
+          <Stage beat={leaving.beat} placement={leaving.placement} agents={agents} channels={channels} ids={ids} />
+        </div>
+      ) : null}
+      <div key={current.roomKey} className={`panel__page panel__page--enter-${direction.current}`}>
+        <Stage beat={beat} placement={placement} agents={agents} channels={channels} ids={ids} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/stage/Panel.tsx
+++ b/packages/web/src/stage/Panel.tsx
@@ -69,13 +69,13 @@ export function Panel({
   }, [leaving]);
 
   return (
-    <div className="panel">
+    <div className="pages">
       {leaving ? (
-        <div key={leaving.roomKey} className={`panel__page panel__page--leave-${leaving.dir}`} aria-hidden="true">
+        <div key={leaving.roomKey} className={`pages__page pages__page--leave-${leaving.dir}`} aria-hidden="true">
           <Stage beat={leaving.beat} placement={leaving.placement} agents={agents} channels={channels} ids={ids} />
         </div>
       ) : null}
-      <div key={current.roomKey} className={`panel__page panel__page--enter-${direction.current}`}>
+      <div key={current.roomKey} className={`pages__page pages__page--enter-${direction.current}`}>
         <Stage beat={beat} placement={placement} agents={agents} channels={channels} ids={ids} />
       </div>
     </div>

--- a/packages/web/src/stage/Stage.tsx
+++ b/packages/web/src/stage/Stage.tsx
@@ -103,6 +103,7 @@ export const Stage = memo(function Stage({ beat, placement, agents, channels, id
             speaker={speakerRef}
             headTopGuess={headTopFor(speaker.point)}
             x={speaker.point.x}
+            scale={speaker.point.scale}
             contentKey={beat.id}
             thought={beat.thought?.text}
             said={beat.text}

--- a/packages/web/src/stage/Stage.tsx
+++ b/packages/web/src/stage/Stage.tsx
@@ -3,26 +3,24 @@
  *
  * One beat is on stage at a time. Whoever is in the channel stands in their
  * slot; whoever is speaking is lit and the rest recede. A line appears on paper.
- * A thought appears in handwriting, and never on paper, because a thought was
- * not said.
+ * A thought appears in italic, and never on paper, because a thought was not
+ * said.
  *
- * Nothing here decides what a beat means — `live-to-beats` already did that.
- * This only places it.
+ * Nothing here decides what a beat means — `live-to-beats` already did that —
+ * and nothing here decides where anyone stands — `placeBeats` did that for the
+ * whole run at once. This only draws the placement it is handed, which is what
+ * lets the contact sheet and the room agree, and lets an outgoing page keep
+ * drawing a frozen beat while the next one turns in.
  */
-import { useMemo, useRef } from "react";
+import { memo, useMemo, useRef } from "react";
 import {
-  assignSlots,
-  chipFor,
   chipIndexFor,
-  emotionLabel,
-  headTopFor,
   faceFor,
   gestureEnergy,
-  slotsFor,
-  type ChannelKind,
+  headTopFor,
   type LiveChannel,
+  type Placement,
   type StageBeat,
-  type StageSlot,
 } from "@perfectman/shared";
 import { Figure } from "./Figure.js";
 import { roomLabel } from "./room-label.js";
@@ -30,41 +28,21 @@ import { Bubble } from "./Bubble.js";
 
 export type StageAgent = { id: string; displayName: string };
 
-export function Stage({
-  beat,
-  agents,
-  channels,
-  idleChannelId,
-}: {
+export type StageProps = {
   beat: StageBeat | undefined;
+  placement: Placement;
   agents: readonly StageAgent[];
   channels: readonly LiveChannel[];
-  /** Who stands in the room before anything has been said. */
-  idleChannelId?: string;
-}): JSX.Element {
-  // Slot assignment is sticky per channel across beats, so a figure only moves
-  // when the room actually changes. A ref, not state: it is a memo of where
-  // people already are, and writing it must not cause a render.
-  const held = useRef(new Map<string, Map<number, number>>());
+  /** Every agent id in the run; chips are assigned from the sorted list. */
+  ids: readonly string[];
+};
 
-  const channelId = beat?.channelId ?? idleChannelId ?? channels[0]?.id ?? "";
+export const Stage = memo(function Stage({ beat, placement, agents, channels, ids }: StageProps): JSX.Element {
+  const { kind, channelId, marks, speaker } = placement;
   const channel = channels.find((c) => c.id === channelId);
-  const kind = kindOf(channel?.type, beat);
-  const points = slotsFor(kind);
-
-  const placed = useMemo(() => {
-    const order = beat
-      ? presentOrder(beat, agents)
-      : (channel?.memberAgentIds ?? []).map((id) => agents.findIndex((a) => a.id === id)).filter((i) => i >= 0);
-    if (order.length === 0) return [];
-    const previous = held.current.get(channelId) ?? new Map<number, number>();
-    const slots = assignSlots(order, kind, previous);
-    held.current.set(channelId, slots);
-    return [...slots]
-      .map(([agentIndex, slot]) => ({ agentIndex, point: points[slot] }))
-      .filter((placement): placement is { agentIndex: number; point: StageSlot } => placement.point !== undefined);
-    // Recomputed per beat; `held` carries the memory between them.
-  }, [beat, agents, kind, points, channelId, channel]);
+  // The speaker's mark, so the balloon can measure where the head actually is
+  // rather than trusting a constant that assumes a 16:7 room.
+  const speakerRef = useRef<HTMLDivElement>(null);
 
   // Who is in the run but not in this room. Naming them is the whole point of a
   // private channel: the interesting fact is not that two people are talking,
@@ -74,15 +52,9 @@ export function Stage({
     [kind, agents, channel],
   );
 
-  const caption = emotionLabel(beat?.emotion);
-  const ids = useMemo(() => agents.map((a) => a.id), [agents]);
-  const speaker = placed.find(({ agentIndex }) => agents[agentIndex]?.id === beat?.actorId);
-
   return (
     <div className={`stage stage--${kind}`}>
-      {/* Keyed on the room, so moving to a private channel re-mounts the box
-          and plays its entrance rather than silently swapping the contents. */}
-      <div className="stage__room" key={channelId}>
+      <div className="stage__room">
         <p className="stage__where">
           <span aria-hidden="true">{kind === "private" ? "↔" : "#"}</span>
           {roomLabel(channel, agents)}
@@ -92,12 +64,14 @@ export function Stage({
             </span>
           ) : null}
         </p>
-        {placed.map(({ agentIndex, point }) => {
-          const agent = agents[agentIndex]!;
+        {marks.map(({ agentId, point }) => {
+          const agent = agents.find((a) => a.id === agentId);
+          if (!agent) return null;
           const isActor = beat?.actorId === agent.id;
           return (
             <div
               key={agent.id}
+              ref={isActor ? speakerRef : undefined}
               className="stage__mark"
               style={{
                 left: `${point.x * 100}%`,
@@ -126,7 +100,8 @@ export function Stage({
         {beat && speaker && (beat.text || beat.thought) ? (
           <Bubble
             key={beat.id}
-            headTop={headTopFor(speaker.point)}
+            speaker={speakerRef}
+            headTopGuess={headTopFor(speaker.point)}
             x={speaker.point.x}
             contentKey={beat.id}
             thought={beat.thought?.text}
@@ -134,66 +109,6 @@ export function Stage({
           />
         ) : null}
       </div>
-
-      <div className="stage__utterance">
-        {!beat && idleChannelId ? null : beat ? (
-          <p className="attribution">
-            <span
-              className="attribution__chip"
-              style={{ background: chipFor(chipIndexFor(beat.actorId ?? "", ids)) }}
-            />
-            <strong>{nameOf(agents, beat.actorId)}</strong>
-            <span className="u-dim">{describe(beat, agents, roomLabel(channel, agents))}</span>
-            {caption ? <span className="attribution__reading">{caption}</span> : null}
-          </p>
-        ) : (
-          <p className="u-dim">Waiting for the first move.</p>
-        )}
-      </div>
     </div>
   );
-}
-
-/**
- * Who stands where, most important first: the speaker, then whoever the line is
- * aimed at, then everyone else in the room. `assignSlots` caps it.
- */
-function presentOrder(beat: StageBeat, agents: readonly StageAgent[]): number[] {
-  const ids = [
-    ...(beat.actorId ? [beat.actorId] : []),
-    ...beat.audienceIds,
-    ...beat.participantIds,
-  ];
-  const seen = new Set<string>();
-  const order: number[] = [];
-  for (const id of ids) {
-    if (seen.has(id)) continue;
-    seen.add(id);
-    const at = agents.findIndex((a) => a.id === id);
-    if (at >= 0) order.push(at);
-  }
-  return order;
-}
-
-/** One plain sentence about what kind of moment this is. */
-function describe(beat: StageBeat, agents: readonly StageAgent[], channelName: string | undefined): string {
-  if (beat.kind === "silence") return "says nothing this turn";
-  if (beat.kind === "aside") return "what they were actually after";
-  if (beat.kind === "event") return `in ${channelName ?? "the room"}`;
-  if (beat.audienceIds.length > 0) {
-    const who = beat.audienceIds.map((id) => nameOf(agents, id)).join(", ");
-    return `— only ${who} can see this`;
-  }
-  return channelName ? `in ${channelName}` : "";
-}
-
-function kindOf(type: string | undefined, beat: StageBeat | undefined): ChannelKind {
-  if (beat?.kind === "silence") return "thought";
-  if (type === "private_channel") return "private";
-  if (type === "operator_channel" || type === "spectator_channel") return "operator";
-  return "public";
-}
-
-function nameOf(agents: readonly StageAgent[], id: string | undefined): string {
-  return agents.find((a) => a.id === id)?.displayName ?? id ?? "someone";
-}
+});

--- a/packages/web/src/stage/__tests__/bubble-anchor.test.ts
+++ b/packages/web/src/stage/__tests__/bubble-anchor.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { FIGURE_HEIGHT_FRACTION, headTopFor, slotsFor } from "@perfectman/shared";
-import { BUBBLE_MARGIN, bubbleBottom } from "../useBubbleAnchor.js";
+import { BUBBLE_MARGIN, bubbleBottom, bubbleClamped } from "../useBubbleAnchor.js";
 
 const ROOM = 300;
 
@@ -52,5 +52,18 @@ describe("bubbleBottom", () => {
     // The real head is measured once laid out; this is only what the balloon
     // uses on its first frame, so it should be the drawing's own geometry.
     expect(FIGURE_HEIGHT_FRACTION).toBeCloseTo(0.15 * 1.68 * (16 / 7), 10);
+  });
+});
+
+describe("bubbleClamped", () => {
+  it("is false when the balloon fits above the head", () => {
+    expect(bubbleClamped(0.6, ROOM, 60)).toBe(false);
+  });
+
+  it("is true when the balloon had to slide down over the figure", () => {
+    // Back row, a full page of text: the only place it fits is over the face,
+    // and the caller should move it beside the head instead.
+    const headTop = headTopFor(slotsFor("public")[4]!);
+    expect(bubbleClamped(headTop, ROOM, 150)).toBe(true);
   });
 });

--- a/packages/web/src/stage/__tests__/bubble-anchor.test.ts
+++ b/packages/web/src/stage/__tests__/bubble-anchor.test.ts
@@ -48,8 +48,9 @@ describe("bubbleBottom", () => {
     expect(bubbleBottom(0.2, 200, 400)).toBe(0);
   });
 
-  it("agrees with the figure height the CSS draws", () => {
-    // If these drift the balloon detaches from the head it belongs to.
+  it("guesses the first paint from the 16:7 drawing before anything is measured", () => {
+    // The real head is measured once laid out; this is only what the balloon
+    // uses on its first frame, so it should be the drawing's own geometry.
     expect(FIGURE_HEIGHT_FRACTION).toBeCloseTo(0.15 * 1.68 * (16 / 7), 10);
   });
 });

--- a/packages/web/src/stage/__tests__/contact-sheet.test.tsx
+++ b/packages/web/src/stage/__tests__/contact-sheet.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * The strip under the room: every beat as a small picture, the current one
+ * ringed, the ones a live run has produced but the reader has not reached
+ * still blank. It is the scrubber, so it must work from the keyboard.
+ */
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { placeBeats, type LiveChannel, type StageBeat } from "@perfectman/shared";
+import { ContactSheet } from "../ContactSheet.js";
+import { frameFor, frameLabel } from "../Frame.js";
+
+const AGENTS = [
+  { id: "iris", displayName: "íris" },
+  { id: "bruno", displayName: "bruno" },
+];
+const IDS = ["iris", "bruno"];
+const CHANNELS: LiveChannel[] = [{ id: "geral", name: "geral", type: "public_channel", memberAgentIds: IDS }];
+
+function beat(id: string, over: Partial<StageBeat> = {}): StageBeat {
+  return {
+    id, kind: "message", pulseIndex: 0, channelId: "geral", actorId: "iris", text: id,
+    audienceIds: [], participantIds: IDS, duration: 3, page: 0, ...over,
+  };
+}
+const BEATS = ["a", "b", "c", "d", "e"].map((id) => beat(id, { actorId: id < "c" ? "iris" : "bruno" }));
+const PLACED = placeBeats(BEATS, AGENTS, CHANNELS);
+const FRAMES = BEATS.map((b, i) => frameFor(b, PLACED[i]!, IDS));
+const LABELS = BEATS.map((b) => frameLabel(b, AGENTS, CHANNELS[0]));
+
+function sheet(over: Partial<Parameters<typeof ContactSheet>[0]> = {}) {
+  const onSeek = vi.fn();
+  const utils = render(
+    <ContactSheet frames={FRAMES} labels={LABELS} index={2} reached={2} live={false} onSeek={onSeek} {...over} />,
+  );
+  return { ...utils, onSeek, buttons: () => utils.container.querySelectorAll("button") };
+}
+
+describe("ContactSheet", () => {
+  it("shows one frame per beat, with no words in it", () => {
+    const { buttons, container } = sheet();
+    expect(buttons()).toHaveLength(5);
+    expect(container.textContent).toBe("");
+  });
+
+  it("rings the current frame and names every frame for a screen reader", () => {
+    const { buttons } = sheet();
+    expect(buttons()[2]?.getAttribute("aria-current")).toBe("true");
+    expect(buttons()[1]?.getAttribute("aria-current")).toBeNull();
+    expect(buttons()[0]?.getAttribute("aria-label")).toBe("íris speaks in geral");
+  });
+
+  it("seeks to a frame when it is clicked", () => {
+    const { buttons, onSeek } = sheet();
+    fireEvent.click(buttons()[4]!);
+    expect(onSeek).toHaveBeenCalledWith(4);
+  });
+
+  it("is one tab stop that the arrow keys move through", () => {
+    const { buttons, onSeek, container } = sheet();
+    expect([...buttons()].filter((b) => b.tabIndex === 0)).toHaveLength(1);
+    fireEvent.keyDown(container.querySelector('[role="group"]')!, { key: "ArrowRight" });
+    expect(onSeek).toHaveBeenCalledWith(3);
+    fireEvent.keyDown(container.querySelector('[role="group"]')!, { key: "Home" });
+    expect(onSeek).toHaveBeenCalledWith(0);
+  });
+
+  it("leaves frames the reader has not reached blank while the run is live", () => {
+    const { container } = sheet({ live: true, reached: 2 });
+    const blank = container.querySelectorAll(".frame--blank");
+    expect(blank).toHaveLength(2);
+    expect(container.querySelectorAll("button")[3]?.getAttribute("aria-label")).toContain("ahead of you");
+  });
+
+  it("draws every frame of a finished run, whatever was reached", () => {
+    const { container } = sheet({ live: false, reached: 0 });
+    expect(container.querySelectorAll(".frame--blank")).toHaveLength(0);
+  });
+});

--- a/packages/web/src/stage/__tests__/frame.test.ts
+++ b/packages/web/src/stage/__tests__/frame.test.ts
@@ -1,0 +1,77 @@
+/**
+ * One frame of the contact sheet is a picture of a beat with no words in it:
+ * the room's ground, a dot per person where they stood, and a mark on the one
+ * whose moment it was. Two beats that look the same must produce the same
+ * signature so the sheet does not repaint them.
+ */
+import { describe, expect, it } from "vitest";
+import { placeBeats, type LiveChannel, type StageBeat } from "@perfectman/shared";
+import { frameFor, frameLabel } from "../Frame.js";
+
+const AGENTS = [
+  { id: "iris", displayName: "íris" },
+  { id: "bruno", displayName: "bruno" },
+  { id: "marcela", displayName: "marcela" },
+];
+const IDS = AGENTS.map((a) => a.id);
+const CHANNELS: LiveChannel[] = [
+  { id: "geral", name: "geral", type: "public_channel", memberAgentIds: IDS },
+  { id: "dm", name: "dm", type: "private_channel", memberAgentIds: ["iris", "marcela"] },
+];
+
+function beat(over: Partial<StageBeat> = {}): StageBeat {
+  return {
+    id: "b", kind: "message", pulseIndex: 0, channelId: "geral", actorId: "iris", text: "hi",
+    audienceIds: [], participantIds: IDS, duration: 3, page: 0, ...over,
+  };
+}
+
+function frame(b: StageBeat, channels = CHANNELS) {
+  const [placement] = placeBeats([b], AGENTS, channels);
+  return frameFor(b, placement!, IDS);
+}
+
+describe("frameFor", () => {
+  it("draws one dot per person in the room, and exactly one is the speaker", () => {
+    const f = frame(beat());
+    expect(f.dots).toHaveLength(3);
+    expect(f.dots.filter((d) => d.speaker)).toHaveLength(1);
+  });
+
+  it("puts speech in a box and a thought in a cloud", () => {
+    expect(frame(beat()).glyph).toBe("speech");
+    expect(frame(beat({ kind: "silence", text: "", thought: { text: "…", drivers: [] } })).glyph).toBe("thought");
+    expect(frame(beat({ kind: "aside", text: "", thought: { text: "…", drivers: [] } })).glyph).toBe("thought");
+  });
+
+  it("marks arrivals and departures with their own glyph", () => {
+    expect(frame(beat({ kind: "event", stageAction: { kind: "arrive", agentIds: ["iris"] } })).glyph).toBe("arrive");
+    expect(frame(beat({ kind: "event", stageAction: { kind: "leave", agentIds: ["iris"] } })).glyph).toBe("leave");
+  });
+
+  it("carries the room kind so a private frame can be drawn differently", () => {
+    expect(frame(beat({ channelId: "dm", participantIds: ["iris", "marcela"] })).kind).toBe("private");
+  });
+
+  it("signs two identical pictures the same and two different speakers differently", () => {
+    const a = frame(beat({ id: "x" }));
+    const b = frame(beat({ id: "y" }));
+    const c = frame(beat({ id: "z", actorId: "bruno" }));
+    expect(a.sig).toBe(b.sig);
+    expect(a.sig).not.toBe(c.sig);
+  });
+
+  it("keeps the words out of the picture", () => {
+    const f = frame(beat({ text: "a secret" }));
+    expect(JSON.stringify(f)).not.toContain("secret");
+  });
+});
+
+describe("frameLabel", () => {
+  it("says who did what where, for a reader who cannot see the picture", () => {
+    expect(frameLabel(beat(), AGENTS, CHANNELS[0])).toBe("íris speaks in geral");
+    expect(frameLabel(beat({ kind: "silence", actorId: "marcela" }), AGENTS, CHANNELS[0])).toBe("marcela says nothing");
+    expect(frameLabel(beat({ kind: "aside", actorId: "bruno" }), AGENTS, CHANNELS[0])).toBe("what bruno was after");
+    expect(frameLabel(beat({ kind: "event", stageAction: { kind: "leave", agentIds: [] } }), AGENTS, CHANNELS[0])).toBe("íris leaves geral");
+  });
+});

--- a/packages/web/src/stage/__tests__/panel.test.tsx
+++ b/packages/web/src/stage/__tests__/panel.test.tsx
@@ -42,24 +42,24 @@ describe("Panel", () => {
 
   it("shows one page in one room", () => {
     const { container } = render(panelAt(0));
-    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(1);
   });
 
   it("does not turn between two lines in the same room", () => {
     const { container, rerender } = render(panelAt(0));
     rerender(panelAt(1));
-    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(1);
     expect(container.textContent).toContain("line b");
   });
 
   it("keeps the leaving page up for the turn, still showing its own line", () => {
     const { container, rerender } = render(panelAt(1));
     rerender(panelAt(2));
-    const pages = container.querySelectorAll(".panel__page");
+    const pages = container.querySelectorAll(".pages__page");
     expect(pages).toHaveLength(2);
-    expect(pages[0]?.className).toContain("panel__page--leave-forward");
+    expect(pages[0]?.className).toContain("pages__page--leave-forward");
     expect(pages[0]?.textContent).toContain("line b");
-    expect(pages[1]?.className).toContain("panel__page--enter-forward");
+    expect(pages[1]?.className).toContain("pages__page--enter-forward");
     expect(pages[1]?.textContent).toContain("line c");
   });
 
@@ -69,15 +69,15 @@ describe("Panel", () => {
     act(() => {
       vi.advanceTimersByTime(TURN_MS + 1);
     });
-    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(1);
   });
 
   it("turns the other way when seeking backwards", () => {
     const { container, rerender } = render(panelAt(3));
     rerender(panelAt(0));
-    const pages = container.querySelectorAll(".panel__page");
-    expect(pages[0]?.className).toContain("panel__page--leave-back");
-    expect(pages[1]?.className).toContain("panel__page--enter-back");
+    const pages = container.querySelectorAll(".pages__page");
+    expect(pages[0]?.className).toContain("pages__page--leave-back");
+    expect(pages[1]?.className).toContain("pages__page--enter-back");
   });
 
   it("never holds more than one leaving page under rapid seeks", () => {
@@ -85,14 +85,14 @@ describe("Panel", () => {
     rerender(panelAt(2));
     rerender(panelAt(0));
     rerender(panelAt(3));
-    expect(container.querySelectorAll(".panel__page")).toHaveLength(2);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(2);
   });
 
   it("swaps instantly when the reader asked for less motion", () => {
     vi.spyOn(motion, "reducedMotion").mockReturnValue(true);
     const { container, rerender } = render(panelAt(1));
     rerender(panelAt(2));
-    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(1);
     expect(container.textContent).toContain("line c");
   });
 });

--- a/packages/web/src/stage/__tests__/panel.test.tsx
+++ b/packages/web/src/stage/__tests__/panel.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * A change of room is a page turning, not a swap. The page that is leaving
+ * stays mounted for the turn and keeps drawing the beat it was on; the new one
+ * comes in behind it. Same room, new line: no turn, the room just updates.
+ */
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { placeBeats, type LiveChannel, type StageBeat } from "@perfectman/shared";
+import { Panel, TURN_MS } from "../Panel.js";
+import * as motion from "../motion.js";
+
+const AGENTS = [
+  { id: "iris", displayName: "íris" },
+  { id: "bruno", displayName: "bruno" },
+];
+const IDS = ["bruno", "iris"];
+const CHANNELS: LiveChannel[] = [
+  { id: "geral", name: "geral", type: "public_channel", memberAgentIds: ["iris", "bruno"] },
+  { id: "dm", name: "dm", type: "private_channel", memberAgentIds: ["iris", "bruno"] },
+];
+
+function beat(id: string, over: Partial<StageBeat> = {}): StageBeat {
+  return {
+    id, kind: "message", pulseIndex: 0, channelId: "geral", actorId: "iris", text: `line ${id}`,
+    audienceIds: [], participantIds: ["iris", "bruno"], duration: 3, page: 0, ...over,
+  };
+}
+
+const BEATS = [beat("a"), beat("b", { actorId: "bruno" }), beat("c", { channelId: "dm" }), beat("d", { channelId: "dm" })];
+const PLACED = placeBeats(BEATS, AGENTS, CHANNELS);
+
+function panelAt(index: number) {
+  return <Panel beat={BEATS[index]} placement={PLACED[index]!} index={index} agents={AGENTS} channels={CHANNELS} ids={IDS} />;
+}
+
+describe("Panel", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("shows one page in one room", () => {
+    const { container } = render(panelAt(0));
+    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+  });
+
+  it("does not turn between two lines in the same room", () => {
+    const { container, rerender } = render(panelAt(0));
+    rerender(panelAt(1));
+    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.textContent).toContain("line b");
+  });
+
+  it("keeps the leaving page up for the turn, still showing its own line", () => {
+    const { container, rerender } = render(panelAt(1));
+    rerender(panelAt(2));
+    const pages = container.querySelectorAll(".panel__page");
+    expect(pages).toHaveLength(2);
+    expect(pages[0]?.className).toContain("panel__page--leave-forward");
+    expect(pages[0]?.textContent).toContain("line b");
+    expect(pages[1]?.className).toContain("panel__page--enter-forward");
+    expect(pages[1]?.textContent).toContain("line c");
+  });
+
+  it("drops the leaving page once the turn is over", () => {
+    const { container, rerender } = render(panelAt(1));
+    rerender(panelAt(2));
+    act(() => {
+      vi.advanceTimersByTime(TURN_MS + 1);
+    });
+    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+  });
+
+  it("turns the other way when seeking backwards", () => {
+    const { container, rerender } = render(panelAt(3));
+    rerender(panelAt(0));
+    const pages = container.querySelectorAll(".panel__page");
+    expect(pages[0]?.className).toContain("panel__page--leave-back");
+    expect(pages[1]?.className).toContain("panel__page--enter-back");
+  });
+
+  it("never holds more than one leaving page under rapid seeks", () => {
+    const { container, rerender } = render(panelAt(0));
+    rerender(panelAt(2));
+    rerender(panelAt(0));
+    rerender(panelAt(3));
+    expect(container.querySelectorAll(".panel__page")).toHaveLength(2);
+  });
+
+  it("swaps instantly when the reader asked for less motion", () => {
+    vi.spyOn(motion, "reducedMotion").mockReturnValue(true);
+    const { container, rerender } = render(panelAt(1));
+    rerender(panelAt(2));
+    expect(container.querySelectorAll(".panel__page")).toHaveLength(1);
+    expect(container.textContent).toContain("line c");
+  });
+});

--- a/packages/web/src/stage/__tests__/stage-clock.test.tsx
+++ b/packages/web/src/stage/__tests__/stage-clock.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * The clock's high-water mark. `behind` is how deep the queue is from where
+ * you are; `reached` is how far you have ever been. The sheet draws up to
+ * `reached` and leaves the rest blank, so seeking back must not un-draw.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { StageBeat } from "@perfectman/shared";
+import { useStageClock } from "../useStageClock.js";
+
+function beat(id: string): StageBeat {
+  return {
+    id, kind: "message", pulseIndex: 0, channelId: "c", actorId: "a", text: id,
+    audienceIds: [], participantIds: ["a"], duration: 99, page: 0,
+  };
+}
+const BEATS = ["a", "b", "c", "d"].map(beat);
+
+describe("useStageClock.reached", () => {
+  it("starts at the first beat", () => {
+    const { result } = renderHook(() => useStageClock(BEATS));
+    expect(result.current.reached).toBe(0);
+  });
+
+  it("rises with a seek forward and stays up on a seek back", () => {
+    const { result } = renderHook(() => useStageClock(BEATS));
+    act(() => result.current.seek(3));
+    expect(result.current.reached).toBe(3);
+    act(() => result.current.seek(1));
+    expect(result.current.index).toBe(1);
+    expect(result.current.reached).toBe(3);
+    expect(result.current.behind).toBe(2);
+  });
+});

--- a/packages/web/src/stage/__tests__/stage.test.tsx
+++ b/packages/web/src/stage/__tests__/stage.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * The room draws what the placement says, not what it works out for itself.
+ * Seating is decided once for the whole run (see shared `placeBeats`); the
+ * stage only puts figures on the marks it is handed.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { idlePlacement, placeBeats, type LiveChannel, type StageBeat } from "@perfectman/shared";
+import { Stage } from "../Stage.js";
+
+const AGENTS = [
+  { id: "iris", displayName: "íris" },
+  { id: "bruno", displayName: "bruno" },
+  { id: "marcela", displayName: "marcela" },
+];
+const IDS = AGENTS.map((a) => a.id).sort();
+const CHANNELS: LiveChannel[] = [
+  { id: "geral", name: "geral", type: "public_channel", memberAgentIds: ["iris", "bruno", "marcela"] },
+];
+
+function beat(over: Partial<StageBeat> = {}): StageBeat {
+  return {
+    id: "b1", kind: "message", pulseIndex: 0, channelId: "geral", actorId: "iris", text: "hello",
+    audienceIds: [], participantIds: ["iris", "bruno", "marcela"], duration: 3, page: 0, ...over,
+  };
+}
+
+describe("Stage", () => {
+  it("draws exactly the marks in the placement, not everyone in the beat", () => {
+    const b = beat();
+    const [placement] = placeBeats([b], AGENTS, CHANNELS);
+    const only = { ...placement!, marks: placement!.marks.filter((m) => m.agentId === "bruno") };
+    const { container } = render(<Stage beat={b} placement={only} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    expect(container.querySelectorAll(".stage__mark")).toHaveLength(1);
+    expect(container.textContent).toContain("bruno");
+    expect(container.textContent).not.toContain("marcela");
+  });
+
+  it("hangs one speech balloon off the speaker", () => {
+    const b = beat();
+    const [placement] = placeBeats([b], AGENTS, CHANNELS);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    expect(container.querySelectorAll(".bubble--speech")).toHaveLength(1);
+    expect(container.querySelectorAll(".bubble--thought")).toHaveLength(0);
+  });
+
+  it("shows a thought as a cloud, never as paper", () => {
+    const b = beat({ kind: "silence", text: "", thought: { text: "not now", drivers: [] } });
+    const [placement] = placeBeats([b], AGENTS, CHANNELS);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    expect(container.querySelectorAll(".bubble--thought")).toHaveLength(1);
+    expect(container.querySelectorAll(".bubble--speech")).toHaveLength(0);
+    expect(container.querySelector(".stage--thought")).not.toBeNull();
+  });
+
+  it("names who is shut out of a private room", () => {
+    const channels: LiveChannel[] = [
+      ...CHANNELS,
+      { id: "dm", name: "dm", type: "private_channel", memberAgentIds: ["iris", "marcela"] },
+    ];
+    const b = beat({ channelId: "dm", participantIds: ["iris", "marcela"] });
+    const [placement] = placeBeats([b], AGENTS, channels);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={AGENTS} channels={channels} ids={IDS} />);
+    expect(container.querySelector(".stage__shut-out")?.textContent).toContain("bruno");
+  });
+
+  it("seats the idle room with nobody lit and no balloon", () => {
+    const placement = idlePlacement(CHANNELS[0], AGENTS);
+    const { container } = render(<Stage beat={undefined} placement={placement} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    expect(container.querySelectorAll(".stage__mark")).toHaveLength(3);
+    expect(container.querySelectorAll(".bubbles")).toHaveLength(0);
+  });
+});

--- a/packages/web/src/stage/figure.css
+++ b/packages/web/src/stage/figure.css
@@ -92,8 +92,10 @@
   transition: opacity var(--quick) var(--ease);
 }
 
+/* Sized against the room, not the viewport: a 19px tag on a 300px-wide room
+   is a third of a figure's width and hides behind whoever stands in front. */
 .figure__name {
-  font-size: 19px;
+  font-size: clamp(11px, 2.4cqw, 19px);
   color: var(--ink-70);
   line-height: 1;
   white-space: nowrap;

--- a/packages/web/src/stage/figure.css
+++ b/packages/web/src/stage/figure.css
@@ -60,10 +60,10 @@
 }
 
 /* Staggered so a cast does not blink in unison, which reads as a glitch. */
-.figure:nth-child(3n + 2) .figure__eye {
+.stage__mark:nth-child(3n + 2) .figure__eye {
   animation-delay: 1.7s;
 }
-.figure:nth-child(3n) .figure__eye {
+.stage__mark:nth-child(3n) .figure__eye {
   animation-delay: 3.1s;
 }
 

--- a/packages/web/src/stage/motion.ts
+++ b/packages/web/src/stage/motion.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether the reader asked for less motion. Read in JS as well as CSS because
+ * some motion is structural — a page that stays mounted to animate out — and
+ * zeroing a duration does not stop it being mounted.
+ */
+export function reducedMotion(): boolean {
+  return typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -1,13 +1,22 @@
 /*
- * The room is a fixed aspect box so the ported slot geometry keeps working at
- * any width. Everything inside is positioned in percentages of it.
+ * The room is a fixed-aspect box so the slot geometry means what it says.
+ * Everything inside is positioned in percentages of it.
+ *
+ * The aspect is enforced through the width, not a max-height: a box with
+ * `aspect-ratio` and a `max-height` stops being that aspect the moment the cap
+ * bites, and then the figures — sized by width — are the wrong height for the
+ * room. Capping the column's width keeps the room 16:7 at every viewport.
  */
 
-.stage {
-  padding-top: 20px;
+.flipbook {
+  width: min(100%, calc(44vh * 16 / 7));
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  gap: 20px;
+  gap: 14px;
+  padding-top: 20px;
+}
+
+.stage {
+  display: grid;
   min-height: 0;
 }
 
@@ -15,23 +24,18 @@
   position: relative;
   overflow: hidden;
   aspect-ratio: 16 / 7;
-  max-height: 44vh;
   border-radius: var(--r-xl);
   background: var(--paper-warm);
   box-shadow: var(--ring), var(--lift);
   transition: background var(--settle) var(--ease), box-shadow var(--settle) var(--ease);
 }
 
-/* Entering a room is a moment, not a swap: the box is keyed on the channel so
-   it re-mounts and plays this, and the figures inside arrive with it. */
-.stage__room {
-  animation: room-enter 460ms var(--ease) both;
-}
-
-@keyframes room-enter {
-  from {
-    opacity: 0;
-    transform: scale(0.985);
+/* A phone is taller than it is wide; so is the room there. The slot fractions
+   are the same, so figures stand shorter against a taller room and balloons
+   have the headroom they never had at 153px. */
+@media (max-width: 640px) {
+  .stage__room {
+    aspect-ratio: 4 / 3;
   }
 }
 
@@ -107,7 +111,6 @@
 .stage__mark {
   position: absolute;
   width: 15%;
-  min-width: 78px;
   transform-origin: 50% 100%;
   transition: left var(--settle) var(--ease), top var(--settle) var(--ease),
     transform var(--settle) var(--ease);

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -322,6 +322,108 @@
   right: 0;
 }
 
+/* --- the contact sheet --------------------------------------------------- */
+
+/*
+ * A strip of frames as wide as the page above it. Frames are 16:7 like the
+ * room, so a dot lands where the figure stood. The current frame is ringed in
+ * ink; nothing else on the strip says anything, because it is an index of the
+ * run, not a transcript of it.
+ */
+.sheet {
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-radius: var(--r-lg);
+  background: var(--paper-warm);
+  box-shadow: var(--ring);
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-strong) transparent;
+}
+
+.sheet__frame {
+  flex: 0 0 auto;
+  width: 64px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  background: none;
+  border-radius: var(--r-xs);
+  display: block;
+  transition: box-shadow var(--quick) var(--ease), transform var(--quick) var(--ease);
+}
+.sheet__frame:hover {
+  box-shadow: 0 0 0 1px var(--ink-50);
+}
+.sheet__frame--here,
+.sheet__frame--here:hover {
+  box-shadow: 0 0 0 1.5px var(--ink);
+}
+.sheet__frame:focus-visible {
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .sheet__frame {
+    width: 48px;
+    height: 21px;
+  }
+}
+
+.frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.frame__ground {
+  fill: var(--paper-warm);
+  stroke: var(--rule-strong);
+  stroke-width: 0.6;
+}
+.frame--private .frame__ground {
+  fill: #f7f3ec;
+}
+.frame--thought .frame__ground {
+  fill: var(--paper);
+}
+.frame__inset {
+  fill: none;
+  stroke: var(--rule-strong);
+  stroke-width: 0.5;
+  stroke-dasharray: 1.2 1;
+}
+
+.frame__dot {
+  stroke: rgba(28, 27, 27, 0.4);
+  stroke-width: 0.5;
+}
+.frame__ring {
+  fill: none;
+  stroke: var(--ink);
+  stroke-width: 0.8;
+}
+.frame__glyph--speech {
+  fill: var(--paper);
+  stroke: var(--ink);
+  stroke-width: 0.7;
+}
+.frame__glyph--thought {
+  fill: var(--paper);
+  stroke: var(--ink-50);
+  stroke-width: 0.7;
+}
+.frame__glyph--move {
+  fill: none;
+  stroke: var(--ink);
+  stroke-width: 0.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 /* --- attribution --------------------------------------------------------- */
 
 .attribution {

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -20,6 +20,67 @@
   min-height: 0;
 }
 
+/* --- the page ------------------------------------------------------------ */
+
+/*
+ * Two pages at most, stacked in one grid cell: the one leaving and the one
+ * arriving. The leaving page is a snapshot that keeps its own DOM, so figures
+ * keep breathing while it goes. `clip` rather than `hidden`, because the 6%
+ * slide must not give the whole document a horizontal scrollbar.
+ */
+.panel {
+  display: grid;
+  perspective: 1200px;
+  overflow-x: clip;
+}
+
+.panel__page {
+  grid-area: 1 / 1;
+  min-width: 0;
+  transform-origin: 50% 50%;
+  will-change: transform, opacity;
+}
+
+.panel__page--leave-forward {
+  animation: page-leave-forward var(--turn) var(--ease) both;
+  pointer-events: none;
+}
+.panel__page--enter-forward {
+  animation: page-enter-forward var(--turn) var(--ease) both;
+}
+.panel__page--leave-back {
+  animation: page-leave-back var(--turn) var(--ease) both;
+  pointer-events: none;
+}
+.panel__page--enter-back {
+  animation: page-enter-back var(--turn) var(--ease) both;
+}
+
+@keyframes page-leave-forward {
+  to {
+    opacity: 0;
+    transform: translateX(-6%) rotateY(-6deg);
+  }
+}
+@keyframes page-enter-forward {
+  from {
+    opacity: 0;
+    transform: translateX(6%);
+  }
+}
+@keyframes page-leave-back {
+  to {
+    opacity: 0;
+    transform: translateX(6%) rotateY(6deg);
+  }
+}
+@keyframes page-enter-back {
+  from {
+    opacity: 0;
+    transform: translateX(-6%);
+  }
+}
+
 .stage__room {
   position: relative;
   overflow: hidden;

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -2,10 +2,11 @@
  * The room is a fixed-aspect box so the slot geometry means what it says.
  * Everything inside is positioned in percentages of it.
  *
- * The aspect is enforced through the width, not a max-height: a box with
- * `aspect-ratio` and a `max-height` stops being that aspect the moment the cap
- * bites, and then the figures — sized by width — are the wrong height for the
- * room. Capping the column's width keeps the room 16:7 at every viewport.
+ * The height cap lives on the column's width rather than on the room's
+ * max-height so that everything in the column — the caption, the contact
+ * sheet — is exactly as wide as the room it describes. The room itself would
+ * have been 16:7 either way: a browser transfers a max-height through an
+ * aspect-ratio into the width.
  */
 
 .flipbook {
@@ -20,39 +21,49 @@
   min-height: 0;
 }
 
-/* --- the page ------------------------------------------------------------ */
+/* --- the pages ----------------------------------------------------------- */
 
 /*
  * Two pages at most, stacked in one grid cell: the one leaving and the one
  * arriving. The leaving page is a snapshot that keeps its own DOM, so figures
- * keep breathing while it goes. `clip` rather than `hidden`, because the 6%
- * slide must not give the whole document a horizontal scrollbar.
+ * keep breathing while it goes.
  */
-.panel {
+.pages {
   display: grid;
   perspective: 1200px;
-  overflow-x: clip;
 }
 
-.panel__page {
+/* On a phone the column is the whole width, so the 6% slide would give the
+   document a horizontal scrollbar for half a second. Clip it there, and drop
+   the room's ambient shadow, which a clip would cut into bands. */
+@media (max-width: 640px) {
+  .pages {
+    overflow-x: clip;
+  }
+  .stage__room {
+    box-shadow: var(--ring);
+  }
+}
+
+.pages__page {
   grid-area: 1 / 1;
   min-width: 0;
   transform-origin: 50% 50%;
   will-change: transform, opacity;
 }
 
-.panel__page--leave-forward {
+.pages__page--leave-forward {
   animation: page-leave-forward var(--turn) var(--ease) both;
   pointer-events: none;
 }
-.panel__page--enter-forward {
+.pages__page--enter-forward {
   animation: page-enter-forward var(--turn) var(--ease) both;
 }
-.panel__page--leave-back {
+.pages__page--leave-back {
   animation: page-leave-back var(--turn) var(--ease) both;
   pointer-events: none;
 }
-.panel__page--enter-back {
+.pages__page--enter-back {
   animation: page-enter-back var(--turn) var(--ease) both;
 }
 
@@ -84,6 +95,8 @@
 .stage__room {
   position: relative;
   overflow: hidden;
+  /* Name tags are sized against the room, see figure.css. */
+  container-type: inline-size;
   aspect-ratio: 16 / 7;
   border-radius: var(--r-xl);
   background: var(--paper-warm);
@@ -100,17 +113,26 @@
   }
 }
 
+/* Above the balloons, on its own paper: a balloon that could not fit above a
+   back-row head reaches the top of the room, and the room's name must still
+   be readable over it. */
 .stage__where {
   position: absolute;
-  top: 14px;
-  left: 18px;
+  top: 10px;
+  left: 12px;
   display: flex;
   align-items: baseline;
   gap: 8px;
+  padding: 3px 8px;
+  border-radius: var(--r-pill);
+  background: var(--paper-warm);
   font-size: 12.5px;
   color: var(--ink-50);
   z-index: 500;
   max-width: none;
+}
+.stage--thought .stage__where {
+  background: var(--paper);
 }
 
 .stage__where > span:first-child {
@@ -211,6 +233,16 @@
 }
 .bubbles--left {
   transform: translateX(-84%);
+}
+
+/* Beside the head rather than over it, when there was no room above. The
+   inner edge sits just clear of the figure and the tail still hangs on that
+   side, pointing down at whose line it is. */
+.bubbles--right.bubbles--beside {
+  transform: translateX(0);
+}
+.bubbles--left.bubbles--beside {
+  transform: translateX(-100%);
 }
 
 @keyframes bubble-in {

--- a/packages/web/src/stage/useBubbleAnchor.ts
+++ b/packages/web/src/stage/useBubbleAnchor.ts
@@ -38,6 +38,21 @@ export function bubbleBottom(
 }
 
 /**
+ * Whether the balloon could not fit above the head and had to slide down over
+ * the figure. The caller moves it beside the head instead: a balloon over a
+ * picture is fine, a balloon over the speaker's face is not.
+ */
+export function bubbleClamped(
+  headTop: number,
+  roomHeight: number,
+  bubbleHeight: number,
+  margin = BUBBLE_MARGIN,
+): boolean {
+  const wanted = (1 - headTop) * roomHeight + roomHeight * 0.02;
+  return wanted > roomHeight - bubbleHeight - margin;
+}
+
+/**
  * Where the drawn head begins, as a fraction of the room's height, from the
  * figure's and the room's on-screen boxes. Both boxes move together under a
  * page turn's translate, and the ratio cancels it.
@@ -54,9 +69,10 @@ export function useBubbleAnchor(
   headTopGuess: number,
   /** Changes whenever the content does, so the measurement is redone. */
   key: string,
-): { ref: RefObject<HTMLDivElement>; bottom: string } {
+): { ref: RefObject<HTMLDivElement>; bottom: string; beside: boolean } {
   const ref = useRef<HTMLDivElement>(null);
   const [bottom, setBottom] = useState(`${(1 - headTopGuess) * 100 + 2}%`);
+  const [beside, setBeside] = useState(false);
 
   useLayoutEffect(() => {
     const node = ref.current;
@@ -70,6 +86,7 @@ export function useBubbleAnchor(
       const headTop =
         (figure && measuredHeadTop(figure.getBoundingClientRect(), room.getBoundingClientRect())) ?? headTopGuess;
       setBottom(`${bubbleBottom(headTop, roomHeight, node.offsetHeight)}px`);
+      setBeside(bubbleClamped(headTop, roomHeight, node.offsetHeight));
     };
     place();
 
@@ -80,5 +97,5 @@ export function useBubbleAnchor(
     return () => watcher.disconnect();
   }, [speaker, headTopGuess, key]);
 
-  return { ref, bottom };
+  return { ref, bottom, beside };
 }

--- a/packages/web/src/stage/useBubbleAnchor.ts
+++ b/packages/web/src/stage/useBubbleAnchor.ts
@@ -7,11 +7,15 @@
  * dead band above the stage on every ordinary beat, and still only works for
  * the text lengths that were guessed at.
  *
- * So it is measured. The balloon is placed against the head, and if that would
- * carry its top out of the frame it slides down until it fits — overlapping the
- * scene, which is what a balloon over a picture is supposed to do.
+ * So it is measured, twice over. Where the head is comes from the speaker's
+ * drawn figure — not from a constant, because the constant assumed a 16:7 room
+ * and a room capped by the viewport's height is not 16:7, and because the name
+ * tag under a figure is set in pixels. Then the balloon is placed against that
+ * head, and if that would carry its top out of the frame it slides down until
+ * it fits — overlapping the scene, which is what a balloon over a picture is
+ * supposed to do.
  */
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState, type RefObject } from "react";
 
 /** Breathing room between a balloon and the top of the frame. */
 export const BUBBLE_MARGIN = 8;
@@ -33,24 +37,48 @@ export function bubbleBottom(
   return Math.max(0, Math.min(wanted, ceiling));
 }
 
+/**
+ * Where the drawn head begins, as a fraction of the room's height, from the
+ * figure's and the room's on-screen boxes. Both boxes move together under a
+ * page turn's translate, and the ratio cancels it.
+ */
+export function measuredHeadTop(figure: DOMRect, room: DOMRect): number | undefined {
+  if (room.height <= 0) return undefined;
+  return (figure.top - room.top) / room.height;
+}
+
 export function useBubbleAnchor(
-  /** Fraction from the room's top where the speaker's head begins. */
-  headTop: number,
+  /** The speaker's mark. Its `.figure__body` is the drawing whose top is the head. */
+  speaker: RefObject<HTMLElement>,
+  /** Fraction from the room's top where the head should begin, until measured. */
+  headTopGuess: number,
   /** Changes whenever the content does, so the measurement is redone. */
   key: string,
-): { ref: React.RefObject<HTMLDivElement>; bottom: string } {
+): { ref: RefObject<HTMLDivElement>; bottom: string } {
   const ref = useRef<HTMLDivElement>(null);
-  const [bottom, setBottom] = useState(`${(1 - headTop) * 100 + 2}%`);
+  const [bottom, setBottom] = useState(`${(1 - headTopGuess) * 100 + 2}%`);
 
   useLayoutEffect(() => {
     const node = ref.current;
     const room = node?.offsetParent as HTMLElement | null;
     if (!node || !room) return;
 
-    const roomHeight = room.clientHeight;
-    if (roomHeight === 0) return;
-    setBottom(`${bubbleBottom(headTop, roomHeight, node.offsetHeight)}px`);
-  }, [headTop, key]);
+    const place = (): void => {
+      const roomHeight = room.clientHeight;
+      if (roomHeight === 0) return;
+      const figure = speaker.current?.querySelector<SVGElement>(".figure__body");
+      const headTop =
+        (figure && measuredHeadTop(figure.getBoundingClientRect(), room.getBoundingClientRect())) ?? headTopGuess;
+      setBottom(`${bubbleBottom(headTop, roomHeight, node.offsetHeight)}px`);
+    };
+    place();
+
+    // The bottom is in pixels, so a resized room needs a fresh measurement.
+    if (typeof ResizeObserver === "undefined") return;
+    const watcher = new ResizeObserver(place);
+    watcher.observe(room);
+    return () => watcher.disconnect();
+  }, [speaker, headTopGuess, key]);
 
   return { ref, bottom };
 }

--- a/packages/web/src/stage/useStageClock.ts
+++ b/packages/web/src/stage/useStageClock.ts
@@ -23,6 +23,11 @@ export type StageClock = {
   playing: boolean;
   /** Beats waiting behind the one on stage. */
   behind: number;
+  /**
+   * The furthest beat that has been on stage. Unlike `behind`, seeking back
+   * does not lower it: what has been shown has been shown.
+   */
+  reached: number;
   atEnd: boolean;
   play: () => void;
   pause: () => void;
@@ -40,6 +45,8 @@ export function useStageClock(beats: readonly StageBeat[], speed = 1): StageCloc
   const bounded = Math.min(index, Math.max(0, beats.length - 1));
   const beat = beats[bounded];
   const atEnd = bounded >= beats.length - 1;
+  const [reached, setReached] = useState(0);
+  if (bounded > reached) setReached(bounded);
 
   useEffect(() => {
     if (!playing || !beat || atEnd) return;
@@ -75,6 +82,7 @@ export function useStageClock(beats: readonly StageBeat[], speed = 1): StageCloc
     beat,
     playing,
     behind: Math.max(0, beats.length - 1 - bounded),
+    reached: Math.max(reached, bounded),
     atEnd,
     play,
     pause: () => setPlaying(false),

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from "vitest/config";
 
 /**
- * Only the pure stream fold is covered. It is the one piece of web code with
- * behaviour rather than markup — and the piece that shipped a duplicate-run bug
- * the moment it met a real reconnect.
+ * Pure logic runs in node; anything ending in `.test.tsx` gets a DOM. The split
+ * is by extension on purpose: a component test needs jsdom, a fold or a
+ * geometry check does not, and jsdom start-up is most of a test's cost.
  */
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    environmentMatchGlobs: [["src/**/*.test.tsx", "jsdom"]],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,9 +157,6 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@fontsource-variable/caveat':
-        specifier: ^5.3.0
-        version: 5.3.0
       '@fontsource-variable/fraunces':
         specifier: ^5.3.0
         version: 5.3.0
@@ -825,9 +822,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@fontsource-variable/caveat@5.3.0':
-    resolution: {integrity: sha512-Q3mjghoYIlXgwqBPJKZ4q6f3zu921Gq7UU76r9Z+NAmhapHfX130GIFpOCYf8vt2SIcgCi9RHDT7anfJKg/kiA==}
 
   '@fontsource-variable/dm-sans@5.3.0':
     resolution: {integrity: sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==}
@@ -3412,8 +3406,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
-
-  '@fontsource-variable/caveat@5.3.0': {}
 
   '@fontsource-variable/dm-sans@5.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.1.9(vitest@2.1.9(@types/node@26.2.0))
+        version: 2.1.9(vitest@2.1.9(@types/node@26.2.0)(jsdom@30.0.1))
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   packages/engine:
     dependencies:
@@ -32,7 +32,7 @@ importers:
         version: 10.0.0(@stryker-mutator/core@10.0.0(@types/node@26.2.0))(typescript@5.9.3)
       '@stryker-mutator/vitest-runner':
         specifier: ^10.0.0
-        version: 10.0.0(@stryker-mutator/core@10.0.0(@types/node@26.2.0))(vitest@2.1.9(@types/node@26.2.0))
+        version: 10.0.0(@stryker-mutator/core@10.0.0(@types/node@26.2.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@30.0.1))
       fast-check:
         specifier: ^4.9.0
         version: 4.9.0
@@ -41,7 +41,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   packages/eval:
     dependencies:
@@ -78,7 +78,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   packages/server:
     dependencies:
@@ -124,7 +124,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   packages/shared:
     dependencies:
@@ -143,7 +143,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   packages/web:
     dependencies:
@@ -163,6 +163,9 @@ importers:
       '@fontsource-variable/instrument-sans':
         specifier: ^5.3.0
         version: 5.3.0
+      '@testing-library/react':
+        specifier: ^16.3.3
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.31
@@ -172,6 +175,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@5.4.21(@types/node@26.2.0))
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -180,7 +186,7 @@ importers:
         version: 5.4.21(@types/node@26.2.0)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@26.2.0)
+        version: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
 packages:
 
@@ -209,6 +215,14 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -467,6 +481,10 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
@@ -497,6 +515,46 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.2':
+    resolution: {integrity: sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.12':
+    resolution: {integrity: sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discordjs/builders@1.14.1':
     resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
@@ -822,6 +880,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fontsource-variable/dm-sans@5.3.0':
     resolution: {integrity: sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==}
@@ -1415,6 +1482,28 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.3':
+    resolution: {integrity: sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1550,9 +1639,16 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1575,6 +1671,9 @@ packages:
 
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bidi-js@1.1.0:
+    resolution: {integrity: sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -1693,12 +1792,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1708,6 +1815,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1741,6 +1851,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
@@ -1766,6 +1880,9 @@ packages:
   discord.js@14.26.4:
     resolution: {integrity: sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==}
     engines: {node: '>=18'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1799,6 +1916,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1996,6 +2117,10 @@ packages:
     resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2050,6 +2175,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -2092,6 +2220,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2153,6 +2290,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
@@ -2173,6 +2314,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -2307,6 +2451,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2344,6 +2491,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -2358,6 +2509,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   puppeteer-core@25.10.0:
     resolution: {integrity: sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==}
@@ -2378,6 +2533,9 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2423,6 +2581,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2550,6 +2712,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -2585,6 +2750,21 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2636,6 +2816,10 @@ packages:
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
+    engines: {node: '>=22.19.0'}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -2717,6 +2901,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   weapon-regex@2.0.4:
     resolution: {integrity: sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==}
 
@@ -2727,8 +2915,24 @@ packages:
   webdriver-bidi-protocol@0.4.3:
     resolution: {integrity: sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2782,6 +2986,13 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2854,6 +3065,21 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.1.0
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3155,6 +3381,8 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 8.0.1(@babel/core@8.0.1)
       '@babel/plugin-transform-typescript': 8.0.1(@babel/core@8.0.1)
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3205,6 +3433,34 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.4
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.12(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@discordjs/builders@1.14.1':
     dependencies:
@@ -3406,6 +3662,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@fontsource-variable/dm-sans@5.3.0': {}
 
@@ -3884,18 +4142,41 @@ snapshots:
 
   '@stryker-mutator/util@10.0.0': {}
 
-  '@stryker-mutator/vitest-runner@10.0.0(@stryker-mutator/core@10.0.0(@types/node@26.2.0))(vitest@2.1.9(@types/node@26.2.0))':
+  '@stryker-mutator/vitest-runner@10.0.0(@stryker-mutator/core@10.0.0(@types/node@26.2.0))(vitest@2.1.9(@types/node@26.2.0)(jsdom@30.0.1))':
     dependencies:
       '@stryker-mutator/api': 10.0.0
       '@stryker-mutator/core': 10.0.0(@types/node@26.2.0)
       '@stryker-mutator/util': 10.0.0
       semver: 7.8.1
       tslib: 2.8.1
-      vitest: 2.1.9(@types/node@26.2.0)
+      vitest: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
 
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3966,7 +4247,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@26.2.0))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@26.2.0)(jsdom@30.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -3980,7 +4261,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@26.2.0)
+      vitest: 2.1.9(@types/node@26.2.0)(jsdom@30.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4057,7 +4338,13 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -4073,6 +4360,10 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+
+  bidi-js@1.1.0:
+    dependencies:
+      require-from-string: 2.0.2
 
   bignumber.js@9.3.1:
     optional: true
@@ -4189,14 +4480,28 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1:
     optional: true
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4226,6 +4531,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   des.js@1.1.0:
     dependencies:
@@ -4263,6 +4570,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  dom-accessibility-api@0.5.16: {}
+
   dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
@@ -4291,6 +4600,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -4557,6 +4868,12 @@ snapshots:
 
   hono@4.13.7: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   https-proxy-agent@7.0.6:
@@ -4623,6 +4940,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-stream@4.0.1: {}
 
   is-unicode-supported@2.1.0: {}
@@ -4665,6 +4984,32 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.12(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4719,6 +5064,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.21:
@@ -4740,6 +5087,8 @@ snapshots:
       escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -4851,6 +5200,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -4889,6 +5242,12 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -4914,6 +5273,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   puppeteer-core@25.10.0:
     dependencies:
@@ -4947,6 +5308,8 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -5016,6 +5379,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5165,6 +5532,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -5206,6 +5575,20 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tree-kill@1.2.2: {}
 
   ts-mixer@6.0.4: {}
@@ -5241,6 +5624,8 @@ snapshots:
   undici@6.24.1: {}
 
   undici@7.29.0: {}
+
+  undici@8.10.2: {}
 
   unicode-properties@1.4.1:
     dependencies:
@@ -5289,7 +5674,7 @@ snapshots:
       '@types/node': 26.2.0
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@26.2.0):
+  vitest@2.1.9(@types/node@26.2.0)(jsdom@30.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@26.2.0))
@@ -5313,6 +5698,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5324,6 +5710,10 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   weapon-regex@2.0.4: {}
 
   web-streams-polyfill@3.3.3:
@@ -5331,7 +5721,27 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.3: {}
 
+  webidl-conversions@8.0.1: {}
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -5369,6 +5779,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/audit-tests.mjs
+++ b/scripts/audit-tests.mjs
@@ -19,7 +19,7 @@ function walk(dir, acc = []) {
     if (e.name === "node_modules" || e.name === "dist" || e.name === ".stryker-tmp") continue;
     const p = join(dir, e.name);
     if (e.isDirectory()) walk(p, acc);
-    else if (e.name.endsWith(".test.ts")) acc.push(p);
+    else if (/\.test\.tsx?$/.test(e.name)) acc.push(p);
   }
   return acc;
 }


### PR DESCRIPTION
## What

Turns the run screen into a flipbook — the room is the page, the run so far is a strip of pictures under it:

- `placeBeats` (`shared/src/stage/placement.ts`) seats every beat in one pass with memory keyed by `kind/channel`. A `silence` beat rendered the same channel as a one-seat thought room and overwrote the public room's seats, so the next line moved everyone; seeking back now shows the seating a beat had the first time.
- `Panel` keeps the leaving room mounted for `--turn` (520 ms), forward or back by seek direction; no leaving page under `prefers-reduced-motion`. `key={channelId}` and `room-enter` are gone.
- `ContactSheet` + `Frame`: one 64×28 SVG per beat — ground per room kind, a dot per person where they stood, a ring on the speaker, a box/cloud/arrow glyph. No words, `aria-label` per frame, one tab stop, arrow keys. Replaces the `<input type=range>`. Frames past `reached` stay blank while live.
- `useBubbleAnchor` measures the speaker's `.figure__body` instead of trusting `FIGURE_HEIGHT_FRACTION`; `bubbleClamped` moves a boxed-in balloon beside the head rather than over the face. `min-width: 78px` on `.stage__mark` is gone; the room is 4:3 under 640 px; name tags are sized in `cqw`.
- `PUBLIC_SLOTS[2..3]` move to `.42/.58`; `slot-geometry.test.ts` keeps every mid-row tag out of every front-row box.
- `useSoundtrack`: per-element fade cancellation, `unlock()` in the Run click on beds and a pre-created cue pool, `sfxCueFor` fires once per line (`StageBeat.page === 0`) and only while playing, a refused `play()` flips the control but never writes `localStorage`, `AbortError` is not a refusal, beds stay off where element volume is read-only (iOS).
- `.test.tsx` runs under jsdom via `environmentMatchGlobs`; `audit-tests.mjs` now counts `.test.tsx`.
- 55 tests: placement stickiness / room-size re-check / silence isolation / determinism / seed / slot order, slot geometry, beat pages, Stage marks / balloon kind / shut-out / idle, Panel same-room / turn / cleanup / direction / rapid seeks / reduced motion, Frame dots / glyphs / signature / no words, ContactSheet frames / current / click / keys / blank rule, clock `reached`, cue rule, refusal classifier.

## Why

Measured against `main` with a mock run of `the-group` × `A última proteína` (36 beats): every balloon sat 6–14 px onto the speaker's head, because the anchoring constant knew the drawn figure and not the name tag under it; at 390 px the balloon was clipped out of the room entirely (top at −127 px) and mid-row tags hid 25 px behind the front row; `message.ogg` fired on every step while paused. The strip under the room in the earlier mockup read as a log, so the port replaces it with pictures.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (1987 passed, +55: web 28 → 64, shared +19)
- Same mock run at 1456×832 and 390×844: balloon-on-head 36/36 → 0; phone balloon −127 px → 27 px inside the room; hidden tags 10 px → 0 on desktop, 25 px → 1 px on phone; seating identical on revisit; calm bed `paused=false` at 0.153 with 0 rejections, sound on end to end; 0 cues while paused; no horizontal scroll at 390 px; web bundle 347.78 kB / 102.58 kB gz
- The turn is not exercisable by the mock (it never leaves the public channel); covered by seven `Panel` tests and a keyframe check, and noted in `docs/frontend-handoff.md`