### PR TITLE
feat(web): the landing plays the real page and characters are faces

### DIFF
--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -85,8 +85,9 @@ Forty files. These are the ones that carry weight.
 
 | File | What it does |
 |---|---|
-| `onboarding/Intro.tsx` | Plays a scene instead of explaining one. Shown once; flag in `localStorage`. |
-| `onboarding/intro-script.ts` | Six hand-written beats. No server involved — safe to edit freely. |
+| `onboarding/Intro.tsx` | Plays a scene instead of explaining one, through the run's own `Panel`, caption and `ContactSheet`. Shown once; flag in `localStorage`. |
+| `onboarding/intro-script.ts` | Six hand-written beats, and `introRun()` turning them into `StageBeat`s. No server involved — safe to edit freely. |
+| `pick/RoomPreview.tsx` | `CastRoom` stands the chosen cast in the room; `SceneRooms` draws one room per compiled channel with the shut-out named. |
 
 ### The stage — where the work is
 
@@ -115,7 +116,7 @@ Forty files. These are the ones that carry weight.
 
 | File | What it does |
 |---|---|
-| `shared/src/stage/live-to-beats.ts` | Pulse → beats. The event allowlist lives here. |
+| `shared/src/stage/live-to-beats.ts` | Pulse → beats. The event allowlist lives here. Fills `reactions` so listeners wear what was recorded about them. |
 | `shared/src/stage/emotion-face.ts` | Recorded emotion → face. Shared with the MP4 renderer so both agree. |
 | `shared/src/stage/slots.ts` | Where figures stand, as fractions. The figure-height constant is only the first-paint guess. |
 | `shared/src/stage/placement.ts` | `placeBeats`: seating for the whole run in one pass, memory keyed by room, not channel. |
@@ -166,6 +167,18 @@ The contact sheet is the run as pictures: ground per room kind, a dot per
 person where they stood, a ring on the speaker. It replaced the range input.
 Anything readable in it would make it a transcript, which is what the details
 drawer is for. `reached` is not `behind`: seeking back does not un-draw.
+
+**The landing is the product, not a picture of it.**
+The intro renders through `Panel`, `Attribution` and `ContactSheet` with beats
+from `introRun()`. A separate intro layout drifted from the stage the moment the
+stage changed; now it cannot. The provenance reading in the caption is hidden
+there by CSS, because on the landing everything is authored.
+
+**The previous page lives in state, not a ref.**
+React renders twice in development. A ref written during the first pass made
+the second pass see no room change, and the turn was silently dropped in dev
+while passing its tests. `Panel` keeps the last page in state and resets it
+during render; the StrictMode test pins it.
 
 **Mute flips, only the toggle persists.**
 A refused `play()` turns the control off so it never claims sound that is not

--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -85,9 +85,8 @@ Forty files. These are the ones that carry weight.
 
 | File | What it does |
 |---|---|
-| `onboarding/Intro.tsx` | Plays a scene instead of explaining one, through the run's own `Panel`, caption and `ContactSheet`. Shown once; flag in `localStorage`. |
+| `onboarding/Intro.tsx` | Plays a scene instead of explaining one, through the run's own `Panel` and caption. Shown once; flag in `localStorage`. |
 | `onboarding/intro-script.ts` | Six hand-written beats, and `introRun()` turning them into `StageBeat`s. No server involved — safe to edit freely. |
-| `pick/RoomPreview.tsx` | `CastRoom` stands the chosen cast in the room; `SceneRooms` draws one room per compiled channel with the shut-out named. |
 
 ### The stage — where the work is
 
@@ -97,7 +96,7 @@ Forty files. These are the ones that carry weight.
 | `stage/Stage.tsx` | Draws a `Placement`: figures on their marks, the excluded named, one balloon. Room only. |
 | `stage/Attribution.tsx` | The caption under the room. Separate so the turn rotates the picture, not the text. |
 | `stage/ContactSheet.tsx`, `stage/Frame.tsx` | The scrubber: one SVG frame per beat, no words, `aria-label` per frame, arrow keys. |
-| `stage/Figure.tsx` | The drawn character. Face is a pose lookup; every change is a CSS transition. |
+| `stage/Figure.tsx` | The drawn character: a face and a name, no body. Pose is a lookup; the head tilts, the cheeks colour, the mouth moves while speaking. All CSS transitions. |
 | `stage/useBubbleAnchor.ts` | Measures the speaker's drawn head and the balloon, clamps inside the room, moves beside the head when it cannot fit above. The pure functions are tested. |
 | `stage/useStageClock.ts` | Live queue and replay seeking, one machine. `reached` is the high-water mark the sheet draws up to. |
 | `stage/room-label.ts` | Names a private room by its members, because the engine names it with an id. |
@@ -169,10 +168,18 @@ Anything readable in it would make it a transcript, which is what the details
 drawer is for. `reached` is not `behind`: seeking back does not un-draw.
 
 **The landing is the product, not a picture of it.**
-The intro renders through `Panel`, `Attribution` and `ContactSheet` with beats
-from `introRun()`. A separate intro layout drifted from the stage the moment the
+The intro renders through `Panel` and `Attribution` with beats from
+`introRun()`. A separate intro layout drifted from the stage the moment the
 stage changed; now it cannot. The provenance reading in the caption is hidden
-there by CSS, because on the landing everything is authored.
+there by CSS, because on the landing everything is authored. Nothing else was
+added to the landing or the pick steps on purpose: the direction is to sharpen
+what is there, not to add to it.
+
+**A character is a face.**
+The body never carried information and, at the sizes the stage and the cards
+draw, only made the face smaller. Marks are 18% of the room; the rows sit at
+`.92 / .66 / .46` so five faces fill a page. `FIGURE_HEIGHT_FRACTION` is the
+face's height and still only the first-paint guess.
 
 **The previous page lives in state, not a ref.**
 React renders twice in development. A ref written during the first pass made

--- a/packages/shared/src/stage/__tests__/live-to-beats.test.ts
+++ b/packages/shared/src/stage/__tests__/live-to-beats.test.ts
@@ -172,3 +172,25 @@ describe("pulseToBeats — pages", () => {
     expect(beat?.page).toBe(0);
   });
 });
+
+describe("pulseToBeats — reactions", () => {
+  it("carries everyone else's recorded emotion so the room can react to a line", () => {
+    const emotions = {
+      iris: { valence: 0.2, arousal: 0.3, top: [{ key: "neutral", value: 0.5 }] },
+      marcela: { valence: -0.6, arousal: 0.7, top: [{ key: "fear_of_exclusion", value: 0.8 }] },
+    };
+    const [beat] = pulseToBeats(frame({ messages: [message()], emotions }), CONTEXT);
+    expect(beat?.emotion?.label).toBe("neutral");
+    expect(beat?.reactions?.["marcela"]?.label).toBe("fear_of_exclusion");
+    expect(beat?.reactions?.["iris"]).toBeUndefined();
+  });
+
+  it("only includes people in the room", () => {
+    const emotions = { marcela: { valence: 0, arousal: 0, top: [{ key: "calm", value: 1 }] } };
+    const [beat] = pulseToBeats(
+      frame({ messages: [message({ channelId: "dm", actorId: "iris" })], emotions: { ...emotions, bruno: emotions.marcela } }),
+      CONTEXT,
+    );
+    expect(Object.keys(beat?.reactions ?? {})).toEqual(["marcela"]);
+  });
+});

--- a/packages/shared/src/stage/__tests__/slot-geometry.test.ts
+++ b/packages/shared/src/stage/__tests__/slot-geometry.test.ts
@@ -4,16 +4,15 @@
  * figure's box, the name is hidden by a torso.
  *
  * Geometry in fractions of the room's width (W) with H = 7/16 W. A mark is 15%
- * of W wide, scaled; the figure is 168 tall in a 100-wide box plus a 19px tag,
- * so at scale s a mark spans [x − .075s, x + .075s] × [y − .616s·(16/7)/… , y].
- * The tag is budgeted at ten italic characters (~0.55em of 19px each).
+ * of W wide — 18% — scaled; the face is a 100×100 drawing plus a 19px tag. The tag is
+ * budgeted at ten italic characters (~0.55em of 19px each).
  */
 import { describe, expect, it } from "vitest";
 import { slotsFor, type StageSlot } from "../slots.js";
 
 const H_OVER_W = 7 / 16;
-/** Figure height as a fraction of H at scale 1 — SVG 168 over a 100-wide mark at 15% of W. */
-const FIGURE_H = 0.15 * 1.68 / H_OVER_W;
+/** Figure height as a fraction of H at scale 1 — a 100×100 face on a mark 15% of W. */
+const FIGURE_H = 0.18 * 1.0 / H_OVER_W;
 /** Name tag: ten characters at ~0.55em × 19px, in a 1200px-wide room. */
 const TAG_HALF_W = (10 * 0.55 * 19) / 2 / 1200;
 const TAG_H = 22 / (1200 * H_OVER_W);
@@ -22,8 +21,8 @@ type Box = { left: number; right: number; top: number; bottom: number };
 
 function markBox(slot: StageSlot): Box {
   return {
-    left: slot.x - 0.075 * slot.scale,
-    right: slot.x + 0.075 * slot.scale,
+    left: slot.x - 0.09 * slot.scale,
+    right: slot.x + 0.09 * slot.scale,
     top: slot.y - FIGURE_H * slot.scale - TAG_H * slot.scale,
     bottom: slot.y,
   };

--- a/packages/shared/src/stage/beat.ts
+++ b/packages/shared/src/stage/beat.ts
@@ -44,6 +44,12 @@ export type StageBeat = {
   /** Everyone in frame for this beat, actor included. */
   participantIds: string[];
   emotion?: RecordedEmotion;
+  /**
+   * What everyone else in the room was feeling at this moment, by agent id.
+   * The speaker's face comes from `emotion`; these are the faces of the people
+   * listening. Absent for a room that has recorded nothing about them.
+   */
+  reactions?: Record<string, RecordedEmotion>;
   thought?: StageThought;
   stageAction?: { kind: "arrive" | "leave" | "invite"; agentIds: string[] };
   /** Seconds this beat holds before the next one takes the stage. */

--- a/packages/shared/src/stage/live-to-beats.ts
+++ b/packages/shared/src/stage/live-to-beats.ts
@@ -96,6 +96,21 @@ function toThought(thinking: LiveThinking | undefined): StageThought | undefined
   };
 }
 
