### PR TITLE
feat(web): one way to answer, and a failed run asks for the key again

### DIFF
--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -106,7 +106,8 @@ Forty files. These are the ones that carry weight.
 | File | What it does |
 |---|---|
 | `run/RunScreen.tsx` | Warm-up gate, stage, transport, drawer. |
-| `run/known-routes.ts` | One-click provider prefills. Never holds a key. |
+| `run/known-routes.ts` | One-click endpoint prefills. Never holds a key. |
+| `run/ProviderForm.tsx` | Endpoint, model, key, turns. Start is disabled without a key. |
 | `run/useSoundtrack.ts` | Mood beds with an 8 s hold, plus cues. `unlock()` runs in the Run click; a refusal flips the control but is not saved. |
 | `run/sfx-cue.ts` | Which cue a beat makes: once per line, none for a thought, none while paused. |
 | `run/DetailsDrawer.tsx` | Compiled config, diagnostics, raw frame log. Kept, just demoted. |
@@ -266,13 +267,14 @@ pnpm web                              # run server on :4317
 pnpm --filter @perfectman/web dev     # interface on :5317, hot reload
 ```
 
-Pick the **Mock** provider for a run that finishes in seconds and needs no key.
-For a real one, the form has a one-click prefill for OrcaRouter + Qwen3.5-27B;
-you supply only the key.
-
-Mock is a bad proxy for the real path — it skips prompt building, TLS and
-response parsing, which is where the time actually goes. Check anything
-performance-shaped against a real model.
+The run form takes one thing: an OpenAI-compatible endpoint and a key. It
+opens on the OrcaRouter + Qwen3.5-27B route; you supply only the key. The mock
+and Ollama choices are gone from the interface (the mock provider still exists
+server-side for tests). A run whose key, endpoint or output format does not
+work comes straight back to the form with the reason and the key field
+cleared: the health check catches a dead endpoint or bad key before the run,
+and `LlmHealthWatch` fails the run if its first three model calls all come
+back as engine fallbacks.
 
 ### Redeploying
 

--- a/packages/server/src/http/run/__tests__/llm-health-watch.test.ts
+++ b/packages/server/src/http/run/__tests__/llm-health-watch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A run whose model never answers usably is a failed run, not a quiet one.
+ * The health check catches a dead endpoint or a bad key before the run;
+ * this catches the case it cannot: a model that answers, but with nothing
+ * the parser can use — wrong output format, reasoning eating the budget.
+ */
+import { describe, expect, it } from "vitest";
+import type { OperatorEvent } from "@perfectman/shared";
+import { LlmHealthWatch } from "../llm-health-watch.js";
+
+function intent(agentId: string, motive: string, pulseIndex = 0): OperatorEvent {
+  return {
+    type: "action_intent",
+    simulationId: "s",
+    agentId,
+    pulseIndex,
+    detail: "Action intent",
+    data: { intentId: "i", intentType: "no_op", privateMotiveSummary: motive, emotionDrivers: [], motivationDrivers: [] },
+    createdAt: 0,
+  };
+}
+
+describe("LlmHealthWatch", () => {
+  it("fails the run when the first three calls are all engine fallbacks", () => {
+    const watch = new LlmHealthWatch(3);
+    expect(watch.observe(intent("a", "Provider failed: HTTP 401: bad key"))).toBeNull();
+    expect(watch.observe(intent("b", "Fallback applied: could not parse intent JSON"))).toBeNull();
+    const fatal = watch.observe(intent("c", "Retry call failed."));
+    expect(fatal?.message).toContain("first 3");
+    expect(fatal?.message).toContain("Retry call failed.");
+    expect(fatal?.hint).toMatch(/key|JSON/);
+  });
+
+  it("lets a run through once any call has answered usably", () => {
+    const watch = new LlmHealthWatch(3);
+    watch.observe(intent("a", "Provider failed: HTTP 500"));
+    watch.observe(intent("b", "quero fofocar no privado"));
+    expect(watch.observe(intent("c", "Provider failed: HTTP 500"))).toBeNull();
+    expect(watch.observe(intent("d", "Provider failed: HTTP 500"))).toBeNull();
+  });
+
+  it("does not count the engine's own silences as model failures", () => {
+    const watch = new LlmHealthWatch(2);
+    watch.observe(intent("a", "Repetition guard: near-duplicate"));
+    expect(watch.observe(intent("b", "LLM budget exceeded: minute cap"))).toBeNull();
+  });
+
+  it("ignores everything that is not an intent", () => {
+    const watch = new LlmHealthWatch(1);
+    expect(watch.observe({ type: "llm_failure", simulationId: "s", agentId: "a", pulseIndex: 0, detail: "x", createdAt: 0 })).toBeNull();
+  });
+});

--- a/packages/server/src/http/run/llm-health-watch.ts
+++ b/packages/server/src/http/run/llm-health-watch.ts
@@ -1,0 +1,90 @@
+/**
+ * A run whose model never answers usably is a failed run, not a quiet one.
+ *
+ * The health check before a run catches a dead endpoint or a bad key. It
+ * cannot catch the case where the model answers but with nothing the parser
+ * can use — the wrong output format, reasoning that eats the whole budget —
+ * because that only shows on a real turn. Left alone, such a run plays out
+ * as a room where nobody says anything, and the person watching concludes
+ * the product is broken rather than the key.
+ *
+ * So the first few calls are watched. If every one of them came back as an
+ * engine fallback, the run stops with the last reason and a hint; one usable
+ * answer proves the model works, and after that ordinary failures are the
+ * engine's business.
+ */
+import type { ChannelType, EndReason, EndingOffer, OperatorEvent, SpectatorEvent } from "@perfectman/shared";
+import type { DeliveryMessage, IDeliveryGateway } from "../../simulation/scheduler-contracts.js";
+
+export type LlmFatal = { message: string; hint: string };
+
+/** Motive prefixes that mean the model, not the character, failed to answer. */
+const MODEL_FAILURE_PREFIXES = ["Provider failed:", "Fallback applied:", "Retry call failed."];
+
+export const LLM_FAILURE_HINT =
+  "Check the API key, the base URL and the model name. If the model reasons by default, switch JSON mode to json_object or add the extra field that disables reasoning.";
+
+export class LlmHealthWatch {
+  private calls = 0;
+  private failures = 0;
+  private lastReason = "";
+  private proven = false;
+  private verdict: LlmFatal | null = null;
+
+  constructor(private readonly window = 3) {}
+
+  /** Returns the fatal verdict the first time it is reached; null otherwise. */
+  observe(event: OperatorEvent): LlmFatal | null {
+    if (this.proven || this.verdict || event.type !== "action_intent") return null;
+    const motive = typeof event.data?.["privateMotiveSummary"] === "string" ? (event.data["privateMotiveSummary"] as string) : "";
+    this.calls += 1;
+    if (MODEL_FAILURE_PREFIXES.some((prefix) => motive.startsWith(prefix))) {
+      this.failures += 1;
+      this.lastReason = motive;
+    } else {
+      this.proven = true;
+      return null;
+    }
+    if (this.calls >= this.window && this.failures === this.calls) {
+      this.verdict = {
+        message: `The model answered nothing usable in the first ${this.window} calls. Last reason: ${this.lastReason}`,
+        hint: LLM_FAILURE_HINT,
+      };
+      return this.verdict;
+    }
+    return null;
+  }
+}
+
+/** A gateway that only listens, and tells the run when the model has failed it. */
+export class LlmHealthGateway implements IDeliveryGateway {
+  constructor(
+    private readonly watch: LlmHealthWatch,
+    private readonly onFatal: (fatal: LlmFatal) => void,
+  ) {}
+
+  sendOperatorEvent(event: OperatorEvent): Promise<void> {
+    const fatal = this.watch.observe(event);
+    if (fatal) this.onFatal(fatal);
+    return Promise.resolve();
+  }
+
+  sendAgentMessage(_channelId: string, _message: DeliveryMessage): Promise<void> {
+    return Promise.resolve();
+  }
+  createChannel(_channelId: string, _type: ChannelType, _memberAgentIds: string[]): Promise<void> {
+    return Promise.resolve();
+  }
+  addMember(_channelId: string, _agentId: string): Promise<void> {
+    return Promise.resolve();
+  }
+  removeMember(_channelId: string, _agentId: string): Promise<void> {
+    return Promise.resolve();
+  }
+  sendSpectatorEvent(_event: SpectatorEvent): Promise<void> {
+    return Promise.resolve();
+  }
+  onSimulationStopped(_simulationId: string, _endReason?: EndReason, _endingOffer?: EndingOffer): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/server/src/http/run/run-controller.ts
+++ b/packages/server/src/http/run/run-controller.ts
@@ -15,6 +15,7 @@ import type {
 } from "@perfectman/shared";
 import { HtmlSnapshotGateway } from "../../delivery/html-snapshot-gateway.js";
 import { SseDeliveryGateway } from "../../delivery/sse-delivery-gateway.js";
+import { LlmHealthGateway, LlmHealthWatch, type LlmFatal } from "./llm-health-watch.js";
 import { timeboxGateway, type TimeboxCounter } from "../../delivery/timeboxed-gateway.js";
 import { messageFromCommitted } from "../../delivery/live-frame-assembly.js";
 import { buildConfiguredSimulation } from "../../config/simulation-config.js";
@@ -69,6 +70,8 @@ export class RunController {
   private artifacts: RunArtifacts | null = null;
   private finished: Promise<void> | null = null;
   private stopped = false;
+  /** Set when the model failed the run's first calls; the run ends as failed. */
+  private fatal: LlmFatal | null = null;
 
   constructor(private readonly runsRoot: string) {}
 
@@ -96,6 +99,7 @@ export class RunController {
     this.abort = new AbortController();
     this.inFlight = { current: null };
     this.stopped = false;
+    this.fatal = null;
     this.artifacts = new RunArtifacts(this.runsRoot, params.runId);
     this.status = {
       runId: params.runId,
@@ -149,6 +153,14 @@ export class RunController {
             sseGateway = new SseDeliveryGateway(this.hub, meta);
             return timeboxGateway(sseGateway, GATEWAY_TIMEOUT_MS, gatewayCounter);
           },
+          // Watches the first model calls; a model that answers nothing
+          // usable fails the run instead of playing out as a silent room.
+          health: () =>
+            new LlmHealthGateway(new LlmHealthWatch(), (fatal) => {
+              if (this.fatal) return;
+              this.fatal = fatal;
+              this.abort.abort();
+            }),
         },
       });
       this.handle = handle;
@@ -181,6 +193,13 @@ export class RunController {
         this.inFlight,
       );
 
+      if (this.fatal) {
+        this.status.stopReason = "error";
+        this.status.error = this.fatal;
+        this.hub.publish({ type: "error", data: { type: "error", message: this.fatal.message, hint: this.fatal.hint } satisfies LiveEvent });
+        await this.teardown(params, replayGateway, gatewayCounter, "failed");
+        return;
+      }
       this.status.stopReason = outcome.reason;
       if (outcome.error) {
         this.status.error = { message: outcome.error.message };

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -108,7 +108,7 @@ export function App(): JSX.Element {
   }
 
   return (
-    <Shell step={step} furthest={furthest} onStep={setStep}>
+    <Shell step={step} furthest={furthest} onStep={setStep} onHome={() => setIntroDone(false)}>
       {presetsError ? (
         <div className="alert alert--shell" role="alert">
           <p>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -165,6 +165,7 @@ export function App(): JSX.Element {
           onRun={run}
           onStop={stop}
           onDismissError={() => setFailure(null)}
+          onReset={() => setRunId(null)}
         />
       ) : null}
     </Shell>

--- a/packages/web/src/design/Shell.tsx
+++ b/packages/web/src/design/Shell.tsx
@@ -17,12 +17,15 @@ export function Shell({
   step,
   furthest,
   onStep,
+  onHome,
   children,
 }: {
   step: StepId;
   /** How far the user has actually got; later steps are not clickable yet. */
   furthest: StepId;
   onStep: (step: StepId) => void;
+  /** The mark is the way home: it shows the landing again, keeping what was picked. */
+  onHome: () => void;
   children: React.ReactNode;
 }): JSX.Element {
   const reached = STEPS.findIndex((s) => s.id === furthest);
@@ -31,7 +34,9 @@ export function Shell({
   return (
     <div className="shell">
       <header className="shell__bar">
-        <span className="shell__mark">perfectman</span>
+        <button type="button" className="shell__mark" onClick={onHome} title="Back to the landing">
+          perfectman
+        </button>
         <nav className="shell__rail" aria-label="Progress">
           {STEPS.map((s, i) => (
             <button

--- a/packages/web/src/design/__tests__/shell.test.tsx
+++ b/packages/web/src/design/__tests__/shell.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * The mark in the corner is the way home: it shows the landing again. It is
+ * not a step, so it does not touch what has been picked.
+ */
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Shell } from "../Shell.js";
+
+describe("Shell", () => {
+  afterEach(cleanup);
+
+  it("shows the landing when the mark is clicked", () => {
+    const onHome = vi.fn();
+    const { getByRole } = render(
+      <Shell step="cast" furthest="cast" onStep={vi.fn()} onHome={onHome}>
+        <p>step</p>
+      </Shell>,
+    );
+    fireEvent.click(getByRole("button", { name: /perfectman/ }));
+    expect(onHome).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/design/shell.css
+++ b/packages/web/src/design/shell.css
@@ -17,6 +17,11 @@
 }
 
 .shell__mark {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--ink);
+  cursor: pointer;
   font-family: var(--serif);
   font-variation-settings: "opsz" 40, "SOFT" 40, "WONK" 1;
   font-weight: 600;

--- a/packages/web/src/run/ProviderForm.tsx
+++ b/packages/web/src/run/ProviderForm.tsx
@@ -1,12 +1,14 @@
 /**
  * Who answers, and for how long.
  *
- * Kept to four visible fields. Everything a hosted reasoning model needs to
- * behave — JSON mode, a reasoning-disable key — is real and load-bearing but
- * belongs behind a disclosure, because getting it wrong is a specific failure
- * with a specific message rather than something to warn everyone about.
+ * One way to answer: an OpenAI-compatible endpoint with a key. The mock and
+ * the local daemon were developer conveniences that put a "run" on screen
+ * with nothing behind it. Everything a hosted reasoning model needs to behave
+ * — JSON mode, a reasoning-disable key — is real and load-bearing but belongs
+ * behind a disclosure, because getting it wrong is a specific failure with a
+ * specific message rather than something to warn everyone about.
  */
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { StartRunRequest } from "@perfectman/shared";
 import { KNOWN_ROUTES } from "./known-routes.js";
 
@@ -17,52 +19,39 @@ export type ProviderValue = {
   extraBodyText: string;
 };
 
+/** Opens on the first route that is known to work; the key is always yours to paste. */
 export const DEFAULT_PROVIDER: ProviderValue = {
-  llm: { providerType: "mock", modelName: "mock" },
+  llm: { providerType: "openai-compatible", ...KNOWN_ROUTES[0]?.llm },
   maxPulses: null,
-  extraBodyText: "",
+  extraBodyText: KNOWN_ROUTES[0]?.extraBodyText ?? "",
 };
-
-const PROVIDERS = [
-  { id: "mock", label: "Mock", note: "Instant, no key, no network. Shows the shape of a run." },
-  { id: "ollama", label: "Ollama", note: "A model on this machine. Needs the daemon running." },
-  { id: "openai-compatible", label: "Any /v1 endpoint", note: "OpenAI-compatible. Bring a base URL and a key." },
-];
 
 export function ProviderForm({
   value,
   onChange,
   onRun,
   ready,
+  focusKey = false,
 }: {
   value: ProviderValue;
   onChange: (next: ProviderValue) => void;
   onRun: () => void;
   ready: boolean;
+  /** Put the cursor in the key field: the last run failed and it is probably the key. */
+  focusKey?: boolean;
 }): JSX.Element {
   const extraBodyError = useMemo(() => parseExtraBody(value.extraBodyText).error, [value.extraBodyText]);
-  const hosted = value.llm.providerType !== "mock";
+  const keyField = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (focusKey) keyField.current?.focus();
+  }, [focusKey]);
+  const hasKey = (value.llm.apiKey ?? "").trim() !== "";
   const set = (llm: Partial<StartRunRequest["llm"]>): void =>
     onChange({ ...value, llm: { ...value.llm, ...llm } });
 
   return (
     <div className="provider">
-      <div className="provider__choices">
-        {PROVIDERS.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            className={`card${value.llm.providerType === p.id ? " card--on" : ""}`}
-            aria-pressed={value.llm.providerType === p.id}
-            onClick={() => set({ providerType: p.id, modelName: p.id === "mock" ? "mock" : value.llm.modelName })}
-          >
-            <span className="card__title u-serif">{p.label}</span>
-            <span className="card__blurb">{p.note}</span>
-          </button>
-        ))}
-      </div>
-
-      {hosted ? (
+      {(
         <div className="routes">
           <p className="u-dim">
             Endpoints someone has already got working. Filling one in still
@@ -88,10 +77,10 @@ export function ProviderForm({
             ))}
           </div>
         </div>
-      ) : null}
+      )}
 
       <div className="provider__fields">
-        {hosted ? (
+        {(
           <>
             <label>
               <span>Model</span>
@@ -112,15 +101,17 @@ export function ProviderForm({
             <label>
               <span>API key</span>
               <input
+                ref={keyField}
                 type="password"
                 value={value.llm.apiKey ?? ""}
-                placeholder="Leave blank to use the server's .env"
+                placeholder="Paste the key for this endpoint"
+                autoComplete="off"
                 onChange={(e) => set({ apiKey: e.target.value })}
               />
               <em>Held for this run only. The saved config keeps the variable name, never the key.</em>
             </label>
           </>
-        ) : null}
+        )}
 
         <label>
           <span>Turns</span>
@@ -135,7 +126,7 @@ export function ProviderForm({
         </label>
       </div>
 
-      {hosted ? (
+      {(
         <details className="advanced">
           <summary>If the model answers with nothing</summary>
           <p>
@@ -170,13 +161,13 @@ export function ProviderForm({
             </em>
           </label>
         </details>
-      ) : null}
+      )}
 
       <div className="step__foot">
         <button
           type="button"
           className="btn"
-          disabled={!ready || Boolean(extraBodyError)}
+          disabled={!ready || !hasKey || Boolean(extraBodyError)}
           onClick={() => {
             const extra = parseExtraBody(value.extraBodyText);
             onChange({ ...value, llm: { ...value.llm, ...(extra.value ? { extraBody: extra.value } : {}) } });
@@ -185,7 +176,11 @@ export function ProviderForm({
         >
           Start the run
         </button>
-        {!ready ? <span className="u-dim">The cast and scene need to fit together first.</span> : null}
+        {!ready ? (
+          <span className="u-dim">The cast and scene need to fit together first.</span>
+        ) : !hasKey ? (
+          <span className="u-dim">Paste a key to start.</span>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -6,7 +6,7 @@
  * moves into `details`, still complete, just no longer the thing you are
  * looking at.
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { idlePlacement, placeBeats, type CompileResponse, type StartRunRequest } from "@perfectman/shared";
 import type { RunStream } from "../api/useRunStream.js";
 import type { LiveChannel } from "@perfectman/shared";
@@ -47,6 +47,7 @@ export function RunScreen({
   onRun,
   onStop,
   onDismissError,
+  onReset,
 }: {
   compiled: CompileResponse | null;
   stream: RunStream;
@@ -55,8 +56,14 @@ export function RunScreen({
   onRun: (llm: StartRunRequest["llm"], limits?: StartRunRequest["limits"]) => void;
   onStop: () => void;
   onDismissError: () => void;
+  /** Forget the current run id, so the form comes back. */
+  onReset: () => void;
 }): JSX.Element {
   const [provider, setProvider] = useState<ProviderValue>(DEFAULT_PROVIDER);
+  // What the last run died of, kept across the reset that brings the form
+  // back. The key is cleared with it: when the model, the key or the output
+  // format does not work, the fix is almost always the key.
+  const [failure, setFailure] = useState<{ message: string; hint?: string } | null>(null);
   const beats = useStageBeats(stream.replay);
   const clock = useStageClock(beats);
   const running = stream.status ? !IDLE_STATES.has(stream.status.state) : false;
@@ -82,6 +89,20 @@ export function RunScreen({
   const ready = warm || beats.length >= WARMUP_BEATS || (!running && beats.length > 0);
   if (ready && !warm) setWarm(true);
 
+  const status = stream.status;
+  const failedEarly = started && !warm && (status?.state === "failed" || stream.error !== null);
+  const giveUp = (why: { message: string; hint?: string }): void => {
+    setFailure(why);
+    setProvider((p) => ({ ...p, llm: { ...p.llm, apiKey: "" } }));
+    onReset();
+  };
+  useEffect(() => {
+    if (!failedEarly) return;
+    giveUp(status?.error ?? { message: stream.error ?? "The run stopped before anything was said." });
+    // The reset changes `started`; the effect must not fire again for the same failure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [failedEarly]);
+
   return (
     <section className="step run">
       {error ? (
@@ -98,11 +119,18 @@ export function RunScreen({
           <header className="step__head">
             <h2>Who is answering?</h2>
             <p>
-              Mock replies instantly and needs no key — it is the fastest way to
-              see the shape of a run. A real model takes minutes and says
-              something worth reading.
+              An OpenAI-compatible endpoint and a key. A real model takes a
+              while per turn and says something worth reading.
             </p>
           </header>
+          {failure ? (
+            <div className="alert" role="alert">
+              <p>
+                The run stopped: {failure.message}
+                {failure.hint ? ` ${failure.hint}` : ""} Paste the key again and start over.
+              </p>
+            </div>
+          ) : null}
           <ProviderForm
             value={provider}
             onChange={setProvider}
@@ -110,9 +138,11 @@ export function RunScreen({
               // Inside the click, before anything async: this is the gesture
               // the browser will let the soundtrack play under later.
               sound.unlock();
+              setFailure(null);
               onRun(provider.llm, provider.maxPulses ? { maxPulses: provider.maxPulses } : undefined);
             }}
             ready={Boolean(compiled?.ok)}
+            focusKey={failure !== null}
           />
         </>
       ) : (
@@ -167,6 +197,14 @@ export function RunScreen({
                 {running ? (
                   <button type="button" className="btn--quiet" onClick={onStop}>
                     Stop the run
+                  </button>
+                ) : status?.state === "failed" ? (
+                  <button
+                    type="button"
+                    className="btn--quiet"
+                    onClick={() => giveUp(status.error ?? { message: "The run stopped." })}
+                  >
+                    Try another key
                   </button>
                 ) : null}
               </div>
@@ -227,7 +265,12 @@ function RunState({ stream, running }: { stream: RunStream; running: boolean }):
     );
   }
   if (status.state === "failed") {
-    return <span className="alert-inline">The run stopped: {status.error?.message ?? "unknown reason"}</span>;
+    return (
+      <span className="alert-inline">
+        The run stopped: {status.error?.message ?? "unknown reason"}
+        {status.error?.hint ? ` ${status.error.hint}` : ""}
+      </span>
+    );
   }
   return (
     <span className="u-dim">

--- a/packages/web/src/run/__tests__/provider-form.test.tsx
+++ b/packages/web/src/run/__tests__/provider-form.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * One way to answer: an OpenAI-compatible endpoint with a key. The mock and
+ * the local daemon were developer conveniences that put a "run" on screen
+ * with nothing behind it.
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_PROVIDER, ProviderForm } from "../ProviderForm.js";
+
+describe("ProviderForm", () => {
+  afterEach(cleanup);
+
+  it("offers only an endpoint", () => {
+    const { container, queryByText } = render(
+      <ProviderForm value={DEFAULT_PROVIDER} onChange={vi.fn()} onRun={vi.fn()} ready />,
+    );
+    expect(queryByText("Mock")).toBeNull();
+    expect(queryByText("Ollama")).toBeNull();
+    expect(queryByText(/Ollama on this machine/)).toBeNull();
+    expect(container.querySelector('input[type="password"]')).not.toBeNull();
+    expect(DEFAULT_PROVIDER.llm.providerType).toBe("openai-compatible");
+  });
+
+  it("needs a key before it will start", () => {
+    const { getByText } = render(
+      <ProviderForm value={{ ...DEFAULT_PROVIDER, llm: { ...DEFAULT_PROVIDER.llm, apiKey: "" } }} onChange={vi.fn()} onRun={vi.fn()} ready />,
+    );
+    expect((getByText("Start the run") as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/web/src/run/__tests__/run-screen-failure.test.tsx
+++ b/packages/web/src/run/__tests__/run-screen-failure.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * When the model, the key or the output format does not work, the run screen
+ * says so and asks for the key again — it does not sit on "Reaching the
+ * model…" forever.
+ */
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RunStream } from "../../api/useRunStream.js";
+import { RunScreen } from "../RunScreen.js";
+
+const EMPTY: RunStream = {
+  replay: null, helloRunId: null, status: null, notices: [], raw: [], dropped: 0, connected: false, error: null, stoppedReason: null,
+};
+
+function failed(message: string, hint?: string): RunStream {
+  return {
+    ...EMPTY,
+    status: {
+      runId: "r1", simulationId: "s", state: "failed", pulseIndex: 0, pulsesRun: 0, maxPulses: 6,
+      error: { message, ...(hint ? { hint } : {}) }, counters: { llmFailures: 0, gatewayTimeouts: 0, framesDropped: 0 },
+    },
+  };
+}
+
+describe("RunScreen after a failure before the stage", () => {
+  it("returns to the form, shows the error, and asks for the key again", () => {
+    const onReset = vi.fn();
+    const { container, rerender } = render(
+      <RunScreen compiled={{ ok: true, config: {}, diagnostics: [], summary: null }} stream={failed("HTTP 401: invalid api key", "Check the key.")} runId="r1" error={null} onRun={vi.fn()} onStop={vi.fn()} onDismissError={vi.fn()} onReset={onReset} />,
+    );
+    expect(onReset).toHaveBeenCalled();
+    // The app clears the run id in response; the form comes back with the failure on it.
+    rerender(
+      <RunScreen compiled={{ ok: true, config: {}, diagnostics: [], summary: null }} stream={EMPTY} runId={null} error={null} onRun={vi.fn()} onStop={vi.fn()} onDismissError={vi.fn()} onReset={onReset} />,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("HTTP 401: invalid api key");
+    expect(alert?.textContent).toContain("Check the key.");
+    const key = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(key).not.toBeNull();
+    expect(key?.value).toBe("");
+    expect(document.activeElement).toBe(key);
+  });
+});

--- a/packages/web/src/run/known-routes.ts
+++ b/packages/web/src/run/known-routes.ts
@@ -49,17 +49,4 @@ export const KNOWN_ROUTES: KnownRoute[] = [
     },
     extraBodyText: '{ "thinking": { "type": "disabled" } }',
   },
-  {
-    id: "ollama-local",
-    label: "Ollama on this machine",
-    note: "Needs the daemon running. No key.",
-    llm: {
-      providerType: "ollama",
-      modelName: "qwen3:8b",
-      baseUrl: "http://localhost:11434/v1",
-      responseFormatJson: true,
-      responseFormatJsonSchema: false,
-    },
-    extraBodyText: "",
-  },
 ];


### PR DESCRIPTION
## What

Makes a run that cannot work say so, and narrows the run form to the one thing that does:

- `ProviderForm.tsx`: the Mock and Ollama choices are gone; the form opens on `KNOWN_ROUTES[0]` (OrcaRouter · Qwen3.5 27B) with model, base URL, key and turns; **Start the run** is disabled without a key. `known-routes.ts` drops `ollama-local`.
- `RunScreen.tsx`: a run that fails before the stage (`status.state === "failed"` or a stream `error`) returns to the form with the reason and hint in an alert, clears `apiKey` and focuses the key field via `focusKey`; a run that fails after the stage shows the reason and hint under the transport with a **Try another key** button. `App` passes `onReset` (clears `runId`).
- `llm-health-watch.ts` (server): `LlmHealthWatch` counts the first 3 `action_intent` events; if all are engine fallbacks (`Provider failed:` / `Fallback applied:` / `Retry call failed.`) it yields a fatal with the last reason and `LLM_FAILURE_HINT`. `LlmHealthGateway` feeds it from operator events; `RunController` registers it as an extra gateway, aborts the loop on a verdict, publishes the `error` event with the hint and tears down as `failed`. One usable answer switches the watch off; repetition-guard and budget silences do not count.
- `Shell.tsx`: the `perfectman` mark is a button; `onHome` shows the landing again without touching the picked cast and scene.
- `docs/frontend-handoff.md`: running-it section rewritten for the endpoint-only form.
- 9 tests: watch verdict / proven / engine silences / non-intents, form offers only an endpoint / needs a key, failure returns to the form with the error and a cleared focused key, mark goes home.

## Why

A bad key, a dead endpoint or a model that answers with nothing usable left the screen on "Reaching the model…" or played out as a silent room. The mock and the local daemon put a run on screen with nothing behind it.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS on a clean checkout (2035 passed, +9; locally one presets test fails only because of an untracked scene from another session)
- Live against OrcaRouter with a wrong key: health check returns HTTP 401, the form comes back with the message, key empty and focused; no Mock/Ollama on the page; Start disabled until a key is typed
- Run server redeployed from this merge; web deploys from main