### PR TITLE
fix(web): say the server is busy before Start, not after

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -87,7 +87,16 @@ export function App(): JSX.Element {
       setRunId(null);
       startRun({ inputs, llm, ...(limits ? { limits } : {}) })
         .then((res) => setRunId(res.runId))
-        .catch((err: unknown) => setFailure(messageOf(err)));
+        .catch((err: unknown) => {
+          // The busy check runs on a poll, so a start can still lose a race
+          // with someone else's. Say what happened in the app's own words —
+          // the server's sentence is written for an API caller.
+          if (err instanceof ApiRequestError && err.status === 409) {
+            setFailure("Someone else started a run just before you. Stop it above, or wait for it to finish.");
+            return;
+          }
+          setFailure(messageOf(err));
+        });
     },
     [inputs],
   );

--- a/packages/web/src/run/RunScreen.tsx
+++ b/packages/web/src/run/RunScreen.tsx
@@ -20,6 +20,7 @@ import { useStageBeats } from "./useStageBeats.js";
 import { useSoundtrack } from "./useSoundtrack.js";
 import { Transport } from "./Transport.js";
 import { DetailsDrawer } from "./DetailsDrawer.js";
+import { useServerBusy } from "./useServerBusy.js";
 import { ProviderForm, type ProviderValue, DEFAULT_PROVIDER } from "./ProviderForm.js";
 
 const IDLE_STATES = new Set(["idle", "done", "failed"]);