+/** Everyone in the room except the actor, with whatever the pulse recorded about them. */
+function reactionsIn(
+  frame: LivePulseFrame,
+  participantIds: readonly string[],
+  actorId: string | undefined,
+): Record<string, RecordedEmotion> | undefined {
+  const reactions: Record<string, RecordedEmotion> = {};
+  for (const id of participantIds) {
+    if (id === actorId) continue;
+    const emotion = toRecordedEmotion(frame.emotions[id]);
+    if (emotion) reactions[id] = emotion;
+  }
+  return Object.keys(reactions).length > 0 ? reactions : undefined;
+}
+
 function membersOf(channels: readonly LiveChannel[], channelId: string): string[] {
   return channels.find((c) => c.id === channelId)?.memberAgentIds ?? [];
 }
@@ -117,6 +132,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
     const emotion = toRecordedEmotion(frame.emotions[message.actorId]);
     const thought = toThought(frame.thinking[message.actorId]);
     const participantIds = membersOf(context.channels, message.channelId);
+    const reactions = reactionsIn(frame, participantIds, message.actorId);
 
     if (staging === "action") {
       beats.push({
@@ -129,6 +145,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
         audienceIds: message.visibleToAgents,
         participantIds,
         ...(emotion ? { emotion } : {}),
+        ...(reactions ? { reactions } : {}),
         stageAction: { kind: STAGE_ACTIONS[message.eventType] ?? "invite", agentIds: [message.actorId] },
         duration: readingSeconds(message.text || " "),
         page: 0,
@@ -154,6 +171,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
         audienceIds: message.visibleToAgents,
         participantIds,
         ...(emotion ? { emotion } : {}),
+        ...(reactions ? { reactions } : {}),
         duration: readingSeconds(text),
         page,
       });
@@ -170,6 +188,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
           audienceIds: message.visibleToAgents,
           participantIds,
           emotion,
+          reactions,
         }),
       );
     }
@@ -182,6 +201,7 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
     const thought = toThought(thinking);
     if (!thought) continue;
     const emotion = toRecordedEmotion(frame.emotions[agentId]);
+    const participantIds = membersOf(context.channels, context.defaultChannelId);
     beats.push(
       ...thoughtBeats(thought, "silence", {
         idPrefix: `${frame.pulseIndex}:silence:${agentId}`,
@@ -189,8 +209,9 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
         channelId: context.defaultChannelId,
         actorId: agentId,
         audienceIds: [],
-        participantIds: membersOf(context.channels, context.defaultChannelId),
+        participantIds,
         emotion,
+        reactions: reactionsIn(frame, participantIds, agentId),
       }),
     );
   }
