### PR TITLE
fix(simulation): private rooms reach the stage and characters keep their language

### DIFF
--- a/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
+++ b/packages/server/src/agent/__tests__/action-intent-prompt-builder.test.ts
@@ -148,3 +148,30 @@ describe("ActionIntentPromptBuilder — scenario context gating", () => {
     expect(built.system).toContain("Anuncie a proposta da Adamantis");
   });
 });
+
+describe("ActionIntentPromptBuilder — the language is the last thing the model reads", () => {
+  // The pin used to be one sentence in the middle of the system prompt, under
+  // an English user prompt that named privateMotiveSummary twice. Motives
+  // came out in English. The pin now closes the decision block.
+  it("ends the user prompt with the pt-BR pin for both fields", () => {
+    const built = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "pt-BR" }, "action_intent");
+    const tail = built.user.trim().slice(-260);
+    expect(tail).toContain("visibleContent");
+    expect(tail).toContain("privateMotiveSummary");
+    expect(tail).toMatch(/português|Portuguese/);
+  });
+
+  it("pins English the same way for an English profile", () => {
+    const built = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "en" }, "action_intent");
+    expect(built.user.trim().slice(-200)).toMatch(/in English/);
+  });
+
+  it("writes the secret objective and scene labels in the profile's language", () => {
+    const objective = { description: "be picked as leader before Mari is", scarceResourceId: "lead" };
+    const en = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "en", hiddenObjective: objective }, "action_intent");
+    expect(en.system).not.toContain("Você tem um objetivo");
+    expect(en.system).toContain("be picked as leader before Mari is");
+    const pt = PromptBuilder.build(input, { ...EXAMPLE_PROMPT_PROFILE, language: "pt-BR", hiddenObjective: objective }, "action_intent");
+    expect(pt.system).toContain("Você tem um objetivo");
+  });
+});