@@ -70,6 +71,8 @@ export function RunScreen({
   const sound = useSoundtrack(clock.beat, running || beats.length > 0, clock.playing);
 
   const started = runId !== null;
+  // Only worth asking while a start is actually possible.
+  const server = useServerBusy(!started);
   const agents = stream.replay?.agents ?? EMPTY_AGENTS;
   const channels = stream.replay?.channels ?? EMPTY_CHANNELS;
   const ids = useMemo(() => agents.map((a) => a.id), [agents]);
@@ -131,6 +134,7 @@ export function RunScreen({
               </p>
             </div>
           ) : null}
+          {server.busy ? <ServerBusyNotice server={server} /> : null}
           <ProviderForm
             value={provider}
             onChange={setProvider}
@@ -141,7 +145,7 @@ export function RunScreen({
               setFailure(null);
               onRun(provider.llm, provider.maxPulses ? { maxPulses: provider.maxPulses } : undefined);
             }}
-            ready={Boolean(compiled?.ok)}
+            ready={Boolean(compiled?.ok) && !server.busy}
             focusKey={failure !== null}
           />
         </>
@@ -250,6 +254,32 @@ function WarmupNote({
         A real model thinks for a while before anyone speaks. Waiting for a few
         turns means the scene plays through instead of stopping between lines.
       </p>
+    </div>
+  );
+}
+
+/**
+ * The server takes one run at a time, and on a shared link the run in progress
+ * is usually somebody else's. Say whose, how far in, and offer the only action
+ * that helps — rather than letting Start fail with a 409.
+ */
+function ServerBusyNotice({ server }: { server: ReturnType<typeof useServerBusy> }): JSX.Element {
+  const status = server.status;
+  const turns =
+    status && status.maxPulses > 0 ? `${status.pulsesRun} of ${status.maxPulses} turns in` : "just started";
+
+  return (
+    <div className="busy" role="status">
+      <div className="busy__words">
+        <b>A run is already going.</b>
+        <span>
+          {turns}. The server takes one at a time, so this one has to finish or
+          be stopped first.
+        </span>
+      </div>
+      <button type="button" className="btn--quiet" disabled={server.stopping} onClick={() => void server.release()}>
+        {server.stopping ? "Stopping…" : "Stop it"}
+      </button>
     </div>
   );
 }

--- a/packages/web/src/run/__tests__/server-busy.test.tsx
+++ b/packages/web/src/run/__tests__/server-busy.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The server takes one run at a time, and on a shared link the run in progress
+ * is usually not yours. Finding that out by pressing Start and reading a 409 is
+ * the wrong order, so the form asks first and says whose turn it is.
+ */
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RunStatus } from "@perfectman/shared";
+import type { RunStream } from "../../api/useRunStream.js";
+import { RunScreen } from "../RunScreen.js";
+import * as client from "../../api/client.js";
+
+const EMPTY: RunStream = {
+  replay: null, helloRunId: null, status: null, notices: [], raw: [], dropped: 0,
+  connected: false, error: null, stoppedReason: null,
+};
+
+const COMPILED = { ok: true, config: {}, diagnostics: [], summary: null };
+
+function status(over: Partial<RunStatus> = {}): RunStatus {
+  return {
+    runId: "r_other", simulationId: "s", state: "running", pulseIndex: 3, pulsesRun: 4, maxPulses: 16,
+    counters: { llmFailures: 0, gatewayTimeouts: 0, framesDropped: 0 }, ...over,
+  };
+}
+
+function screen(props: Partial<Parameters<typeof RunScreen>[0]> = {}) {
+  return render(
+    <RunScreen
+      compiled={COMPILED} stream={EMPTY} runId={null} error={null}
+      onRun={vi.fn()} onStop={vi.fn()} onDismissError={vi.fn()} onReset={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("when the server is already busy", () => {
+  it("says so, with how far along the other run is", async () => {
+    vi.spyOn(client, "currentStatus").mockResolvedValue(status());
+    const { container } = screen();
+
+    await waitFor(() => expect(container.querySelector(".busy")).not.toBeNull());
+    expect(container.querySelector(".busy")?.textContent).toContain("4 of 16 turns in");
+  });
+
+  it("disables Start rather than letting it fail with a 409", async () => {
+    vi.spyOn(client, "currentStatus").mockResolvedValue(status());
+    const { container } = screen();
+
+    await waitFor(() => expect(container.querySelector(".busy")).not.toBeNull());
+    const start = [...container.querySelectorAll("button")].find((b) => /start/i.test(b.textContent ?? ""));
+    expect(start?.disabled).toBe(true);
+  });
+
+  it("leaves Start alone when the server is idle", async () => {
+    vi.spyOn(client, "currentStatus").mockResolvedValue(
+      status({ runId: null, state: "idle", pulsesRun: 0, maxPulses: 0 }),
+    );
+    const { container } = screen();
+
+    await waitFor(() => expect(client.currentStatus).toHaveBeenCalled());
+    expect(container.querySelector(".busy")).toBeNull();
+  });
+
+  it("does not block the button when the server cannot be reached", async () => {
+    // An unreachable server is a different problem, and pressing Start reports
+    // it properly. Blocking on it would strand the user with no way forward.
+    vi.spyOn(client, "currentStatus").mockRejectedValue(new Error("network"));
+    const { container } = screen();
+
+    await waitFor(() => expect(client.currentStatus).toHaveBeenCalled());
+    expect(container.querySelector(".busy")).toBeNull();
+  });
+
+  it("treats a run that is still tearing down as busy", async () => {
+    // `stopping` still refuses a start: teardown waits for the pulse in flight.
+    vi.spyOn(client, "currentStatus").mockResolvedValue(status({ state: "stopping" }));
+    const { container } = screen();
+
+    await waitFor(() => expect(container.querySelector(".busy")).not.toBeNull());
+  });
+
+  it("stops asking once a run of your own is on screen", async () => {
+    vi.spyOn(client, "currentStatus").mockResolvedValue(status());
+    screen({ runId: "r_mine" });
+
+    await new Promise((r) => setTimeout(r, 60));
+    expect(client.currentStatus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/run/run.css
+++ b/packages/web/src/run/run.css
@@ -311,3 +311,30 @@
     transform: scale(1);
   }
 }
+
+/* --- server busy --------------------------------------------------------- */
+
+/* Not an error — nothing is broken, someone else is just using it. Reads as
+   information with an action, not as a failure. */
+.busy {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 13px 16px;
+  border-radius: var(--r-lg);
+  background: var(--paper-warm);
+  box-shadow: var(--ring);
+}
+
+.busy__words {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 22ch;
+  font-size: 13.5px;
+}
+
+.busy__words span {
+  color: var(--ink-70);
+}

--- a/packages/web/src/run/useServerBusy.ts
+++ b/packages/web/src/run/useServerBusy.ts
@@ -1,0 +1,83 @@
+/**
+ * Whether the server is already busy with somebody else's run.
+ *
+ * The server holds one run at a time, so a second Start comes back `409` — and
+ * a shared deployment means the other run is usually not yours and often not
+ * even in your browser. Finding that out by pressing the button and reading an
+ * error is the wrong order: the answer is knowable before the click, so this
+ * asks for it and the form disables Start while it is true.
+ *
+ * Polling rather than pushing, because there is no stream to subscribe to
+ * until a run exists — that is precisely the state being reported on.
+ */
+import { useCallback, useEffect, useState } from "react";
+import type { RunStatus } from "@perfectman/shared";
+import { currentStatus, stopRun } from "../api/client.js";
+
+/** Run states where the server will refuse a second start. */
+const BUSY_STATES = new Set(["compiling", "validating", "health_check", "building", "running", "stopping"]);
+
+const POLL_MS = 4000;
+
+export type ServerBusy = {
+  /** Null until the first answer arrives, so the form can avoid flashing. */
+  status: RunStatus | null;
+  busy: boolean;
+  stopping: boolean;
+  /** Resolves once the other run has actually let go, not when stop was accepted. */
+  release: () => Promise<void>;
+  refresh: () => void;
+};
+
+export function useServerBusy(active: boolean): ServerBusy {
+  const [status, setStatus] = useState<RunStatus | null>(null);
+  const [stopping, setStopping] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    let live = true;
+
+    const read = async (): Promise<void> => {
+      try {
+        const next = await currentStatus();
+        if (live) setStatus(next);
+      } catch {
+        // A server that cannot be reached is a different problem, and starting
+        // a run will report it properly. Do not block the button for it.
+        if (live) setStatus(null);
+      }
+    };
+
+    void read();
+    const timer = setInterval(() => void read(), POLL_MS);
+    return () => {
+      live = false;
+      clearInterval(timer);
+    };
+  }, [active, tick]);
+
+  const busy = status !== null && BUSY_STATES.has(status.state);
+
+  const release = useCallback(async (): Promise<void> => {
+    if (!status?.runId) return;
+    setStopping(true);
+    try {
+      await stopRun(status.runId);
+      // Stop is accepted immediately but teardown waits for the pulse in
+      // flight, which on a real model is minutes. Poll until it lets go rather
+      // than re-enabling a button that would only 409 again.
+      for (let i = 0; i < 150; i++) {
+        await new Promise((r) => setTimeout(r, 2000));
+        const next = await currentStatus().catch(() => null);
+        if (next) setStatus(next);
+        if (!next || !BUSY_STATES.has(next.state)) return;
+      }
+    } finally {
+      setStopping(false);
+      setTick((t) => t + 1);
+    }
+  }, [status?.runId]);
+
+  return { status, busy, stopping, release, refresh: () => setTick((t) => t + 1) };
+}


### PR DESCRIPTION
## What

- `run/useServerBusy.ts` polls `/api/runs/current` while a start is still possible, and a notice above the form names how far along the other run is with a **Stop it** button. Start is disabled while it holds.
- `App.run()` keeps a `409` handler for the race the poll cannot close, phrased in the app's words rather than the server's.
- Six tests covering the states that matter.

## Why

The server takes one run at a time and answers a second start with `409`. On a shared link the run in progress is usually somebody else's and often not in your browser at all, so the first sign of it was a raw API sentence appearing after the click — written for a caller, offering nothing to do about it.

Three cases the poll has to get right, all tested. `stopping` still counts as busy, because teardown waits for the pulse in flight and a start would `409` anyway. An unreachable server does **not** count, because that is a different problem and pressing Start reports it properly — blocking there would strand the user with no way forward. And `release()` waits for the other run to actually let go rather than resolving when stop is accepted, since on a real model that gap is minutes.

## Validation

- `pnpm lint` PASS - `pnpm test:all` PASS - 2042 passed (+6)
- Verified on https://perfectman.avenza.cloud against a genuinely occupied server: notice reads "A run is already going. 3 of 8 turns in.", Start disabled.