@@ -213,6 +234,7 @@ function thoughtBeats(
     audienceIds: string[];
     participantIds: string[];
     emotion: RecordedEmotion | undefined;
+    reactions: Record<string, RecordedEmotion> | undefined;
   },
 ): StageBeat[] {
   const pages = paginate(thought.text, THOUGHT_PAGE);
@@ -226,6 +248,7 @@ function thoughtBeats(
     audienceIds: at.audienceIds,
     participantIds: at.participantIds,
     ...(at.emotion ? { emotion: at.emotion } : {}),
+    ...(at.reactions ? { reactions: at.reactions } : {}),
     // Drivers belong with the last page, where the caption sits.
     thought: { ...thought, text, ...(page < pages.length - 1 ? { drivers: [] } : {}) },
     duration: readingSeconds(text),

--- a/packages/shared/src/stage/slots.ts
+++ b/packages/shared/src/stage/slots.ts
@@ -15,12 +15,12 @@ export type StageSlot = { x: number; y: number; scale: number };
 
 /**
  * How tall a figure's drawing stands, as a fraction of the room's height, in a
- * 16:7 room: a mark is 15% of the room's width and the figure is drawn 100
- * wide by 168 tall. This is the first-paint guess for where a head begins; the
- * stage measures the real thing once it has laid out, because the name tag
- * under the figure is set in pixels and the room is not 16:7 on a phone.
+ * 16:7 room: a mark is 18% of the room's width and the figure is a face drawn
+ * 100 wide by 100 tall. This is the first-paint guess for where a head begins;
+ * the stage measures the real thing once it has laid out, because the name tag
+ * under the face is set in pixels and the room is not 16:7 on a phone.
  */
-export const FIGURE_HEIGHT_FRACTION = 0.15 * 1.68 * (16 / 7);
+export const FIGURE_HEIGHT_FRACTION = 0.18 * 1.0 * (16 / 7);
 
 /** Where the top of a figure's head sits, as a fraction from the room's top. */
 export function headTopFor(slot: StageSlot): number {
@@ -35,26 +35,26 @@ export type ChannelKind = "public" | "private" | "thought" | "operator";
  * because that stage had a sidebar cropping the corners.
  */
 const PUBLIC_SLOTS: readonly StageSlot[] = [
-  { x: 0.29, y: 0.94, scale: 1.0 },
-  { x: 0.71, y: 0.94, scale: 1.0 },
+  { x: 0.29, y: 0.92, scale: 1.0 },
+  { x: 0.71, y: 0.92, scale: 1.0 },
   // The mid pair sits inside the front pair's gap so their name tags clear the
-  // front figures' torsos: a tag under .63 landed inside the figure at .71.
-  { x: 0.42, y: 0.7, scale: 0.78 },
-  { x: 0.58, y: 0.68, scale: 0.76 },
-  { x: 0.13, y: 0.52, scale: 0.6 },
-  { x: 0.87, y: 0.52, scale: 0.6 },
+  // front faces: a tag under .63 landed inside the face at .71.
+  { x: 0.43, y: 0.66, scale: 0.78 },
+  { x: 0.57, y: 0.64, scale: 0.76 },
+  { x: 0.13, y: 0.46, scale: 0.6 },
+  { x: 0.87, y: 0.46, scale: 0.6 },
 ];
 
 const PRIVATE_SLOTS: readonly StageSlot[] = [
-  { x: 0.35, y: 0.94, scale: 1.05 },
-  { x: 0.65, y: 0.94, scale: 1.05 },
-  { x: 0.5, y: 0.68, scale: 0.78 },
-  { x: 0.17, y: 0.52, scale: 0.6 },
-  { x: 0.83, y: 0.52, scale: 0.6 },
+  { x: 0.35, y: 0.92, scale: 1.05 },
+  { x: 0.65, y: 0.92, scale: 1.05 },
+  { x: 0.5, y: 0.64, scale: 0.78 },
+  { x: 0.17, y: 0.46, scale: 0.6 },
+  { x: 0.83, y: 0.46, scale: 0.6 },
 ];
 
 /** A thought has one occupant by definition, and it stands closer. */
-const THOUGHT_SLOTS: readonly StageSlot[] = [{ x: 0.5, y: 0.94, scale: 1.25 }];
+const THOUGHT_SLOTS: readonly StageSlot[] = [{ x: 0.5, y: 0.92, scale: 1.25 }];
 
 export function slotsFor(kind: ChannelKind): readonly StageSlot[] {
   if (kind === "thought") return THOUGHT_SLOTS;

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>perfectman — run</title>
+    <meta name="theme-color" content="#fdfdfc" />
+    <meta
+      name="description"
+      content="Characters who decide for themselves whether to speak. Watch a room where what is said and what is wanted come apart."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='52' r='42' fill='%23C4E2FB' stroke='%231c1b1b' stroke-opacity='.55' stroke-width='3'/%3E%3Cellipse cx='40' cy='50' rx='5.5' ry='6.5' fill='%231c1b1b'/%3E%3Cellipse cx='60' cy='50' rx='5.5' ry='6.5' fill='%231c1b1b'/%3E%3Cpath d='M42 68h16' stroke='%231c1b1b' stroke-width='3' stroke-linecap='round' fill='none'/%3E%3C/svg%3E"
+    />
+    <title>perfectman</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -14,7 +14,6 @@ import { useRunStream } from "./api/useRunStream.js";
 import { Shell, type StepId } from "./design/Shell.js";
 import { Intro } from "./onboarding/Intro.js";
 import { PickStep, type Selection } from "./pick/PickStep.js";
-import { CastRoom, SceneRooms } from "./pick/RoomPreview.js";
 import { usePresets } from "./pick/usePresets.js";
 import { RunScreen } from "./run/RunScreen.js";
 
@@ -118,7 +117,6 @@ export function App(): JSX.Element {
           onSelect={setCast}
           accept=".md,text/markdown"
           emptyHint="One markdown file per character: how they see themselves, how they talk, what they remember."
-          preview={<CastRoom files={cast.files} />}
         >
           <button type="button" className="btn" disabled={cast.files.length === 0} onClick={() => advance("scene")}>
             Choose a scene
@@ -136,7 +134,6 @@ export function App(): JSX.Element {
           onSelect={pickScene}
           accept=".md,text/markdown"
           emptyHint="One markdown file: the room, the channels, and a hidden objective per character."
-          preview={<SceneRooms summary={compiled?.ok ? compiled.summary : null} />}
         >
           <button
             type="button"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -14,6 +14,7 @@ import { useRunStream } from "./api/useRunStream.js";
 import { Shell, type StepId } from "./design/Shell.js";
 import { Intro } from "./onboarding/Intro.js";
 import { PickStep, type Selection } from "./pick/PickStep.js";
+import { CastRoom, SceneRooms } from "./pick/RoomPreview.js";
 import { usePresets } from "./pick/usePresets.js";
 import { RunScreen } from "./run/RunScreen.js";
 
@@ -117,6 +118,7 @@ export function App(): JSX.Element {
           onSelect={setCast}
           accept=".md,text/markdown"
           emptyHint="One markdown file per character: how they see themselves, how they talk, what they remember."
+          preview={<CastRoom files={cast.files} />}
         >
           <button type="button" className="btn" disabled={cast.files.length === 0} onClick={() => advance("scene")}>
             Choose a scene
@@ -134,6 +136,7 @@ export function App(): JSX.Element {
           onSelect={pickScene}
           accept=".md,text/markdown"
           emptyHint="One markdown file: the room, the channels, and a hidden objective per character."
+          preview={<SceneRooms summary={compiled?.ok ? compiled.summary : null} />}
         >
           <button
             type="button"

--- a/packages/web/src/onboarding/Intro.tsx
+++ b/packages/web/src/onboarding/Intro.tsx
@@ -4,22 +4,42 @@
  * The claim is that these agents decide when to speak, and that what they want
  * is not what they say. Asserting that in a paragraph is cheap; showing a room
  * where someone stays quiet on purpose costs six beats and is the only version
- * anyone believes. So the hero is the scene, and the prose beside it is short
- * enough to read while it plays.
+ * anyone believes. So the hero is the scene, played through the very page a
+ * run plays on — the same room, caption and strip of frames — and the prose
+ * beside it is short enough to read while it plays.
  */
-import { useEffect, useState } from "react";
-import { gestureEnergy } from "@perfectman/shared";
-import { Figure } from "../stage/Figure.js";
-import { INTRO_BEATS, INTRO_CAST } from "./intro-script.js";
+import { useEffect, useMemo, useState } from "react";
+import { idlePlacement, placeBeats } from "@perfectman/shared";
+import { Attribution } from "../stage/Attribution.js";
+import { ContactSheet } from "../stage/ContactSheet.js";
+import { frameFor, frameLabel } from "../stage/Frame.js";
+import { Panel } from "../stage/Panel.js";
+import { introRun } from "./intro-script.js";
 
 export function Intro({ onDone }: { onDone: () => void }): JSX.Element {
-  const [index, setIndex] = useState(0);
-  const beat = INTRO_BEATS[index] ?? INTRO_BEATS[0]!;
+  const run = useMemo(introRun, []);
+  const staged = useMemo(() => {
+    const ids = run.agents.map((a) => a.id);
+    const idle = idlePlacement(run.channels[0], run.agents);
+    const placements = placeBeats(run.beats, run.agents, run.channels, { seed: idle });
+    return {
+      ids,
+      placements,
+      frames: run.beats.map((b, i) => frameFor(b, placements[i]!, ids)),
+      labels: run.beats.map((b) => frameLabel(b, run.agents, run.channels[0])),
+    };
+  }, [run]);
 
+  const [index, setIndex] = useState(0);
+  const beat = run.beats[index] ?? run.beats[0]!;
+  const last = run.beats.length - 1;
+
+  // Loops. The strip under the room makes the loop legible: you can see where
+  // you are in the six beats, and click any of them.
   useEffect(() => {
-    const timer = setTimeout(() => setIndex((i) => (i + 1) % INTRO_BEATS.length), beat.hold);
+    const timer = setTimeout(() => setIndex((i) => (i + 1) % run.beats.length), beat.duration * 1000);
     return () => clearTimeout(timer);
-  }, [index, beat.hold]);
+  }, [index, beat.duration, run.beats.length]);
 
   return (
     <main className="intro">
@@ -31,8 +51,8 @@ export function Intro({ onDone }: { onDone: () => void }): JSX.Element {
         </h1>
         <p className="intro__lede u-serif">
           Nobody here takes turns. Each character reads the room, weighs what it
-          would cost to speak, and often decides against it. What you see below
-          is the whole product: a line, and the reason behind it.
+          would cost to speak, and often decides against it. The scene beside
+          this is the whole product: a line, and the reason behind it.
         </p>
         <div className="intro__actions">
           <button type="button" className="btn" onClick={onDone}>
@@ -44,36 +64,24 @@ export function Intro({ onDone }: { onDone: () => void }): JSX.Element {
         </div>
       </div>
 
-      <div className="intro__scene" aria-hidden="true">
-        <div className="intro__cast">
-          {INTRO_CAST.map((name, i) => (
-            <Figure
-              key={name}
-              index={i}
-              name={name}
-              face={beat.faces[i] ?? "neutral"}
-              energy={gestureEnergy(beat.emotions[i])}
-              speaking={beat.actor === i && Boolean(beat.line)}
-              attentive={beat.actor === i || !beat.thought}
-            />
-          ))}
-        </div>
-
-        <div className="intro__utterance">
-          {beat.line ? (
-            <p key={`line-${index}`} className="intro__line u-serif">
-              <span className="intro__who">{INTRO_CAST[beat.actor]}</span>
-              {beat.line}
-            </p>
-          ) : (
-            <p key={`thought-${index}`} className="intro__thought u-hand">
-              {beat.thought}
-              <span className="intro__thought-note">
-                {INTRO_CAST[beat.actor]} says nothing this turn
-              </span>
-            </p>
-          )}
-        </div>
+      <div className="intro__scene flipbook">
+        <Panel
+          beat={beat}
+          placement={staged.placements[index] ?? staged.placements[0]!}
+          index={index}
+          agents={run.agents}
+          channels={run.channels}
+          ids={staged.ids}
+        />
+        <Attribution beat={beat} agents={run.agents} channels={run.channels} ids={staged.ids} />
+        <ContactSheet
+          frames={staged.frames}
+          labels={staged.labels}
+          index={index}
+          reached={last}
+          live={false}
+          onSeek={setIndex}
+        />
       </div>
     </main>
   );

--- a/packages/web/src/onboarding/Intro.tsx
+++ b/packages/web/src/onboarding/Intro.tsx
@@ -5,14 +5,12 @@
  * is not what they say. Asserting that in a paragraph is cheap; showing a room
  * where someone stays quiet on purpose costs six beats and is the only version
  * anyone believes. So the hero is the scene, played through the very page a
- * run plays on — the same room, caption and strip of frames — and the prose
- * beside it is short enough to read while it plays.
+ * run plays on — the same room and caption — and the prose beside it is short
+ * enough to read while it plays.
  */
 import { useEffect, useMemo, useState } from "react";
 import { idlePlacement, placeBeats } from "@perfectman/shared";
 import { Attribution } from "../stage/Attribution.js";
-import { ContactSheet } from "../stage/ContactSheet.js";
-import { frameFor, frameLabel } from "../stage/Frame.js";
 import { Panel } from "../stage/Panel.js";
 import { introRun } from "./intro-script.js";
 
@@ -21,21 +19,13 @@ export function Intro({ onDone }: { onDone: () => void }): JSX.Element {
   const staged = useMemo(() => {
     const ids = run.agents.map((a) => a.id);
     const idle = idlePlacement(run.channels[0], run.agents);
-    const placements = placeBeats(run.beats, run.agents, run.channels, { seed: idle });
-    return {
-      ids,
-      placements,
-      frames: run.beats.map((b, i) => frameFor(b, placements[i]!, ids)),
-      labels: run.beats.map((b) => frameLabel(b, run.agents, run.channels[0])),
-    };
+    return { ids, placements: placeBeats(run.beats, run.agents, run.channels, { seed: idle }) };
   }, [run]);
 
   const [index, setIndex] = useState(0);
   const beat = run.beats[index] ?? run.beats[0]!;
-  const last = run.beats.length - 1;
 
-  // Loops. The strip under the room makes the loop legible: you can see where
-  // you are in the six beats, and click any of them.
+  // Loops, the way it always did.
   useEffect(() => {
     const timer = setTimeout(() => setIndex((i) => (i + 1) % run.beats.length), beat.duration * 1000);
     return () => clearTimeout(timer);
@@ -74,14 +64,6 @@ export function Intro({ onDone }: { onDone: () => void }): JSX.Element {
           ids={staged.ids}
         />
         <Attribution beat={beat} agents={run.agents} channels={run.channels} ids={staged.ids} />
-        <ContactSheet
-          frames={staged.frames}
-          labels={staged.labels}
-          index={index}
-          reached={last}
-          live={false}
-          onSeek={setIndex}
-        />
       </div>
     </main>
   );

--- a/packages/web/src/onboarding/__tests__/intro-beats.test.ts
+++ b/packages/web/src/onboarding/__tests__/intro-beats.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The intro is six hand-written beats played through the same stage a run
+ * uses, so it must produce the same shape a run produces.
+ */
+import { describe, expect, it } from "vitest";
+import { INTRO_BEATS, INTRO_CAST, introRun } from "../intro-script.js";
+
+describe("introRun", () => {
+  const run = introRun();
+
+  it("has one beat per scripted moment, in order", () => {
+    expect(run.beats).toHaveLength(INTRO_BEATS.length);
+    expect(run.beats.map((b) => b.actorId)).toEqual(INTRO_BEATS.map((b) => INTRO_CAST[b.actor]));
+  });
+
+  it("stages a line as speech and a private thought as silence", () => {
+    expect(run.beats[0]?.kind).toBe("message");
+    expect(run.beats[0]?.text).toBe(INTRO_BEATS[0]!.line);
+    const quiet = run.beats.find((b) => b.kind === "silence");
+    expect(quiet?.thought?.text).toBe(INTRO_BEATS.find((b) => b.thought)!.thought);
+    expect(quiet?.text).toBe("");
+  });
+
+  it("holds each beat for the scripted time, in seconds", () => {
+    expect(run.beats[2]?.duration).toBeCloseTo(INTRO_BEATS[2]!.hold / 1000);
+  });
+
+  it("puts the whole cast in one public room with the rest of the room reacting", () => {
+    expect(run.channels).toHaveLength(1);
+    expect(run.channels[0]?.memberAgentIds).toEqual(run.agents.map((a) => a.id));
+    const b = run.beats[1]!;
+    const others = run.agents.filter((a) => a.id !== b.actorId).map((a) => a.id);
+    expect(Object.keys(b.reactions ?? {}).sort()).toEqual(others.sort());
+  });
+});

--- a/packages/web/src/onboarding/intro-script.ts
+++ b/packages/web/src/onboarding/intro-script.ts
@@ -9,7 +9,7 @@
  * These are the same beat and emotion shapes a real run produces, so the intro
  * renders through the same components as the stage.
  */
-import type { FaceState, RecordedEmotion } from "@perfectman/shared";
+import type { FaceState, LiveChannel, RecordedEmotion, StageBeat } from "@perfectman/shared";
 
 export type IntroBeat = {
   /** Roster index of whoever holds the beat. */
@@ -72,3 +72,45 @@ export const INTRO_BEATS: IntroBeat[] = [
     hold: 3600,
   },
 ];
+
+export type IntroRun = {
+  agents: Array<{ id: string; displayName: string }>;
+  channels: LiveChannel[];
+  beats: StageBeat[];
+};
+
+/**
+ * The script as a run: the same beat shape a live pulse produces, so the intro
+ * plays through the real page, caption and contact sheet rather than a copy of
+ * them. A line is speech with the room reacting; a thought is a silence.
+ */
+export function introRun(): IntroRun {
+  const agents = INTRO_CAST.map((name) => ({ id: name, displayName: name }));
+  const ids = agents.map((a) => a.id);
+  const channel: LiveChannel = { id: "kitchen", name: "the kitchen", type: "public_channel", memberAgentIds: ids };
+  const beats = INTRO_BEATS.map((beat, i): StageBeat => {
+    const actorId = INTRO_CAST[beat.actor]!;
+    const reactions: Record<string, RecordedEmotion> = {};
+    ids.forEach((id, at) => {
+      const emotion = beat.emotions[at];
+      if (id !== actorId && emotion) reactions[id] = emotion;
+    });
+    const emotion = beat.emotions[beat.actor];
+    return {
+      id: `intro:${i}`,
+      kind: beat.line ? "message" : "silence",
+      pulseIndex: i,
+      channelId: channel.id,
+      actorId,
+      text: beat.line ?? "",
+      audienceIds: [],
+      participantIds: ids,
+      ...(emotion ? { emotion } : {}),
+      reactions,
+      ...(beat.thought ? { thought: { text: beat.thought, drivers: [] } } : {}),
+      duration: beat.hold / 1000,
+      page: 0,
+    };
+  });
+  return { agents, channels: [channel], beats };
+}

--- a/packages/web/src/onboarding/intro.css
+++ b/packages/web/src/onboarding/intro.css
@@ -1,14 +1,15 @@
 /*
- * The one orchestrated moment in the app. Everything else waits for a click.
+ * The one orchestrated moment in the app: the page turns in, the cast arrives,
+ * the first line lands. Everything else waits for a click.
  */
 
 .intro {
   max-width: var(--shell);
   margin: 0 auto;
-  padding: clamp(32px, 7vh, 88px) 32px 64px;
+  padding: clamp(28px, 6vh, 72px) clamp(20px, 4vw, 40px) 64px;
   display: grid;
-  gap: clamp(32px, 6vw, 72px);
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: clamp(28px, 5vw, 64px);
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
   align-items: center;
   min-height: 100vh;
 }
@@ -17,7 +18,11 @@
   .intro {
     grid-template-columns: minmax(0, 1fr);
     align-items: start;
-    padding-top: 40px;
+    padding-top: 28px;
+  }
+  /* The scene is the argument; on a narrow screen it goes first. */
+  .intro__scene {
+    order: -1;
   }
 }
 
@@ -43,77 +48,16 @@
 
 /* --- the scene ----------------------------------------------------------- */
 
-.intro__scene {
-  display: grid;
-  gap: 28px;
-  padding: 36px 28px 28px;
-  border-radius: var(--r-xl);
-  background: var(--paper-warm);
-  box-shadow: var(--ring), var(--lift);
+/* The scene is the same flipbook column the run uses, sized by its grid cell
+   rather than by the viewport's height. */
+.intro__scene.flipbook {
+  width: 100%;
+  padding-top: 0;
 }
 
-.intro__cast {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  align-items: end;
-  gap: 12px;
-  padding: 0 clamp(0px, 3vw, 28px);
-}
-
-.intro__cast .figure:nth-child(2) {
-  transform: translateY(-14px) scale(0.9);
-}
-
-.intro__utterance {
-  min-height: 132px;
-  display: grid;
-  align-content: start;
-}
-
-.intro__line,
-.intro__thought {
-  animation: utterance-in 420ms var(--ease) both;
-}
-
-@keyframes utterance-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-}
-
-.intro__line {
-  font-size: 21px;
-  line-height: 1.45;
-  background: var(--paper);
-  border-radius: var(--r-lg);
-  box-shadow: var(--ring);
-  padding: 16px 20px;
-}
-
-.intro__who {
-  display: block;
-  font-family: var(--sans);
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  color: var(--ink-50);
-  margin-bottom: 6px;
-}
-
-.intro__thought {
-  font-size: 23px;
-  line-height: 1.35;
-  color: var(--ink-70);
-  padding: 14px 22px;
-  /* Dashed, because a thought is not a message and should not look like one. */
-  border-left: 1px dashed var(--rule-strong);
-}
-
-.intro__thought-note {
-  display: block;
-  font-family: var(--sans);
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  color: var(--ink-30);
-  margin-top: 10px;
+/* The caption's provenance reading ("Authored: worried") is for a run, where
+   recorded and authored must never be confused. On the landing everything is
+   authored, and saying so reads as debugging. */
+.intro .attribution__reading {
+  display: none;
 }

--- a/packages/web/src/pick/PickStep.tsx
+++ b/packages/web/src/pick/PickStep.tsx
@@ -28,7 +28,6 @@ export function PickStep({
   onSelect,
   accept,
   emptyHint,
-  preview,
   children,
 }: {
   title: string;
@@ -39,8 +38,6 @@ export function PickStep({
   /** File-extension hint for the upload control. */
   accept: string;
   emptyHint: string;
-  /** The selection, shown as a room. Sits between the cards and the files. */
-  preview?: React.ReactNode;
   /** The step's footer — continue button and anything beside it. */
   children: React.ReactNode;
 }): JSX.Element {
@@ -130,8 +127,6 @@ export function PickStep({
           </div>
         </div>
       </div>
-
-      {preview}
 
       {editing ? (
         <MarkdownEditor

--- a/packages/web/src/pick/PickStep.tsx
+++ b/packages/web/src/pick/PickStep.tsx
@@ -28,6 +28,7 @@ export function PickStep({
   onSelect,
   accept,
   emptyHint,
+  preview,
   children,
 }: {
   title: string;
@@ -38,6 +39,8 @@ export function PickStep({
   /** File-extension hint for the upload control. */
   accept: string;
   emptyHint: string;
+  /** The selection, shown as a room. Sits between the cards and the files. */
+  preview?: React.ReactNode;
   /** The step's footer — continue button and anything beside it. */
   children: React.ReactNode;
 }): JSX.Element {
@@ -127,6 +130,8 @@ export function PickStep({
           </div>
         </div>
       </div>
+
+      {preview}
 
       {editing ? (
         <MarkdownEditor

--- a/packages/web/src/pick/PickStep.tsx
+++ b/packages/web/src/pick/PickStep.tsx
@@ -128,6 +128,8 @@ export function PickStep({
         </div>
       </div>
 
+      <CastRow files={selection.files} />
+
       {editing ? (
         <MarkdownEditor
           files={selection.files}
@@ -140,6 +142,32 @@ export function PickStep({
 
       <footer className="step__foot">{children}</footer>
     </section>
+  );
+}
+
+/**
+ * The cast as it is now. Read off the files themselves, so an uploaded, edited
+ * or dropped persona shows up here at once, while the editor is open — the
+ * cards above show what a preset offers, this shows what you have.
+ */
+function CastRow({ files }: { files: UploadedFile[] }): JSX.Element | null {
+  const cast = charactersIn(files);
+  if (cast.length === 0) return null;
+  const ids = cast.map((c) => c.id);
+  return (
+    <div className="card__cast cast-row" aria-hidden="true">
+      {cast.map((character) => (
+        <Figure
+          key={character.id}
+          index={chipIndexFor(character.id, ids)}
+          name={character.name}
+          face="neutral"
+          energy={0.3}
+          speaking={false}
+          attentive
+        />
+      ))}
+    </div>
   );
 }
 

--- a/packages/web/src/pick/__tests__/pick-step.test.tsx
+++ b/packages/web/src/pick/__tests__/pick-step.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * The faces under the cards are the cast as it is now — edited, uploaded or
+ * picked — not the preset that was clicked, and they stay up while the editor
+ * is open. Add a file and a face appears; drop one and it goes.
+ */
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PickStep } from "../PickStep.js";
+
+const persona = (id: string, name: string) => ({
+  filename: `${id}.persona.md`,
+  text: `---\npersonaId: ${id}\ndisplayName: ${name}\narchetype: x\n---\n`,
+});
+
+function step(files: ReturnType<typeof persona>[]) {
+  return (
+    <PickStep
+      title="Who is in the room?"
+      lede=""
+      presets={[]}
+      selection={{ presetId: null, files }}
+      onSelect={vi.fn()}
+      accept=".md"
+      emptyHint=""
+    >
+      <span />
+    </PickStep>
+  );
+}
+
+describe("PickStep", () => {
+  afterEach(cleanup);
+
+  it("shows a face for each character in the current files, and follows edits", () => {
+    const { container, rerender } = render(step([persona("iris", "Íris"), persona("bruno", "Bruno")]));
+    expect(container.querySelectorAll(".cast-row .figure")).toHaveLength(2);
+    rerender(step([persona("iris", "Íris"), persona("bruno", "Bruno"), persona("marcela", "Marcela")]));
+    expect(container.querySelectorAll(".cast-row .figure")).toHaveLength(3);
+    rerender(step([persona("marcela", "Marcela")]));
+    expect(container.querySelectorAll(".cast-row .figure")).toHaveLength(1);
+    expect(container.querySelector(".cast-row")?.textContent).toContain("Marcela");
+  });
+
+  it("keeps the faces up while the editor is open", () => {
+    const { container, getByText } = render(step([persona("iris", "Íris")]));
+    fireEvent.click(getByText("Edit as markdown"));
+    expect(container.querySelectorAll(".cast-row .figure")).toHaveLength(1);
+    expect(container.querySelector(".editor")).not.toBeNull();
+  });
+});

--- a/packages/web/src/pick/pick.css
+++ b/packages/web/src/pick/pick.css
@@ -94,6 +94,26 @@
 
 /* --- selection summary --------------------------------------------------- */
 
+/* --- the room, before anything happens ----------------------------------- */
+
+.rooms {
+  display: grid;
+  gap: 12px;
+}
+
+.rooms .flipbook {
+  padding-top: 0;
+}
+
+/* Several rooms side by side: each is smaller, and the name tags scale with
+   the room because they are sized in container units. */
+.rooms--many {
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+.rooms--many .flipbook {
+  width: 100%;
+}
+
 .summary-strip {
   display: grid;
   gap: 10px;

--- a/packages/web/src/pick/pick.css
+++ b/packages/web/src/pick/pick.css
@@ -94,26 +94,6 @@
 
 /* --- selection summary --------------------------------------------------- */
 
-/* --- the room, before anything happens ----------------------------------- */
-
-.rooms {
-  display: grid;
-  gap: 12px;
-}
-
-.rooms .flipbook {
-  padding-top: 0;
-}
-
-/* Several rooms side by side: each is smaller, and the name tags scale with
-   the room because they are sized in container units. */
-.rooms--many {
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-}
-.rooms--many .flipbook {
-  width: 100%;
-}
-
 .summary-strip {
   display: grid;
   gap: 10px;

--- a/packages/web/src/pick/pick.css
+++ b/packages/web/src/pick/pick.css
@@ -8,6 +8,7 @@
   display: grid;
   gap: 8px;
   align-content: start;
+  min-width: 0;
   text-align: left;
   padding: 18px;
   border: none;
@@ -40,19 +41,26 @@
 }
 
 /* The cast, at the size a decision needs: who is there, not what they said. */
+/* A row of faces that shrinks to fit rather than overflowing the card: five
+   people at full size are wider than a card, and a face still reads at 34px. */
 .card__cast {
   display: flex;
   align-items: flex-end;
-  gap: 2px;
+  gap: 4px;
   margin-bottom: 4px;
+  min-width: 0;
 }
 
 .card__cast .figure {
-  width: 54px;
-  flex: 0 0 auto;
+  flex: 0 1 52px;
+  min-width: 34px;
+  width: 52px;
 }
 .card__cast .figure__name {
-  font-size: 13px;
+  font-size: 12.5px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 /* No idle motion on a card; the stage is where things move. */
 .card__cast .figure__body,
@@ -102,6 +110,22 @@
   border-radius: var(--r-lg);
   background: var(--paper-warm);
   box-shadow: var(--ring);
+}
+
+/* The selection's faces, between the cards and the files. Larger than on a
+   card — these are the people you are about to put in a room. */
+.cast-row {
+  margin: 4px 0 -8px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.cast-row .figure {
+  flex-basis: 64px;
+  width: 64px;
+}
+.cast-row .figure__name {
+  font-size: 14px;
+  max-width: none;
 }
 
 .summary-strip ul {

--- a/packages/web/src/stage/Bubble.tsx
+++ b/packages/web/src/stage/Bubble.tsx
@@ -27,14 +27,12 @@ export function Bubble({
   said: string;
   thought?: string;
 }): JSX.Element {
-  const { ref, bottom, beside } = useBubbleAnchor(speaker, headTopGuess, contentKey);
-  // Balloons open away from the nearest wall, so an edge figure's does not run
-  // off the side of the room.
-  const side = x > 0.5 ? "left" : "right";
   // A balloon that could not fit above the head sits beside it instead, clear
-  // of the figure: half a mark's width plus a little, on the open side.
-  const clearance = beside ? 0.075 * scale + 0.015 : 0;
-  const left = side === "right" ? x + clearance : x - clearance;
+  // of the figure: half a mark's width plus a little. Balloons open away from
+  // the nearest wall, unless that would run them off the side of the room.
+  const clearance = 0.075 * scale + 0.015;
+  const { ref, bottom, beside, side } = useBubbleAnchor(speaker, headTopGuess, contentKey, x, clearance);
+  const left = !beside ? x : side === "right" ? x + clearance : x - clearance;
 
   return (
     <div

--- a/packages/web/src/stage/Bubble.tsx
+++ b/packages/web/src/stage/Bubble.tsx
@@ -21,7 +21,7 @@ export function Bubble({
   /** Fraction from the room's top, used until the mark has been laid out. */
   headTopGuess: number;
   x: number;
-  /** The speaker's slot scale; a mark is 15% of the room wide at scale 1. */
+  /** The speaker's slot scale; a mark is 18% of the room wide at scale 1. */
   scale: number;
   contentKey: string;
   said: string;
@@ -30,7 +30,7 @@ export function Bubble({
   // A balloon that could not fit above the head sits beside it instead, clear
   // of the figure: half a mark's width plus a little. Balloons open away from
   // the nearest wall, unless that would run them off the side of the room.
-  const clearance = 0.075 * scale + 0.015;
+  const clearance = 0.09 * scale + 0.015;
   const { ref, bottom, beside, side } = useBubbleAnchor(speaker, headTopGuess, contentKey, x, clearance);
   const left = !beside ? x : side === "right" ? x + clearance : x - clearance;
 

--- a/packages/web/src/stage/Figure.tsx
+++ b/packages/web/src/stage/Figure.tsx
@@ -31,7 +31,7 @@ export function Figure({ index, name, face, energy, speaking, attentive }: Figur
   const swing = (face === "worried" ? -26 : face === "angry" ? -10 : 6) * (0.65 + energy * 0.35);
 
   return (
-    <div className={`figure${speaking ? " figure--speaking" : ""}${attentive ? "" : " figure--aside"}`}>
+    <div className={`figure${speaking ? " figure--speaking" : ""}${attentive ? "" : " figure--aside"}`} data-face={face}>
       <svg viewBox="0 0 100 168" className="figure__body" aria-hidden="true">
         {/* Every part carries the same hairline the page uses, so a pale
             character still reads as a drawn figure on warm paper. */}

--- a/packages/web/src/stage/Figure.tsx
+++ b/packages/web/src/stage/Figure.tsx
@@ -1,13 +1,15 @@
 /**
- * One character.
+ * One character: a face.
  *
- * The drawing is the video renderer's figure, rebuilt as JSX so the face can be
- * React state rather than a GSAP tween into a pre-rendered node. Every pose is
- * a path swap and every path swap is a CSS transition, which is why this needs
- * no animation library.
+ * The body never carried information — the face does all of it, and at the
+ * sizes the stage and the cards draw, a body only made the face smaller. So a
+ * character is a head with a name under it. Every pose is a path swap and
+ * every path swap is a CSS transition, which is why this needs no animation
+ * library; the head also tilts with the feeling, the cheeks colour, and the
+ * mouth moves while a line is being said.
  *
- * The figure is drawn in its own 100x160 space and positioned by the stage, so
- * nothing here knows where it stands.
+ * Drawn in its own 100×100 space and positioned by the stage, so nothing here
+ * knows where it stands.
  */
 import { chipFor, headShapeFor, FACE_POSES, type FaceState } from "@perfectman/shared";
 
@@ -15,70 +17,55 @@ export type FigureProps = {
   index: number;
   name: string;
   face: FaceState;
-  /** 0–1. Drives how far the arms swing and how much the body leans. */
+  /** 0–1. How much of the feeling shows: brows, cheeks, the tilt of the head. */
   energy: number;
   speaking: boolean;
   /** Dimmed when someone is present but not part of this beat. */
   attentive: boolean;
 };
 
+/** What the pose table does not say: where the eyes look and whether the cheeks colour. */
+const EXPRESSION: Record<FaceState, { gaze: number; blush: number }> = {
+  neutral: { gaze: 0, blush: 0 },
+  smile: { gaze: 0, blush: 0.55 },
+  worried: { gaze: -2.2, blush: 0.3 },
+  angry: { gaze: 0, blush: 0.15 },
+  tired: { gaze: 0.8, blush: 0 },
+  shock: { gaze: 0, blush: 0.2 },
+};
+
 export function Figure({ index, name, face, energy, speaking, attentive }: FigureProps): JSX.Element {
   const chip = chipFor(index);
   const pose = FACE_POSES[face];
   const round = headShapeFor(index) === "round";
-  // Arms read the emotion: worried folds them up, angry plants them, otherwise
-  // they hang. Arousal scales the swing so a calm agent still moves a little.
-  const swing = (face === "worried" ? -26 : face === "angry" ? -10 : 6) * (0.65 + energy * 0.35);
+  const look = EXPRESSION[face] ?? EXPRESSION.neutral;
+  const gaze = look.gaze * (0.6 + energy * 0.4);
 
   return (
-    <div className={`figure${speaking ? " figure--speaking" : ""}${attentive ? "" : " figure--aside"}`} data-face={face}>
-      <svg viewBox="0 0 100 168" className="figure__body" aria-hidden="true">
-        {/* Every part carries the same hairline the page uses, so a pale
-            character still reads as a drawn figure on warm paper. */}
-        <g className="figure__torso" fill={chip} stroke={chip}>
-          <path d="M39 126L34 150" strokeWidth="11" strokeLinecap="round" />
-          <path d="M61 126L66 150" strokeWidth="11" strokeLinecap="round" />
-          <rect className="figure__ink" x="28" y="87" width="44" height="46" rx="18" />
-        </g>
-
-        <g
-          className="figure__arm"
-          fill={chip}
-          stroke={chip}
-          strokeWidth="9"
-          strokeLinecap="round"
-          style={{ transform: `rotate(${swing}deg)`, transformOrigin: "31px 101px" }}
-        >
-          <path d="M31 101Q15 103 13 121" fill="none" />
-          <circle className="figure__ink" cx="13" cy="124" r="6" />
-        </g>
-        <g
-          className="figure__arm"
-          fill={chip}
-          stroke={chip}
-          strokeWidth="9"
-          strokeLinecap="round"
-          style={{ transform: `rotate(${-swing}deg)`, transformOrigin: "69px 101px" }}
-        >
-          <path d="M69 101Q85 103 87 121" fill="none" />
-          <circle className="figure__ink" cx="87" cy="124" r="6" />
-        </g>
-
+    <div
+      className={`figure figure--${face}${speaking ? " figure--speaking" : ""}${attentive ? "" : " figure--aside"}`}
+      data-face={face}
+    >
+      <svg viewBox="0 0 100 100" className="figure__body" aria-hidden="true">
         <g className="figure__head">
+          {/* The same hairline the page uses, so a pale character still reads
+              as a drawn face on warm paper. */}
           <g className="figure__ink" fill={chip}>
             {round ? (
-              <circle cx="50" cy="48" r="43" />
+              <circle cx="50" cy="50" r="44" />
             ) : (
-              <path d="M50 6a42 42 0 1 0 30 72l16-2-11-14A42 42 0 0 0 50 6Z" />
+              <path d="M50 6a44 44 0 1 0 31 75l17-2-12-15A44 44 0 0 0 50 6Z" />
             )}
           </g>
+          <ellipse className="figure__blush" cx="29" cy="62" rx="8" ry="4.5" style={{ opacity: look.blush }} />
+          <ellipse className="figure__blush" cx="71" cy="62" rx="8" ry="4.5" style={{ opacity: look.blush }} />
           <g className="figure__look">
-            <ellipse className="figure__eye" cx="40" cy="47" rx="5.5" ry={pose.eyeRy} />
-            <ellipse className="figure__eye" cx="60" cy="47" rx="5.5" ry={pose.eyeRy} />
+            <ellipse className="figure__eye" cx={39 + gaze} cy="49" rx="5.5" ry={pose.eyeRy} />
+            <ellipse className="figure__eye" cx={61 + gaze} cy="49" rx="5.5" ry={pose.eyeRy} />
             <path className="figure__brow" d={pose.browLeft} opacity={pose.browOpacity} />
             <path className="figure__brow" d={pose.browRight} opacity={pose.browOpacity} />
             <path className="figure__mouth" d={pose.mouth} opacity={face === "shock" ? 0 : 1} />
-            <ellipse className="figure__gasp" cx="50" cy="65" rx="5" ry="7" opacity={face === "shock" ? 1 : 0} />
+            <ellipse className="figure__gasp" cx="50" cy="68" rx="5.5" ry="7.5" opacity={face === "shock" ? 1 : 0} />
           </g>
         </g>
       </svg>

--- a/packages/web/src/stage/Frame.tsx
+++ b/packages/web/src/stage/Frame.tsx
@@ -39,7 +39,7 @@ export type FrameModel = {
 
 export function frameFor(beat: StageBeat, placement: Placement, ids: readonly string[]): FrameModel {
   const dots = placement.marks.map(({ agentId, point }) => {
-    const r = 2.6 * point.scale;
+    const r = 3 * point.scale;
     return {
       x: point.x * FRAME_W,
       // The dot stands for the whole figure, so it sits at the figure's middle.

--- a/packages/web/src/stage/Panel.tsx
+++ b/packages/web/src/stage/Panel.tsx
@@ -11,7 +11,7 @@
  * document, so the breathing figures and the sheet's scroll would freeze for
  * the turn, and it cannot be tested in jsdom. Two keyed pages and a timer can.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { LiveChannel, Placement, StageBeat } from "@perfectman/shared";
 import { reducedMotion } from "./motion.js";
 import { Stage, type StageAgent } from "./Stage.js";
@@ -45,20 +45,24 @@ export function Panel({
   ids: readonly string[];
 }): JSX.Element {
   const current: Page = { roomKey: placement.roomKey, index, beat, placement };
-  // What was on the page last render. A ref, not state: it is a memo of the
-  // previous picture, and writing it must not cause a render of its own.
-  const last = useRef<Page>(current);
-  const direction = useRef<Direction>("forward");
+  // What was on the page last render, held in state rather than a ref: React
+  // renders a component twice in development, and a ref written during the
+  // first pass would make the second pass see no change and drop the turn.
+  // Setting state during render is how React wants a derived reset done — it
+  // re-renders this component at once, before any child is committed.
+  const [last, setLast] = useState<Page>(current);
+  const [direction, setDirection] = useState<Direction>("forward");
   const [leaving, setLeaving] = useState<(Page & { dir: Direction }) | null>(null);
 
-  if (last.current.roomKey !== current.roomKey) {
-    const dir: Direction = index >= last.current.index ? "forward" : "back";
-    direction.current = dir;
-    // Setting state during render is how React wants a derived reset done: it
-    // re-renders this component at once, before any child is committed.
-    if (!reducedMotion()) setLeaving({ ...last.current, dir });
+  if (last.roomKey !== current.roomKey) {
+    const dir: Direction = index >= last.index ? "forward" : "back";
+    setDirection(dir);
+    setLast(current);
+    if (!reducedMotion()) setLeaving({ ...last, dir });
+  } else if (last.beat !== beat || last.placement !== placement || last.index !== index) {
+    // Same room, newer picture: remember it, so a later turn snapshots this.
+    setLast(current);
   }
-  last.current = current;
 
   // A timer rather than `animationend`: the room's own children animate too and
   // their end events bubble, and a page can be replaced before its turn ends.
@@ -75,7 +79,7 @@ export function Panel({
           <Stage beat={leaving.beat} placement={leaving.placement} agents={agents} channels={channels} ids={ids} />
         </div>
       ) : null}
-      <div key={current.roomKey} className={`pages__page pages__page--enter-${direction.current}`}>
+      <div key={current.roomKey} className={`pages__page pages__page--enter-${direction}`}>
         <Stage beat={beat} placement={placement} agents={agents} channels={channels} ids={ids} />
       </div>
     </div>

--- a/packages/web/src/stage/Stage.tsx
+++ b/packages/web/src/stage/Stage.tsx
@@ -55,19 +55,25 @@ export const Stage = memo(function Stage({ beat, placement, agents, channels, id
   return (
     <div className={`stage stage--${kind}`}>
       <div className="stage__room">
-        <p className="stage__where">
-          <span aria-hidden="true">{kind === "private" ? "↔" : "#"}</span>
+        <p
+          className="stage__where"
+          title={`${roomLabel(channel, agents)}${shutOut.length > 0 ? ` — ${listNames(shutOut.map((a) => a.displayName))} cannot see this` : ""}`}
+        >
+          <span className="stage__glyph" aria-hidden="true">
+            {kind === "private" ? "↔" : "#"}
+          </span>
           {roomLabel(channel, agents)}
           {shutOut.length > 0 ? (
-            <span className="stage__shut-out">
-              {shutOut.map((a) => a.displayName).join(" and ")} cannot see this
-            </span>
+            <span className="stage__shut-out">{listNames(shutOut.map((a) => a.displayName))} cannot see this</span>
           ) : null}
         </p>
         {marks.map(({ agentId, point }) => {
           const agent = agents.find((a) => a.id === agentId);
           if (!agent) return null;
           const isActor = beat?.actorId === agent.id;
+          // The speaker wears the recorded emotion; everyone else wears what
+          // was recorded about them at that moment, if anything.
+          const feeling = isActor ? beat?.emotion : beat?.reactions?.[agent.id];
           return (
             <div
               key={agent.id}
@@ -83,8 +89,8 @@ export const Stage = memo(function Stage({ beat, placement, agents, channels, id
               <Figure
                 index={chipIndexFor(agent.id, ids)}
                 name={agent.displayName}
-                face={isActor ? faceFor(beat?.emotion) : "neutral"}
-                energy={isActor ? gestureEnergy(beat?.emotion) : 0.3}
+                face={faceFor(feeling)}
+                energy={feeling ? gestureEnergy(feeling) : 0.3}
                 speaking={Boolean(isActor && beat?.kind === "message")}
                 attentive={!beat || (beat.kind !== "silence" && beat.kind !== "aside") || isActor}
               />
@@ -113,3 +119,9 @@ export const Stage = memo(function Stage({ beat, placement, agents, channels, id
     </div>
   );
 });
+
+/** "a", "a and b", "a, b and c" — the way a sentence would say it. */
+function listNames(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}

--- a/packages/web/src/stage/__tests__/bubble-anchor.test.ts
+++ b/packages/web/src/stage/__tests__/bubble-anchor.test.ts
@@ -2,9 +2,9 @@
  * The balloon hangs off a head, and must not leave the frame doing it.
  *
  * The numbers here are the real ones: a room around 300px tall, and the slot
- * geometry from `slots.ts` — a figure occupies 57.6% of the room's height, so
- * a back-row figure at y 0.52 and scale 0.6 has its head about 52px below the
- * room's top edge. A full page of text is twice that.
+ * geometry from `slots.ts` — a face occupies 41% of the room's height, so a
+ * back-row face at y 0.46 and scale 0.6 has its top about 64px below the
+ * room's top edge. A full page of text is more than that.
  */
 import { describe, expect, it } from "vitest";
 import { FIGURE_HEIGHT_FRACTION, headTopFor, slotsFor } from "@perfectman/shared";
@@ -51,7 +51,7 @@ describe("bubbleBottom", () => {
   it("guesses the first paint from the 16:7 drawing before anything is measured", () => {
     // The real head is measured once laid out; this is only what the balloon
     // uses on its first frame, so it should be the drawing's own geometry.
-    expect(FIGURE_HEIGHT_FRACTION).toBeCloseTo(0.15 * 1.68 * (16 / 7), 10);
+    expect(FIGURE_HEIGHT_FRACTION).toBeCloseTo(0.18 * 1.0 * (16 / 7), 10);
   });
 });
 

--- a/packages/web/src/stage/__tests__/bubble-anchor.test.ts
+++ b/packages/web/src/stage/__tests__/bubble-anchor.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { FIGURE_HEIGHT_FRACTION, headTopFor, slotsFor } from "@perfectman/shared";
-import { BUBBLE_MARGIN, bubbleBottom, bubbleClamped } from "../useBubbleAnchor.js";
+import { BUBBLE_MARGIN, besideSide, besideWidth, bubbleBottom, bubbleClamped } from "../useBubbleAnchor.js";
 
 const ROOM = 300;
 
@@ -65,5 +65,24 @@ describe("bubbleClamped", () => {
     // and the caller should move it beside the head instead.
     const headTop = headTopFor(slotsFor("public")[4]!);
     expect(bubbleClamped(headTop, ROOM, 150)).toBe(true);
+  });
+});
+
+describe("beside the head", () => {
+  it("opens away from the nearest wall", () => {
+    expect(besideSide(0.3)).toBe("right");
+    expect(besideSide(0.7)).toBe("left");
+    expect(besideSide(0.5)).toBe("right");
+  });
+
+  it("gets exactly the room left on that side, so it wraps rather than leaves the frame", () => {
+    // A centre figure at scale 1.25 in a 607px room: the balloon starts at
+    // (0.5 + 0.109) of the width and may use what remains, minus a margin.
+    expect(besideWidth(0.5, 0.109, 607, "right")).toBeCloseTo((1 - 0.609) * 607 - BUBBLE_MARGIN, 3);
+    expect(besideWidth(0.7, 0.09, 600, "left")).toBeCloseTo((0.7 - 0.09) * 600 - BUBBLE_MARGIN, 3);
+  });
+
+  it("never goes below a readable minimum", () => {
+    expect(besideWidth(0.95, 0.09, 300, "right")).toBe(124);
   });
 });

--- a/packages/web/src/stage/__tests__/figure.test.tsx
+++ b/packages/web/src/stage/__tests__/figure.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * A character is a face. The body never carried information — the face does
+ * all of it — and at the sizes the stage and the cards draw, a body only made
+ * the face smaller.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Figure } from "../Figure.js";
+
+function draw(face: Parameters<typeof Figure>[0]["face"], speaking = false) {
+  return render(<Figure index={0} name="íris" face={face} energy={0.5} speaking={speaking} attentive />);
+}
+
+describe("Figure", () => {
+  it("draws a face and a name, and no body", () => {
+    const { container } = draw("neutral");
+    expect(container.querySelector(".figure__head")).not.toBeNull();
+    expect(container.querySelector(".figure__torso")).toBeNull();
+    expect(container.querySelector(".figure__arm")).toBeNull();
+    expect(container.textContent).toBe("íris");
+  });
+
+  it("names the expression so the face can be styled by it", () => {
+    const { container } = draw("worried");
+    expect(container.querySelector(".figure--worried")).not.toBeNull();
+    expect(container.querySelector(".figure")?.getAttribute("data-face")).toBe("worried");
+  });
+
+  it("opens the mouth while speaking", () => {
+    const { container } = draw("neutral", true);
+    expect(container.querySelector(".figure--speaking .figure__mouth")).not.toBeNull();
+  });
+});

--- a/packages/web/src/stage/__tests__/panel.test.tsx
+++ b/packages/web/src/stage/__tests__/panel.test.tsx
@@ -4,6 +4,7 @@
  * comes in behind it. Same room, new line: no turn, the room just updates.
  */
 import { act, render } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { placeBeats, type LiveChannel, type StageBeat } from "@perfectman/shared";
 import { Panel, TURN_MS } from "../Panel.js";
@@ -86,6 +87,16 @@ describe("Panel", () => {
     rerender(panelAt(0));
     rerender(panelAt(3));
     expect(container.querySelectorAll(".pages__page")).toHaveLength(2);
+  });
+
+  it("still turns when React renders twice, as it does in development", () => {
+    const { container, rerender } = render(<StrictMode>{panelAt(1)}</StrictMode>);
+    rerender(<StrictMode>{panelAt(2)}</StrictMode>);
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(2);
+    act(() => {
+      vi.advanceTimersByTime(TURN_MS + 1);
+    });
+    expect(container.querySelectorAll(".pages__page")).toHaveLength(1);
   });
 
   it("swaps instantly when the reader asked for less motion", () => {

--- a/packages/web/src/stage/__tests__/stage.test.tsx
+++ b/packages/web/src/stage/__tests__/stage.test.tsx
@@ -64,10 +64,38 @@ describe("Stage", () => {
     expect(container.querySelector(".stage__shut-out")?.textContent).toContain("bruno");
   });
 
+  it("lists three shut-out people the way a sentence would", () => {
+    const five = [...AGENTS, { id: "d", displayName: "Dora" }, { id: "e", displayName: "Eli" }];
+    const channels: LiveChannel[] = [
+      ...CHANNELS,
+      { id: "dm", name: "dm", type: "private_channel", memberAgentIds: ["iris", "marcela"] },
+    ];
+    const b = beat({ channelId: "dm", participantIds: ["iris", "marcela"] });
+    const [placement] = placeBeats([b], five, channels);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={five} channels={channels} ids={five.map((a) => a.id)} />);
+    expect(container.querySelector(".stage__shut-out")?.textContent).toBe("bruno, Dora and Eli cannot see this");
+  });
+
   it("seats the idle room with nobody lit and no balloon", () => {
     const placement = idlePlacement(CHANNELS[0], AGENTS);
     const { container } = render(<Stage beat={undefined} placement={placement} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
     expect(container.querySelectorAll(".stage__mark")).toHaveLength(3);
     expect(container.querySelectorAll(".bubbles")).toHaveLength(0);
+  });
+});
+
+describe("Stage reactions", () => {
+  it("lets a non-speaker wear the face they recorded", () => {
+    const b = beat({
+      emotion: { source: "authored", label: "neutral" },
+      reactions: { marcela: { source: "authored", label: "worried" } },
+    });
+    const [placement] = placeBeats([b], AGENTS, CHANNELS);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    const faces = Object.fromEntries(
+      [...container.querySelectorAll(".figure")].map((f) => [f.querySelector(".figure__name")?.textContent, f.getAttribute("data-face")]),
+    );
+    expect(faces["marcela"]).toBe("worried");
+    expect(faces["bruno"]).toBe("neutral");
   });
 });

--- a/packages/web/src/stage/figure.css
+++ b/packages/web/src/stage/figure.css
@@ -1,14 +1,14 @@
 /*
- * A figure is drawn once and never re-mounted; everything that changes is a
- * transition on an attribute the pose table supplies. Blink and breath are the
- * only motion nobody asked for, and they exist because a motionless figure
- * looks broken rather than composed.
+ * A face is drawn once and never re-mounted; everything that changes is a
+ * transition on an attribute the pose table supplies, or a transform on the
+ * head. Blink and breath are the only motion nobody asked for, and they exist
+ * because a motionless face looks broken rather than composed.
  */
 
 .figure {
   display: grid;
   justify-items: center;
-  gap: 2px;
+  gap: 4px;
   transition: opacity var(--settle) var(--ease), filter var(--settle) var(--ease);
 }
 
@@ -47,13 +47,40 @@
   }
 }
 
-.figure__arm {
+/* --- the feeling, in the head itself ------------------------------------- */
+
+/* The head tilts with the feeling. Worry leans away, anger squares up and
+   comes forward, a smile lifts, shock recoils. The pose table moves the
+   features; this moves the whole face, which is what a person reads first. */
+.figure__head {
+  transform-box: fill-box;
+  transform-origin: 50% 62%;
   transition: transform var(--settle) var(--ease);
+}
+.figure--worried .figure__head {
+  transform: rotate(-7deg) translateY(1px);
+}
+.figure--angry .figure__head {
+  transform: rotate(4deg) scale(1.04);
+}
+.figure--smile .figure__head {
+  transform: rotate(3deg) translateY(-1px);
+}
+.figure--shock .figure__head {
+  transform: scale(1.06) translateY(-2px);
+}
+.figure--tired .figure__head {
+  transform: rotate(-3deg) translateY(3px);
+}
+
+.figure__blush {
+  fill: rgba(228, 104, 118, 0.32);
+  transition: opacity var(--settle) var(--ease);
 }
 
 .figure__eye {
   fill: var(--ink);
-  transition: ry var(--quick) var(--ease);
+  transition: ry var(--quick) var(--ease), cx var(--settle) var(--ease);
   animation: figure-blink 5.9s steps(1, end) infinite;
   transform-box: fill-box;
   transform-origin: center;
@@ -82,9 +109,28 @@
 .figure__mouth {
   fill: none;
   stroke: var(--ink);
-  stroke-width: 2.6;
+  stroke-width: 3.2;
   stroke-linecap: round;
   transition: d var(--quick) var(--ease), opacity var(--quick) var(--ease);
+}
+
+/* Talking: the mouth opens and closes while the line is up. Steps, not a
+   ramp — a mouth does not ease. */
+.figure__mouth {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.figure--speaking .figure__mouth {
+  animation: figure-talk 340ms steps(2, end) infinite;
+}
+@keyframes figure-talk {
+  0%,
+  100% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(2.2) translateY(1px);
+  }
 }
 
 .figure__gasp {
@@ -93,7 +139,7 @@
 }
 
 /* Sized against the room, not the viewport: a 19px tag on a 300px-wide room
-   is a third of a figure's width and hides behind whoever stands in front. */
+   is a third of a face's width and hides behind whoever stands in front. */
 .figure__name {
   font-size: clamp(11px, 2.4cqw, 19px);
   color: var(--ink-70);

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -199,7 +199,7 @@
 
 .stage__mark {
   position: absolute;
-  width: 15%;
+  width: 18%;
   transform-origin: 50% 100%;
   transition: left var(--settle) var(--ease), top var(--settle) var(--ease),
     transform var(--settle) var(--ease);

--- a/packages/web/src/stage/stage.css
+++ b/packages/web/src/stage/stage.css
@@ -120,22 +120,27 @@
   position: absolute;
   top: 10px;
   left: 12px;
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
+  max-width: calc(100% - 24px);
   padding: 3px 8px;
   border-radius: var(--r-pill);
   background: var(--paper-warm);
   font-size: 12.5px;
   color: var(--ink-50);
   z-index: 500;
-  max-width: none;
+  /* One line. A small room shows the start and the title has the rest. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stage__glyph {
+  margin-right: 7px;
 }
 .stage--thought .stage__where {
   background: var(--paper);
 }
 
-.stage__where > span:first-child {
+.stage__glyph {
   color: var(--ink-30);
 }
 
@@ -144,6 +149,7 @@
 .stage__shut-out {
   color: var(--ink-30);
   font-style: italic;
+  margin-left: 8px;
 }
 .stage__shut-out::before {
   content: "— ";

--- a/packages/web/src/stage/useBubbleAnchor.ts
+++ b/packages/web/src/stage/useBubbleAnchor.ts
@@ -17,8 +17,12 @@
  */
 import { useLayoutEffect, useRef, useState, type RefObject } from "react";
 
-/** Breathing room between a balloon and the top of the frame. */
-export const BUBBLE_MARGIN = 8;
+/**
+ * Room between a balloon and the top of the frame: the row the room's name
+ * sits on, so a balloon that reaches the ceiling stops under the label rather
+ * than behind it.
+ */
+export const BUBBLE_MARGIN = 36;
 
 /**
  * Distance from the room's floor to put the balloon's bottom edge.

--- a/packages/web/src/stage/useBubbleAnchor.ts
+++ b/packages/web/src/stage/useBubbleAnchor.ts
@@ -52,6 +52,29 @@ export function bubbleClamped(
   return wanted > roomHeight - bubbleHeight - margin;
 }
 
+/** A balloon beside a head opens away from the nearest wall. */
+export function besideSide(x: number): "left" | "right" {
+  return x > 0.5 ? "left" : "right";
+}
+
+/** The narrowest a beside-the-head balloon is allowed to get. Matches `.bubble`'s min-width. */
+export const BUBBLE_MIN_WIDTH = 124;
+
+/**
+ * How wide a balloon beside the head may be: the room left on its side, less
+ * a margin, so it wraps into more lines rather than leaving the frame.
+ */
+export function besideWidth(
+  x: number,
+  clearance: number,
+  roomWidth: number,
+  side: "left" | "right",
+  margin = BUBBLE_MARGIN,
+): number {
+  const room = side === "right" ? (1 - x - clearance) * roomWidth : (x - clearance) * roomWidth;
+  return Math.max(BUBBLE_MIN_WIDTH, room - margin);
+}
+
 /**
  * Where the drawn head begins, as a fraction of the room's height, from the
  * figure's and the room's on-screen boxes. Both boxes move together under a
@@ -69,10 +92,14 @@ export function useBubbleAnchor(
   headTopGuess: number,
   /** Changes whenever the content does, so the measurement is redone. */
   key: string,
-): { ref: RefObject<HTMLDivElement>; bottom: string; beside: boolean } {
+  /** The speaker's x and the clearance a beside-the-head balloon needs. */
+  x: number,
+  clearance: number,
+): { ref: RefObject<HTMLDivElement>; bottom: string; beside: boolean; side: "left" | "right" } {
   const ref = useRef<HTMLDivElement>(null);
   const [bottom, setBottom] = useState(`${(1 - headTopGuess) * 100 + 2}%`);
   const [beside, setBeside] = useState(false);
+  const side = besideSide(x);
 
   useLayoutEffect(() => {
     const node = ref.current;
@@ -85,8 +112,17 @@ export function useBubbleAnchor(
       const figure = speaker.current?.querySelector<SVGElement>(".figure__body");
       const headTop =
         (figure && measuredHeadTop(figure.getBoundingClientRect(), room.getBoundingClientRect())) ?? headTopGuess;
+      // Measured at its natural width first. If it has to go beside the head
+      // it is capped to the room on that side and measured again, because the
+      // cap changes how many lines it wraps to, and so how tall it is.
+      node.style.maxWidth = "";
+      let clamped = bubbleClamped(headTop, roomHeight, node.offsetHeight);
+      if (clamped) {
+        node.style.maxWidth = `${besideWidth(x, clearance, room.clientWidth, side)}px`;
+        clamped = bubbleClamped(headTop, roomHeight, node.offsetHeight) || true;
+      }
+      setBeside(clamped);
       setBottom(`${bubbleBottom(headTop, roomHeight, node.offsetHeight)}px`);
-      setBeside(bubbleClamped(headTop, roomHeight, node.offsetHeight));
     };
     place();
 
@@ -95,7 +131,7 @@ export function useBubbleAnchor(
     const watcher = new ResizeObserver(place);
     watcher.observe(room);
     return () => watcher.disconnect();
-  }, [speaker, headTopGuess, key]);
+  }, [speaker, headTopGuess, key, x, clearance, side]);
 
-  return { ref, bottom, beside };
+  return { ref, bottom, beside, side };
 }


### PR DESCRIPTION
## What

Sharpens the elements the flow already has, without adding any:

- `Intro` plays its six beats through the run's own `Panel` and `Attribution` via `introRun()` (`intro-script.ts`), so the landing is the product and a thought turns the page into a room of one. The old flat intro layout is gone; the provenance reading is hidden there by CSS.
- `Figure` is a face and a name, no body: 100×100 drawing on a mark 18% of the room, `figure--<face>` class and `data-face`, head tilt per feeling, cheek colour, gaze aside when worried, mouth animation while speaking (`figure-talk`, steps not ramps).
- `StageBeat.reactions` carries the rest of the room's recorded emotion; `pulseToBeats` fills it from `frame.emotions` for participants, `Stage` reads it for non-speakers.
- `PUBLIC_SLOTS` rows move to `.92 / .66 / .46`, mid pair to `.43 / .57`; `FIGURE_HEIGHT_FRACTION` becomes `0.18 · 16/7`. `slot-geometry.test.ts` keeps every tag out of every closer face.
- `Panel` keeps the previous page in state, not a ref: React's development double render made the second pass see no room change and dropped the turn. A `StrictMode` test pins it.
- `useBubbleAnchor`: `besideWidth` caps a beside-the-head balloon to the room on its side so it wraps instead of leaving the frame; `BUBBLE_MARGIN` is now the room-label row (36 px). `.stage__where` stays on one line with the full text in `title`; three shut-out names read "a, b and c".
- `index.html`: description, theme colour, inline SVG icon (the console's favicon 404 is gone).
- `PickStep`: a `CastRow` of faces read off the current files sits between the cards and the file list and stays up while the editor is open, so an uploaded or dropped persona shows at once; card faces shrink to fit (`flex: 0 1 52px`, `min-width: 34px`) instead of pushing the card's text past its edge.
- 17 tests: cast row follows edits / stays up while editing, reactions filled / room-only, intro run shape / silence / hold / reactions, Figure face-only / face class / talking, Stage reaction face / three-name list, Panel under StrictMode, beside side / width / minimum.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (2004 passed, +17: web 64 → 79, shared 215 → 217)
- Mock run, `the-group` × `A última proteína`, 36 beats at 1456×832 and 390×844 with the faces: balloon on a face 0, balloons beside the head 10 → 3, hidden name tags 0 desktop / 2 px phone, seating identical on revisit, calm bed playing at 0.153 with 0 rejections, no horizontal scroll on phone, 0 console errors
- Cast step in the browser: 5 faces after picking `O grupo`, 4 after dropping a file in the editor; card `scrollWidth − clientWidth` is 0 for every card at 1456 px and 390 px
- Landing in dev: two pages during the thought turn (was one before the StrictMode fix), the cloud wraps inside the room at both widths