--- a/packages/server/src/agent/action-intent-prompt-builder.ts
+++ b/packages/server/src/agent/action-intent-prompt-builder.ts
@@ -280,7 +280,7 @@ export class ActionIntentPromptBuilder {
       .container("pressures", (s) => this.renderPressures(s, translatedEmotionalState, input.activeMotivations))
       .container("memories", (s) => this.renderMemories(s, perceptionPacket.relevantMemories))
       .container("actions", (s) => this.renderActions(s, input))
-      .container("decision", (s) => this.renderDecision(s, input));
+      .container("decision", (s) => this.renderDecision(s, input, profile.language));
     const userPrompt = user.toString();
 
     return { systemPrompt, userPrompt };
@@ -331,8 +331,8 @@ export class ActionIntentPromptBuilder {
     this.addList(s, "Hard avoids", profile.hardAvoids);
     this.renderRelationshipBiases(s, profile);
 
-    if (profile.scenarioContext) this.renderScenarioContext(s, profile.scenarioContext, hasActed);
-    if (profile.hiddenObjective) this.renderHiddenObjective(s, profile.hiddenObjective);
+    if (profile.scenarioContext) this.renderScenarioContext(s, profile.scenarioContext, hasActed, profile.language);
+    if (profile.hiddenObjective) this.renderHiddenObjective(s, profile.hiddenObjective, profile.language);
   }
 
   /**
@@ -341,11 +341,24 @@ export class ActionIntentPromptBuilder {
    * flavor. Placed after scenario context so it's the most recent thing the
    * model reads before the output contract.
    */
-  private static renderHiddenObjective(s: PromptSection, objective: import("@perfectman/shared").AgentObjective): void {
+  private static renderHiddenObjective(
+    s: PromptSection,
+    objective: import("@perfectman/shared").AgentObjective,
+    language: PersonaPromptProfile["language"],
+  ): void {
+    // In the profile's language: this block was hardcoded pt-BR, so an
+    // English cast read Portuguese instructions inside an English prompt.
+    const pt = language === "pt-BR";
     s.heading("Secret objective");
-    s.raw(`Você tem um objetivo pessoal que ninguém na sala sabe: ${objective.description}`);
     s.raw(
-      "Você nunca declara esse objetivo em voz alta nem o explica diretamente. Persiga-o através de suas ações e palavras normais nesta cena — e se perceber que outra pessoa está indo atrás da mesma coisa, isso muda como você age.",
+      pt
+        ? `Você tem um objetivo pessoal que ninguém na sala sabe: ${objective.description}`
+        : `You have a personal objective nobody in the room knows about: ${objective.description}`,
+    );
+    s.raw(
+      pt
+        ? "Você nunca declara esse objetivo em voz alta nem o explica diretamente. Persiga-o através de suas ações e palavras normais nesta cena — e se perceber que outra pessoa está indo atrás da mesma coisa, isso muda como você age."
+        : "You never state this objective out loud or explain it directly. Pursue it through your ordinary words and actions in this scene — and if you notice someone else is after the same thing, that changes how you act.",
     );
     // The three fields below are optional (older/simpler scenarios only set
     // description + scarceResourceId) — when present, they're what actually
@@ -353,14 +366,16 @@ export class ActionIntentPromptBuilder {
     // sentence the character cannot honestly say, a real cost if it leaks,
     // and a defined moment where the performance is allowed to crack.
     if (objective.constraint) {
-      s.raw(`Isso significa que você nunca pode: ${objective.constraint}.`);
+      s.raw(pt ? `Isso significa que você nunca pode: ${objective.constraint}.` : `Which means you can never: ${objective.constraint}.`);
     }
     if (objective.costOfExposure) {
-      s.raw(`Se isso vazar antes da hora: ${objective.costOfExposure}.`);
+      s.raw(pt ? `Se isso vazar antes da hora: ${objective.costOfExposure}.` : `If it comes out too early: ${objective.costOfExposure}.`);
     }
     if (objective.breakingPoint) {
       s.raw(
-        `Você mantém a máscara até que ${objective.breakingPoint} — a partir daí, pode deixar transparecer, mesmo que só por um instante.`,
+        pt
+          ? `Você mantém a máscara até que ${objective.breakingPoint} — a partir daí, pode deixar transparecer, mesmo que só por um instante.`
+          : `You keep the mask on until ${objective.breakingPoint} — from then on it may show, even if only for a moment.`,
       );
     }
   }
@@ -511,7 +526,7 @@ export class ActionIntentPromptBuilder {
   }
 
   // The actionable decision question goes LAST (context first, decision last).
-  private static renderDecision(s: PromptSection, input: AgentRuntimeInput): void {
+  private static renderDecision(s: PromptSection, input: AgentRuntimeInput, language: PersonaPromptProfile["language"]): void {
     s.heading("Decide now");
     s.raw(
       'You can ONLY perform ONE action. Pick exactly one permitted combination from <actions>, fill every relevant field per <output_contract>, and emit the JSON object. The conversation moves FORWARD: if you already said something similar, react differently, change the topic, address someone new, move elsewhere. Withholding is also a move: staying silent while a question hangs, waiting someone out, or refusing to answer is something the room notices — when that is what this person would do, choose "no_op" and say why in privateMotiveSummary.',
@@ -545,6 +560,16 @@ export class ActionIntentPromptBuilder {
       "Generic replies count as that failure: agreeing and restating what someone just said, asking a clarifying " +
         "question instead of taking a position, summarizing what the room already knows, or offering to help in " +
         "the abstract. Say the specific thing, or choose silence on purpose.",
+    );
+    // Last on purpose. The pin used to be one sentence in the middle of the
+    // system prompt, under a user prompt written entirely in English that
+    // named privateMotiveSummary twice; on a pt-BR cast the motive came out
+    // in English often enough to be reported. The last line the model reads
+    // before it writes is now the language it writes in.
+    s.raw(
+      language === "pt-BR"
+        ? 'Escreva "visibleContent" e "privateMotiveSummary" em português (pt-BR) — o pensamento é dessa pessoa, na língua dessa pessoa, nunca uma tradução nem um comentário em inglês.'
+        : 'Write "visibleContent" and "privateMotiveSummary" in English — the thought is this person\'s own, in this person\'s own language.',
     );
   }
 
@@ -608,17 +633,23 @@ export class ActionIntentPromptBuilder {
    * Root-caused via a live capture — "announce the proposal" rendered on all
    * 32 pulses, and the agent re-announced it at p7, p10, p12, p18 and p28.
    */
-  private static renderScenarioContext(s: PromptSection, ctx: ScenarioContextBlock, hasActed: boolean): void {
+  private static renderScenarioContext(
+    s: PromptSection,
+    ctx: ScenarioContextBlock,
+    hasActed: boolean,
+    language: PersonaPromptProfile["language"],
+  ): void {
+    const pt = language === "pt-BR";
     s.heading("Social context");
     s.raw(ctx.roomContext);
-    s.raw(`Humor inicial da sala: ${ctx.startingMood}`);
+    s.raw(`${pt ? "Humor inicial da sala" : "Mood of the room at the start"}: ${ctx.startingMood}`);
     if (!hasActed) {
       s.raw(ctx.introBehaviorInstruction);
       if (ctx.firstMoveGuidance) s.raw(ctx.firstMoveGuidance);
     }
-    if (ctx.hostStartingMessage) s.raw(`Mensagem do anfitrião: "${ctx.hostStartingMessage}"`);
+    if (ctx.hostStartingMessage) s.raw(`${pt ? "Mensagem do anfitrião" : "Host's opening message"}: "${ctx.hostStartingMessage}"`);
     if (ctx.customNotes?.length) {
-      s.list("Regras de comportamento nesta cena", ctx.customNotes);
+      s.list(pt ? "Regras de comportamento nesta cena" : "Rules of behaviour in this scene", ctx.customNotes);
     }
   }
 

--- a/packages/server/src/agent/surface/__tests__/retry-notes.test.ts
+++ b/packages/server/src/agent/surface/__tests__/retry-notes.test.ts
@@ -1,0 +1,16 @@
+/**
+ * The retry corrections are appended to the system prompt as its newest,
+ * most salient instruction. In English, they pulled pt-BR characters into
+ * English on exactly the turns that retried.
+ */
+import { describe, expect, it } from "vitest";
+import { retryCorrectionNote, targetRetryCorrectionNote } from "../action-intent-step.js";
+
+describe("retry correction notes", () => {
+  it("speak the profile's language", () => {
+    expect(retryCorrectionNote("oi", "pt-BR")).toMatch(/^IMPORTANTE/);
+    expect(retryCorrectionNote("hi", "en")).toMatch(/^IMPORTANT:/);
+    expect(targetRetryCorrectionNote("replyToEventId", "e9", ["e1"], "pt-BR")).toMatch(/^IMPORTANTE/);
+    expect(targetRetryCorrectionNote("replyToEventId", "e9", ["e1"], "pt-BR")).toContain("e1");
+  });
+});

--- a/packages/server/src/agent/surface/action-intent-step.ts
+++ b/packages/server/src/agent/surface/action-intent-step.ts
@@ -38,7 +38,13 @@ type RetryKind = "none" | "repeat_failed" | "parse_failed" | "provider_failed";
  * new prompt version; the block motive keeps its own "Repetition guard"
  * prefix (repetition-guard.ts) that the offline sweeps match on.
  */
-function retryCorrectionNote(lastAttempt: string): string {
+export function retryCorrectionNote(lastAttempt: string, language: "pt-BR" | "en"): string {
+  // In the profile's language: this is appended to the system prompt as its
+  // newest instruction, and in English it pulled pt-BR characters into
+  // English on exactly the turns that retried.
+  if (language === "pt-BR") {
+    return `IMPORTANTE: sua última tentativa nesta rodada ("${lastAttempt}") ficou parecida demais com algo que você já disse. Diga algo genuinamente diferente — outro ângulo, uma reação a outra pessoa, uma mudança de assunto — sem deixar de ser fiel ao que você realmente quer agora; não invente novidade que seu motivo e seu estado emocional atuais não justifiquem. Ou escolha "no_op" de propósito — deixar o ponto sem resposta é uma jogada, se for a jogada que essa pessoa faria.`;
+  }
   return `IMPORTANT: your last attempt this turn ("${lastAttempt}") was too close to something you already said. Say something genuinely different — a new angle, a reaction to someone else, a topic change — while staying true to what you actually want right now; do not invent novelty that your current motive and emotional state wouldn't justify. Or choose "no_op" on purpose — letting the point stand unanswered is a move, if it is the move this person would make.`;
 }
 
@@ -48,7 +54,16 @@ function retryCorrectionNote(lastAttempt: string): string {
  * render, and offers the send_message escape hatch. The retry prompt version
  * hash covers this text.
  */
-function targetRetryCorrectionNote(field: string, badHandle: string, validHandles: string[]): string {
+export function targetRetryCorrectionNote(
+  field: string,
+  badHandle: string,
+  validHandles: string[],
+  language: "pt-BR" | "en",
+): string {
+  if (language === "pt-BR") {
+    const valid = validHandles.length > 0 ? validHandles.join(", ") : "(nenhum identificador de evento disponível nesta rodada)";
+    return `IMPORTANTE: você colocou "${field}" como "${badHandle || "(vazio)"}", que não é um dos identificadores de evento mostrados em <events>. Os únicos identificadores válidos nesta rodada são: ${valid}. Ou coloque em "${field}" exatamente um desses identificadores, ou — se isso não era de fato uma resposta/reação a uma mensagem específica — use "intentType" "send_message" e omita "${field}".`;
+  }
   const valid = validHandles.length > 0 ? validHandles.join(", ") : "(no event handles are available this turn)";
   return `IMPORTANT: you set "${field}" to "${badHandle || "(empty)"}", which is not one of the event handles shown in <events>. The only valid handles this turn are: ${valid}. Either set "${field}" to exactly one of those handles, or — if this was not actually a reply/reaction to one specific message — set "intentType" to "send_message" and omit "${field}".`;
 }
@@ -214,13 +229,14 @@ export class ActionIntentStep implements LLMStep<AgentRuntimeInput, AgentRuntime
         // before it goes anywhere near the wire; the trim event and the budget
         // gate below therefore see the corrected, final estimate.
         const corrections: string[] = [];
-        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? ""));
+        if (isRepeat(intent)) corrections.push(retryCorrectionNote(intent.visibleContent ?? "", ctx.profile.language));
         if (parseResult.unresolvedTarget) {
           corrections.push(
             targetRetryCorrectionNote(
               parseResult.unresolvedTarget.field,
               parseResult.unresolvedTarget.badHandle,
               parseResult.unresolvedTarget.validHandles,
+              ctx.profile.language,
             ),
           );
         }

--- a/packages/server/src/authoring/__tests__/compile-run-inputs.test.ts
+++ b/packages/server/src/authoring/__tests__/compile-run-inputs.test.ts
@@ -97,3 +97,31 @@ describe("compileRunInputs — the summary the preview panel reads", () => {
     expect(result.config?.simulation.id).toBe("sim_test");
   });
 });
+
+describe("compileRunInputs — one language per scene", () => {
+  const withoutLanguage = (text: string) => text.replace(/^language: .*\n/m, "");
+
+  it("gives a persona with no language the scene's, not a guess from its prose", () => {
+    const { summary } = compile({
+      ...markdown(),
+      personas: [
+        { filename: "iris.persona.md", text: withoutLanguage(IRIS) },
+        { filename: "bruno.persona.md", text: withoutLanguage(BRUNO) },
+      ],
+    });
+    expect(summary?.languages["iris.persona.md"]?.language).toBe("pt-BR");
+    expect(summary?.languages["iris.persona.md"]?.source).toBe("scenario");
+  });
+
+  it("keeps a persona's own explicit language and says when it differs from the scene", () => {
+    const { summary, diagnostics } = compile({
+      ...markdown(),
+      personas: [
+        { filename: "iris.persona.md", text: IRIS.replace("language: pt-BR", "language: en") },
+        { filename: "bruno.persona.md", text: BRUNO },
+      ],
+    });
+    expect(summary?.languages["iris.persona.md"]?.language).toBe("en");
+    expect(diagnostics.some((d) => d.level === "warning" && /language/i.test(d.message) && /iris/.test(d.message + (d.file ?? "")))).toBe(true);
+  });
+});

--- a/packages/server/src/authoring/__tests__/example-presets.test.ts
+++ b/packages/server/src/authoring/__tests__/example-presets.test.ts
@@ -26,6 +26,7 @@ describe("example presets compile when a scene is paired with its named cast", (
     const library = await loadPresets(PRESETS_ROOT);
     expect(library.casts.map((c) => c.id).sort()).toEqual(["studio-partners", "the-group"]);
     expect(library.scenes.map((s) => s.id).sort()).toEqual([
+      "cinco-gorilas",
       "live-que-nao-cai",
       "o-print",
       "the-slice",

--- a/packages/server/src/authoring/__tests__/example-presets.test.ts
+++ b/packages/server/src/authoring/__tests__/example-presets.test.ts
@@ -26,7 +26,6 @@ describe("example presets compile when a scene is paired with its named cast", (
     const library = await loadPresets(PRESETS_ROOT);
     expect(library.casts.map((c) => c.id).sort()).toEqual(["studio-partners", "the-group"]);
     expect(library.scenes.map((s) => s.id).sort()).toEqual([
-      "cinco-gorilas",
       "live-que-nao-cai",
       "o-print",
       "the-slice",

--- a/packages/server/src/authoring/compile-run-inputs.ts
+++ b/packages/server/src/authoring/compile-run-inputs.ts
@@ -74,14 +74,28 @@ function compileMarkdown(
   const diagnostics: Diagnostic[] = [];
   const personas = new Map<string, CompiledPersona>();
   const languages: CompileSummary["languages"] = {};
+  // The scene's language is the default for any persona that states none,
+  // and a persona that states a different one is flagged: a room where the
+  // cast and the scene disagree on language produces lines in both.
+  const sceneLanguage = scenarioLanguageOf(inputs.scenario.text);
 
   for (const file of inputs.personas) {
     const compiled = compilePersonaMarkdown(file.text, file.filename, {
       ...(inputs.languageOverrides?.[file.filename]
         ? { languageOverride: inputs.languageOverrides[file.filename] }
         : {}),
+      ...(sceneLanguage ? { scenarioLanguage: sceneLanguage } : {}),
     });
     diagnostics.push(...compiled.diagnostics);
+    if (compiled.pack && sceneLanguage && compiled.pack.language !== sceneLanguage) {
+      diagnostics.push({
+        level: "warning",
+        file: file.filename,
+        path: "language",
+        message: `${file.filename} is written for \`${compiled.pack.language}\` but the scene is \`${sceneLanguage}\`; this character will speak a different language from the room.`,
+        hint: "Set the same `language:` on the scene and every persona, or leave it off the personas to inherit the scene's.",
+      });
+    }
     // Reachable by filename and by the persona id inside it, so a scenario can
     // name either without the author having to think about which.
     personas.set(file.filename, compiled);
@@ -124,6 +138,13 @@ function compileMarkdown(
       ? summarize(validated, scenario.maxPulses, languages, sourceByAgent(scenario.cast, inputs.personas))
       : null,
   };
+}
+
+/** The scene's `language:` from its frontmatter, read before the personas compile. */
+function scenarioLanguageOf(text: string): "pt-BR" | "en" | undefined {
+  const front = text.split(/^---\s*$/m)[1] ?? "";
+  const match = /^language:\s*["']?(pt-BR|en)["']?\s*$/m.exec(front);
+  return match ? (match[1] as "pt-BR" | "en") : undefined;
 }
 
 function compileRawJson(

--- a/packages/server/src/authoring/language-detect.ts
+++ b/packages/server/src/authoring/language-detect.ts
@@ -20,7 +20,7 @@ export type LanguageDetection = {
   confidence: number;
   /** Markers that fired, for the UI to show its work. */
   markers: string[];
-  source: "frontmatter" | "heuristic" | "override";
+  source: "frontmatter" | "heuristic" | "override" | "scenario";
 };
 
 /**
@@ -101,21 +101,29 @@ export function detectLanguage(text: string): LanguageDetection {
 }
 
 /**
- * Resolves the language for one authored file: an explicit value wins, an
- * override wins over that, and detection is the fallback.
+ * Resolves the language for one authored file: an override wins, then the
+ * file's own explicit value, then the scene's language, and detection is the
+ * fallback. The scene sits above detection because a persona whose Identity
+ * is written in English but who lives in a pt-BR scene should speak pt-BR —
+ * a guess from prose must not outrank what the author said about the scene.
  */
 export function resolveLanguage(params: {
   explicit?: string | undefined;
   override?: string | undefined;
+  /** The scene's language, for a persona that states none of its own. */
+  scenario?: string | undefined;
   proseForDetection: string;
 }): LanguageDetection & { invalidExplicit?: string } {
-  const { explicit, override, proseForDetection } = params;
+  const { explicit, override, scenario, proseForDetection } = params;
 
   if (override === "pt-BR" || override === "en") {
     return { language: override, confidence: 1, markers: [], source: "override" };
   }
   if (explicit === "pt-BR" || explicit === "en") {
     return { language: explicit, confidence: 1, markers: [], source: "frontmatter" };
+  }
+  if ((scenario === "pt-BR" || scenario === "en") && !explicit) {
+    return { language: scenario, confidence: 1, markers: [], source: "scenario" };
   }
 
   const detected = detectLanguage(proseForDetection);

--- a/packages/server/src/authoring/persona-md-compiler.ts
+++ b/packages/server/src/authoring/persona-md-compiler.ts
@@ -89,7 +89,7 @@ export type CompiledPersona = {
 export function compilePersonaMarkdown(
   text: string,
   filename: string,
-  options: { languageOverride?: string } = {},
+  options: { languageOverride?: string; scenarioLanguage?: string } = {},
 ): CompiledPersona {
   const bag = new DiagnosticBag(filename);
 
@@ -140,6 +140,7 @@ export function compilePersonaMarkdown(
   const language = resolveLanguage({
     explicit: typeof fm["language"] === "string" ? fm["language"] : undefined,
     override: options.languageOverride,
+    scenario: options.scenarioLanguage,
     proseForDetection: [identityFrame, ...voiceGuidelines, ...styleExamples].join("\n"),
   });
   if (language.invalidExplicit !== undefined) {

--- a/packages/server/src/delivery/__tests__/sse-delivery-gateway.test.ts
+++ b/packages/server/src/delivery/__tests__/sse-delivery-gateway.test.ts
@@ -1,0 +1,60 @@
+/**
+ * What the browser learns about channels. A private room's membership
+ * changes after it is created — someone is invited, someone leaves — and the
+ * viewer draws the room from the member list, so it has to hear about it.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { SseDeliveryGateway } from "../sse-delivery-gateway.js";
+import { SseHub, type SseMessage } from "../../http/sse-hub.js";
+
+function harness() {
+  const published: SseMessage[] = [];
+  const hub = new SseHub();
+  vi.spyOn(hub, "publish").mockImplementation((message: SseMessage) => {
+    published.push(message);
+  });
+  const gateway = new SseDeliveryGateway(hub, { simulationId: "s", simulationName: "s", agents: {}, channels: { geral: { name: "geral" } } });
+  const channels = () => published.filter((m) => m.type === "channel").map((m) => (m.data as { channel: { id: string; memberAgentIds: string[] } }).channel);
+  return { gateway, published, channels };
+}
+
+describe("SseDeliveryGateway channels", () => {
+  it("tells the viewer when someone is added to a room", async () => {
+    const { gateway, channels } = harness();
+    await gateway.createChannel("dm", "private_channel", ["rex"]);
+    await gateway.addMember("dm", "goulart");
+    const last = channels().at(-1);
+    expect(last?.id).toBe("dm");
+    expect(last?.memberAgentIds.sort()).toEqual(["goulart", "rex"]);
+  });
+
+  it("tells the viewer when someone leaves", async () => {
+    const { gateway, channels } = harness();
+    await gateway.createChannel("dm", "private_channel", ["rex", "goulart"]);
+    await gateway.removeMember("dm", "rex");
+    expect(channels().at(-1)?.memberAgentIds).toEqual(["goulart"]);
+  });
+
+  it("merges members when the same room is announced twice", async () => {
+    const { gateway, channels } = harness();
+    await gateway.createChannel("dm", "private_channel", ["rex"]);
+    await gateway.createChannel("dm", "private_channel", ["goulart"]);
+    expect(channels().at(-1)?.memberAgentIds.sort()).toEqual(["goulart", "rex"]);
+  });
+
+  it("does not repeat a room whose members did not change", async () => {
+    const { gateway, channels } = harness();
+    await gateway.createChannel("dm", "private_channel", ["rex"]);
+    await gateway.addMember("dm", "rex");
+    expect(channels()).toHaveLength(1);
+  });
+
+  it("never lets a slow client lose a pulse: frames are not coalesced", () => {
+    const { gateway, published } = harness();
+    gateway.commitPulse({ pulseIndex: 0, eventsCommitted: 0, agentsCalled: 0 });
+    gateway.commitPulse({ pulseIndex: 1, eventsCommitted: 0, agentsCalled: 0 });
+    const pulses = published.filter((m) => m.type === "pulse");
+    expect(pulses).toHaveLength(2);
+    expect(pulses.every((m) => m.coalesceKey === undefined)).toBe(true);
+  });
+});

--- a/packages/server/src/delivery/sse-delivery-gateway.ts
+++ b/packages/server/src/delivery/sse-delivery-gateway.ts
@@ -49,14 +49,19 @@ function emptyFrame(): PartialFrame {
 
 export class SseDeliveryGateway implements IDeliveryGateway {
   private frames = new Map<number, PartialFrame>();
-  /** Channels created mid-run, so the viewer can add tabs as they appear. */
-  private readonly knownChannels = new Set<string>();
+  /**
+   * Every channel the viewer has been told about, with the members it was
+   * told. The viewer draws a room from its member list, so a membership
+   * change is republished; a room whose members did not change is not.
+   */
+  private readonly channels = new Map<string, { type: ChannelType; members: Set<string> }>();
 
   constructor(
     private readonly hub: SseHub,
     private readonly meta: GatewayRuntimeMetadata,
   ) {
-    for (const id of Object.keys(meta.channels)) this.knownChannels.add(id);
+    // Announced by `hello`; only a change in membership needs republishing.
+    for (const id of Object.keys(meta.channels)) this.channels.set(id, { type: "public_channel", members: new Set() });
   }
 
   /**
@@ -74,14 +79,11 @@ export class SseDeliveryGateway implements IDeliveryGateway {
       agentsCalled: result.agentsCalled,
       ...partial,
     };
-    this.hub.publish({
-      type: "pulse",
-      data: { type: "pulse", frame },
-      id: result.pulseIndex,
-      // Coalescable: a client that falls behind should see the newest pulse,
-      // not work through a backlog. Gaps are filled from the stored replay.
-      coalesceKey: "pulse",
-    });
+    // Not coalescable. A replaced frame takes every line in it with it, and
+    // a private aside is often one pulse long, so coalescing erased whole
+    // private conversations for a client that fell a frame behind. The hub's
+    // backlog cap bounds the queue; a slow client works through it.
+    this.hub.publish({ type: "pulse", data: { type: "pulse", frame }, id: result.pulseIndex });
     return frame;
   }
 
@@ -93,25 +95,43 @@ export class SseDeliveryGateway implements IDeliveryGateway {
   }
 
   createChannel(channelId: string, type: ChannelType, memberAgentIds: string[]): Promise<void> {
-    if (!this.knownChannels.has(channelId)) {
-      this.knownChannels.add(channelId);
-      const channel: LiveChannel = {
-        id: channelId,
-        name: this.meta.channels[channelId]?.name ?? channelId,
-        type,
-        memberAgentIds,
-      };
-      this.hub.publish({ type: "channel", data: { type: "channel", channel } });
+    const known = this.channels.get(channelId);
+    if (!known) {
+      this.channels.set(channelId, { type, members: new Set(memberAgentIds) });
+      this.publishChannel(channelId);
+      return Promise.resolve();
+    }
+    const before = known.members.size;
+    for (const id of memberAgentIds) known.members.add(id);
+    if (known.members.size !== before) this.publishChannel(channelId);
+    return Promise.resolve();
+  }
+
+  addMember(channelId: string, agentId: string): Promise<void> {
+    const known = this.channels.get(channelId);
+    if (known && !known.members.has(agentId)) {
+      known.members.add(agentId);
+      this.publishChannel(channelId);
     }
     return Promise.resolve();
   }
 
-  addMember(_channelId: string, _agentId: string): Promise<void> {
+  removeMember(channelId: string, agentId: string): Promise<void> {
+    const known = this.channels.get(channelId);
+    if (known?.members.delete(agentId)) this.publishChannel(channelId);
     return Promise.resolve();
   }
 
-  removeMember(_channelId: string, _agentId: string): Promise<void> {
-    return Promise.resolve();
+  private publishChannel(channelId: string): void {
+    const known = this.channels.get(channelId);
+    if (!known) return;
+    const channel: LiveChannel = {
+      id: channelId,
+      name: this.meta.channels[channelId]?.name ?? channelId,
+      type: known.type,
+      memberAgentIds: [...known.members],
+    };
+    this.hub.publish({ type: "channel", data: { type: "channel", channel } });
   }
 
   sendSpectatorEvent(_event: SpectatorEvent): Promise<void> {

--- a/packages/server/src/simulation/__tests__/intent-resolver-channel-id.test.ts
+++ b/packages/server/src/simulation/__tests__/intent-resolver-channel-id.test.ts
@@ -1,0 +1,86 @@
+/**
+ * A created channel has one id — the one the registry gave it — on every
+ * event the intent commits. The invite events used to keep the throwaway id
+ * the resolver minted before registration, so the invitee (and, via the
+ * invite's actor anchor, the creator too) got anchored to a channel that did
+ * not exist, and their next lines landed in a phantom room: no privacy flag,
+ * no members, nothing on the stage but a lone figure "somewhere".
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { IntentResolver } from "../intent-resolver.js";
+import { RateLimitGate } from "../rate-limit-gate.js";
+import { ChannelRegistry } from "../channel-registry.js";
+import { InMemoryChannelRepository } from "../in-memory-stores.js";
+import type { ActionEmotions, ActionIntent, AgentState, AvailableAction, SimulationSettings } from "@perfectman/shared";
+import { createId } from "@perfectman/shared";
+
+const SIM_ID = "sim_test";
+const CREATOR = "rex";
+const INVITEE = "goulart";
+const PUBLIC = "ch_public";
+const SETTINGS: SimulationSettings = {
+  omniscientSpectatorMode: false,
+  allowPrivateChannels: true,
+  maxPrivateChannelsPerAgent: 3,
+  maxMessagesPerMinutePerAgent: 20,
+  llmCallBudgetPerMinute: 10,
+  pulseIntervalMs: 3000,
+  tokenBudgetPerHour: 1_000_000,
+};
+const ACTIONS: AvailableAction[] = [
+  { intentType: "create_channel", channelTargets: [], personTargets: [INVITEE], blocked: false },
+  { intentType: "no_op", channelTargets: [], personTargets: [], blocked: false },
+];
+const EMOTIONS: ActionEmotions = {
+  defensiveness: 0, warmth: 0, jealousInspection: 0, shameWithdrawal: 0, resentfulColdness: 0,
+  curiousApproach: 0, anxiousOverreach: 0, pridefulPerformance: 0, vulnerableRetreat: 0,
+  contemptuousDismissal: 0, strategicPatience: 0, impulsiveProvocation: 0, comfortSeeking: 0,
+  dominanceAssertion: 0, repairImpulse: 0,
+};
+
+function agentState(): AgentState {
+  return {
+    agentId: CREATOR, simulationId: SIM_ID, personaId: "p", presence: "active",
+    coreMood: { valence: 0, arousal: 0.5, stability: 0.8, energy: 0.6, circumplexAngle: 0, circumplexRadius: 0.5, momentumValence: 0, momentumArousal: 0 },
+    socialEmotions: { jealousy: 0, envy: 0, humiliation: 0, pride: 0, shame: 0, affection: 0, resentment: 0, suspicion: 0, admiration: 0, contempt: 0, neediness: 0, socialAnxiety: 0, fearOfExclusion: 0, desireForStatus: 0, desireForIntimacy: 0 },
+    relationalStates: new Map(), memories: [], initiativeAccumulators: [], lastProcessedEventId: null, lastActionAt: null,
+    lastRuminationPulse: null, arrivalPulse: null, createdAt: Date.now(), updatedAt: Date.now(),
+  };
+}
+
+describe("create_channel commits one channel id", () => {
+  let resolver: IntentResolver;
+  let registry: ChannelRegistry;
+  beforeEach(async () => {
+    const repo = new InMemoryChannelRepository();
+    registry = new ChannelRegistry(repo);
+    await repo.create({ id: PUBLIC, simulationId: SIM_ID, type: "public_channel", name: "general", createdBy: "system", memberAgentIds: [CREATOR, INVITEE], spectatorVisible: true, operatorVisible: true, createdForMotives: [], status: "active", createdAt: Date.now(), updatedAt: Date.now() });
+    resolver = new IntentResolver(new RateLimitGate(SETTINGS), registry);
+  });
+
+  const ctx = () => ({ simulationId: SIM_ID, channelId: PUBLIC, pulseIndex: 1, agentState: agentState(), availableActions: ACTIONS, channels: [], membership: [], settings: SETTINGS, actionEmotions: EMOTIONS });
+
+  it("puts the registered id on the invite, not the id the resolver minted first", async () => {
+    const intent: ActionIntent = { id: createId(), actorId: CREATOR, intentType: "create_channel", personTargets: [INVITEE], invitedAgentIds: [INVITEE], privateMotiveSummary: "quero falar com ele longe dos outros", emotionDrivers: [], motivationDrivers: [], memoryWrites: [] };
+    const result = await resolver.resolve(intent, ctx());
+    const created = result.committedEvents.find((e) => e.type === "channel_created");
+    const invited = result.committedEvents.filter((e) => e.type === "agent_invited");
+    expect(created).toBeDefined();
+    expect(invited).toHaveLength(1);
+    expect(invited[0]?.channelId).toBe(created?.channelId);
+    const memberships = await registry.getMembershipsForSimulation(SIM_ID);
+    const inNewChannel = memberships.filter((m) => m.channelId === created?.channelId).map((m) => m.agentId).sort();
+    expect(inNewChannel).toEqual([INVITEE, CREATOR].sort());
+  });
+
+  it("ignores a person id the model put in channelTarget", async () => {
+    // The model sometimes writes the invitee's id where a channel id goes.
+    const intent: ActionIntent = { id: createId(), actorId: CREATOR, intentType: "create_channel", channelTarget: INVITEE, personTargets: [INVITEE], privateMotiveSummary: "…", emotionDrivers: [], motivationDrivers: [], memoryWrites: [] };
+    const result = await resolver.resolve(intent, ctx());
+    for (const e of result.committedEvents.filter((e) => e.type === "channel_created" || e.type === "agent_invited")) {
+      expect(e.channelId).not.toBe(INVITEE);
+    }
+    const ids = new Set(result.committedEvents.filter((e) => e.type === "channel_created" || e.type === "agent_invited").map((e) => e.channelId));
+    expect(ids.size).toBe(1);
+  });
+});

--- a/packages/server/src/simulation/intent-resolver.ts
+++ b/packages/server/src/simulation/intent-resolver.ts
@@ -658,9 +658,14 @@ export class IntentResolver {
         spectatorVisible: false,
         createdForMotives: [intent.privateMotiveSummary.slice(0, 80)],
       });
-      // Rewrite the committed event with the real registered channel id.
+      // Rewrite every event of this intent with the real registered channel
+      // id — the creation and each invite. Rewriting only the creation left
+      // the invites on the id minted before registration, and the anchor
+      // update that follows an invite then parked both parties in a channel
+      // that did not exist: their next lines committed there, unmarked as
+      // private, with no members, and the stage drew a lone figure "somewhere".
       for (const evt of primaryEvents) {
-        if (evt.type === "channel_created") {
+        if (evt.type === "channel_created" || evt.type === "agent_invited") {
           evt.channelId = channel.id;
         }
       }

--- a/packages/shared/src/agent/__tests__/engine-motive.test.ts
+++ b/packages/shared/src/agent/__tests__/engine-motive.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isEngineAuthoredMotive } from "../engine-motive.js";
+
+describe("isEngineAuthoredMotive", () => {
+  it("filters what the engine wrote on the agent's behalf", () => {
+    expect(isEngineAuthoredMotive("Fallback applied: Channel target 'x' is not permitted")).toBe(true);
+    expect(isEngineAuthoredMotive("operator-directed join")).toBe(true);
+    expect(isEngineAuthoredMotive("operator-directed leave")).toBe(true);
+  });
+  it("lets a person's own thought through", () => {
+    expect(isEngineAuthoredMotive("quero fofocar no privado antes da votação")).toBe(false);
+  });
+});

--- a/packages/shared/src/agent/engine-motive.ts
+++ b/packages/shared/src/agent/engine-motive.ts
@@ -32,6 +32,8 @@ export const ENGINE_MOTIVE_PREFIXES: readonly string[] = [
   "Retry call failed.",
   "Reaction target unresolvable",
   "unresolvable ",
+  // Written by the operator command handlers for a forced join or leave.
+  "operator-directed",
 ];
 
 export function isEngineAuthoredMotive(motive: string): boolean {

--- a/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
+++ b/packages/shared/src/intent/__tests__/intent-packet-field-contract.test.ts
@@ -18,3 +18,11 @@ describe("modelIntentPacketFieldContract — memoryWrites", () => {
     expect(full).toMatch(/confidence.*number/);
   });
 });
+
+describe("field contract — language", () => {
+  it("tells the model the motive is in the character's own language", async () => {
+    const { modelIntentPacketFieldContract } = await import("../intent-packet.schema.js");
+    const motive = modelIntentPacketFieldContract().find((line) => line.startsWith('"privateMotiveSummary"'));
+    expect(motive).toMatch(/own language/);
+  });
+});

--- a/packages/shared/src/intent/intent-packet.schema.ts
+++ b/packages/shared/src/intent/intent-packet.schema.ts
@@ -17,8 +17,11 @@ export const ModelIntentPacketSchema = z.object({
   intentType: IntentTypeSchema,
   channelTarget: z.string().optional(),
   personTargets: z.array(z.string()).default([]),
-  visibleContent: z.string().optional(),
-  privateMotiveSummary: z.string().min(1),
+  visibleContent: z.string().optional().describe("What this person says out loud, in this person's own language."),
+  privateMotiveSummary: z
+    .string()
+    .min(1)
+    .describe("This person's own private thought behind the action, in this person's own language."),
   emotionDrivers: z.array(z.string()).default([]),
   motivationDrivers: z.array(z.string()).default([]),
   // Short form first: it is what the prompt asks for and what schema mode
@@ -57,6 +60,7 @@ export function normalizeMemoryWriteProposal(element: ModelIntentPacket["memoryW
 
 type JsonSchemaProp = {
   type?: string;
+  description?: string;
   enum?: readonly string[];
   items?: { type?: string; properties?: Record<string, JsonSchemaProp>; anyOf?: JsonSchemaProp[] };
   properties?: Record<string, JsonSchemaProp>;
@@ -138,7 +142,9 @@ export function modelIntentPacketFieldContract(): string[] {
   const { properties, required } = ModelIntentPacketJsonSchema;
   return Object.entries(properties).map(([name, def]) => {
     const isRequired = (required as readonly string[]).includes(name);
-    return `"${name}" (${isRequired ? "required" : "optional"}): ${describePacketFieldType(def as JsonSchemaProp)}`;
+    const prop = def as JsonSchemaProp;
+    const note = prop.description ? ` — ${prop.description}` : "";
+    return `"${name}" (${isRequired ? "required" : "optional"}): ${describePacketFieldType(prop)}${note}`;
   });
 }
 


### PR DESCRIPTION
## What

Makes private conversations reach the viewer and keeps every character in its own language:

- `intent-resolver.ts`: every event of a `create_channel` intent is rewritten to the registered channel id, not only `channel_created`. The `agent_invited` events kept the throwaway id, and `updateCurrentChannelAnchors` then parked both invitee and creator in a phantom channel — their next lines committed there with `visibilityReason: "public"`, no members, and the stage drew a lone figure "somewhere". Seen in a stored hosted-model run: an invite event with `channelId: "goulart"`, then each party monologuing in a different room.
- `sse-delivery-gateway.ts`: `addMember` / `removeMember` republish the `channel` event with the new member list; `createChannel` merges on repeat. Both were no-ops, so a late joiner never reached `memberAgentIds` and never got a seat.
- `sse-delivery-gateway.ts`: pulse frames drop `coalesceKey`. A replaced frame took every line in it, and a private aside is often one pulse long.
- `action-intent-prompt-builder.ts`: the language pin closes `<decision>` — the last line before generation — in pt-BR or English; `renderHiddenObjective` and the scene-context labels follow `profile.language` instead of hardcoded pt-BR.
- `action-intent-step.ts`: `retryCorrectionNote` / `targetRetryCorrectionNote` take the language and are pt-BR for pt-BR profiles (they are the newest system-prompt instruction on retried turns).
- `language-detect.ts` / `compile-run-inputs.ts`: `resolveLanguage` gains a `scenario` tier between frontmatter and heuristic; a persona with no `language:` inherits the scene's (`source: "scenario"`); a persona whose language differs from the scene's gets a warning diagnostic.
- `intent-packet.schema.ts`: `.describe()` on `visibleContent` and `privateMotiveSummary` ("in this person's own language"), rendered into `modelIntentPacketFieldContract()` so the pin survives constrained decoding.
- `engine-motive.ts`: `operator-directed` joins the engine-motive prefixes.
- 17 tests: registered id on every event / person id in `channelTarget` ignored, gateway add / remove / merge / no-repeat / no-coalesce, pin last for pt-BR and en, objective language, retry notes language, scene language inherited / mismatch warned, field contract mentions language, operator motive filtered.

## Why

Stored run `run_mtqj8dj2_fx5ipf` (the-group × A última proteína, hosted model): two private channels created with invites, every private line spoken by one person alone, and a thinking entry reading `Fallback applied: Channel target 'goulart' is not permitted…`. The prompt builder's own comment already recorded 21 of 50 motives coming out in English in the first real read with the pin where it was.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS (2006 passed, +17: server +14, shared +3; `audit-tests --check` and `docs-lint --check` clean)
- The live run server is redeployed from this merge; the web needs nothing.