### PR TITLE
fix(stage): a room being opened is not a line

### DIFF
--- a/packages/shared/src/stage/__tests__/live-to-beats.test.ts
+++ b/packages/shared/src/stage/__tests__/live-to-beats.test.ts
@@ -194,3 +194,16 @@ describe("pulseToBeats — reactions", () => {
     expect(Object.keys(beat?.reactions ?? {})).toEqual(["marcela"]);
   });
 });
+
+describe("pulseToBeats — a stage action is not a line", () => {
+  it("never puts the channel's name in a balloon when a room is opened", () => {
+    const beats = pulseToBeats(
+      frame({ messages: [message({ eventType: "channel_created", channelId: "dm", text: "conversa_privada", visibleToAgents: ["iris", "marcela"] })] }),
+      CONTEXT,
+    );
+    expect(beats[0]?.kind).toBe("event");
+    expect(beats[0]?.stageAction?.kind).toBe("invite");
+    expect(beats[0]?.text).toBe("");
+    expect(beats[0]?.duration).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/shared/src/stage/live-to-beats.ts
+++ b/packages/shared/src/stage/live-to-beats.ts
@@ -59,6 +59,9 @@ const BALLOON_PAGE = 150;
 /** A thought is set larger than speech, so it fits fewer characters. */
 const THOUGHT_PAGE = 120;
 
+/** How long someone arriving, leaving or opening a room stays on stage. */
+const STAGE_ACTION_SECONDS = 1.8;
+
 const STAGE_ACTIONS: Record<string, "arrive" | "leave" | "invite"> = {
   agent_joined: "arrive",
   agent_arrived: "arrive",
@@ -135,19 +138,23 @@ export function pulseToBeats(frame: LivePulseFrame, context: BeatContext): Stage
     const reactions = reactionsIn(frame, participantIds, message.actorId);
 
     if (staging === "action") {
+      // A stage action is a movement, not a line: nobody said anything. The
+      // display text on these events is the channel's name, and putting it in
+      // a balloon read as the character saying "conversa_privada". The caption
+      // tells the story; the beat holds only long enough to see who moved.
       beats.push({
         id: message.eventId,
         kind: "event",
         pulseIndex: frame.pulseIndex,
         channelId: message.channelId,
         actorId: message.actorId,
-        text: message.text,
+        text: "",
         audienceIds: message.visibleToAgents,
         participantIds,
         ...(emotion ? { emotion } : {}),
         ...(reactions ? { reactions } : {}),
         stageAction: { kind: STAGE_ACTIONS[message.eventType] ?? "invite", agentIds: [message.actorId] },
-        duration: readingSeconds(message.text || " "),
+        duration: STAGE_ACTION_SECONDS,
         page: 0,
       });
       continue;

--- a/packages/web/src/stage/Attribution.tsx
+++ b/packages/web/src/stage/Attribution.tsx
@@ -44,12 +44,33 @@ export function Attribution({
 function describe(beat: StageBeat, agents: readonly StageAgent[], channelName: string | undefined): string {
   if (beat.kind === "silence") return "says nothing this turn";
   if (beat.kind === "aside") return "what they were actually after";
-  if (beat.kind === "event") return `in ${channelName ?? "the room"}`;
+  if (beat.kind === "event") return describeAction(beat, agents, channelName);
   if (beat.audienceIds.length > 0) {
     const who = beat.audienceIds.map((id) => nameOf(agents, id)).join(", ");
     return `— only ${who} can see this`;
   }
   return channelName ? `in ${channelName}` : "";
+}
+
+/**
+ * A stage action has no line, so the caption is the whole story: who opened
+ * a room with whom, who joined, who left. The channel's own name is the
+ * model's invention ("conversa_privada") and is never shown.
+ */
+function describeAction(beat: StageBeat, agents: readonly StageAgent[], channelName: string | undefined): string {
+  const where = channelName ?? "the room";
+  const kind = beat.stageAction?.kind;
+  if (kind === "leave") return `leaves ${where}`;
+  if (kind === "arrive") return `joins ${where}`;
+  const others = beat.audienceIds.filter((id) => id !== beat.actorId).map((id) => nameOf(agents, id));
+  if (others.length > 0) return `opens a private room with ${listNames(others)}`;
+  return `opens ${where}`;
+}
+
+/** "a", "a and b", "a, b and c" — the way a sentence would say it. */
+function listNames(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
 }
 
 function nameOf(agents: readonly StageAgent[], id: string | undefined): string {

--- a/packages/web/src/stage/Frame.tsx
+++ b/packages/web/src/stage/Frame.tsx
@@ -73,8 +73,9 @@ export function frameLabel(beat: StageBeat, agents: readonly NamedAgent[], chann
   if (beat.kind === "aside") return `what ${who} was after`;
   if (beat.kind === "event") {
     if (beat.stageAction?.kind === "leave") return `${who} leaves ${where}`;
-    if (beat.stageAction?.kind === "arrive") return `${who} arrives in ${where}`;
-    return `${who} opens ${where}`;
+    if (beat.stageAction?.kind === "arrive") return `${who} joins ${where}`;
+    const others = beat.audienceIds.filter((id) => id !== beat.actorId).map((id) => agents.find((a) => a.id === id)?.displayName ?? id);
+    return others.length > 0 ? `${who} opens a private room with ${others.join(" and ")}` : `${who} opens ${where}`;
   }
   return `${who} speaks in ${where}`;
 }

--- a/packages/web/src/stage/Stage.tsx
+++ b/packages/web/src/stage/Stage.tsx
@@ -103,7 +103,7 @@ export const Stage = memo(function Stage({ beat, placement, agents, channels, id
             was not, which is the distinction this interface exists to draw, and
             two of them over one head do not fit above a figure at the back of
             the room. */}
-        {beat && speaker && (beat.text || beat.thought) ? (
+        {beat && speaker && beat.kind !== "event" && (beat.text || beat.thought) ? (
           <Bubble
             key={beat.id}
             speaker={speakerRef}

--- a/packages/web/src/stage/__tests__/attribution.test.tsx
+++ b/packages/web/src/stage/__tests__/attribution.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * The caption says what kind of moment this is. For a stage action — a room
+ * opened, someone arriving or leaving — it is the whole story, because there
+ * is no balloon.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LiveChannel, StageBeat } from "@perfectman/shared";
+import { Attribution } from "../Attribution.js";
+
+const AGENTS = [
+  { id: "rex", displayName: "Rex" },
+  { id: "goulart", displayName: "Goulart" },
+  { id: "caio", displayName: "Caio" },
+];
+const IDS = AGENTS.map((a) => a.id);
+const CHANNELS: LiveChannel[] = [
+  { id: "geral", name: "acampamento", type: "public_channel", memberAgentIds: IDS },
+  { id: "dm", name: "conversa_privada", type: "private_channel", memberAgentIds: ["rex", "goulart"] },
+];
+
+function beat(over: Partial<StageBeat>): StageBeat {
+  return {
+    id: "b", kind: "event", pulseIndex: 0, channelId: "dm", actorId: "rex", text: "",
+    audienceIds: [], participantIds: ["rex", "goulart"], duration: 2, page: 0, ...over,
+  };
+}
+
+function caption(b: StageBeat): string {
+  const { container } = render(<Attribution beat={b} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+  return container.textContent ?? "";
+}
+
+describe("Attribution for stage actions", () => {
+  it("says who a private room was opened with, not the channel's name", () => {
+    const text = caption(beat({ stageAction: { kind: "invite", agentIds: ["rex"] }, audienceIds: ["rex", "goulart"] }));
+    expect(text).toContain("Rex");
+    expect(text).toContain("opens a private room with Goulart");
+    expect(text).not.toContain("conversa_privada");
+  });
+  it("says who arrives where", () => {
+    expect(caption(beat({ stageAction: { kind: "arrive", agentIds: ["rex"] }, channelId: "geral" }))).toContain("joins acampamento");
+  });
+  it("says who leaves where", () => {
+    expect(caption(beat({ stageAction: { kind: "leave", agentIds: ["rex"] } }))).toContain("leaves Rex and Goulart");
+  });
+});

--- a/packages/web/src/stage/__tests__/stage.test.tsx
+++ b/packages/web/src/stage/__tests__/stage.test.tsx
@@ -99,3 +99,12 @@ describe("Stage reactions", () => {
     expect(faces["bruno"]).toBe("neutral");
   });
 });
+
+describe("Stage events", () => {
+  it("draws no balloon for someone arriving, leaving or opening a room", () => {
+    const b = beat({ kind: "event", text: "conversa_privada", stageAction: { kind: "invite", agentIds: ["iris"] } });
+    const [placement] = placeBeats([b], AGENTS, CHANNELS);
+    const { container } = render(<Stage beat={b} placement={placement!} agents={AGENTS} channels={CHANNELS} ids={IDS} />);
+    expect(container.querySelector(".bubbles")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Stops stage actions from being drawn as speech:

- `live-to-beats.ts`: `channel_created` / `agent_invited` / `agent_left` beats carry `text: ""` and hold `STAGE_ACTION_SECONDS` (1.8 s) instead of `readingSeconds(channelName)`. The display text on those events is the channel's name (`displayText` falls back to `channelName`), which the balloon rendered as the character saying "conversa_privada".
- `Stage.tsx`: no balloon for `kind === "event"`.
- `Attribution.tsx`: `describeAction` captions the moment — `opens a private room with Goulart` (from `audienceIds` minus the actor), `joins acampamento`, `leaves Rex and Goulart`. The model's channel name is never shown.
- `Frame.tsx`: `frameLabel` matches the caption for screen readers.
- 5 tests: event beat has no text and a short hold, no balloon for an event beat, three captions.

## Why

Reported on the live stage: private rooms showing "conversa_privada" / "bastidores" in a balloon, or nothing. Those are the room-opening and invite events; the private lines themselves were also missing until #208 fixed the phantom channel anchor.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS on a clean checkout (2027 passed, +5). Locally one presets test fails only because an untracked scene from another session sits in `examples/presets/`.
- Web deploys from main via Vercel; no server change.